### PR TITLE
Update status widget to use check multiple esc current sensors

### DIFF
--- a/scripts/rfsuite/tasks/telemetry/telemetry.lua
+++ b/scripts/rfsuite/tasks/telemetry/telemetry.lua
@@ -42,6 +42,7 @@ sensorTable["rssi"] = {sport = rfsuite.utils.getRssiSensor(), ccrsf = rfsuite.ut
 sensorTable["voltage"] = {sport = {category = CATEGORY_TELEMETRY_SENSOR, appId = 0x0210}, ccrsf = {category = CATEGORY_TELEMETRY_SENSOR, appId = 0x1011}, lcrsf = "Rx Batt"}
 sensorTable["rpm"] = {sport = {category = CATEGORY_TELEMETRY_SENSOR, appId = 0x0500}, ccrsf = {category = CATEGORY_TELEMETRY_SENSOR, appId = 0x10C0}, lcrsf = "GPS Alt"}
 sensorTable["current"] = {sport = {category = CATEGORY_TELEMETRY_SENSOR, appId = 0x0200}, ccrsf = {category = CATEGORY_TELEMETRY_SENSOR, appId = 0x1012}, lcrsf = "Rx Curr"}
+sensorTable["currentESC1"] = {sport = {category = CATEGORY_TELEMETRY_SENSOR, appId = 0x0201}, ccrsf = {category = CATEGORY_TELEMETRY_SENSOR, appId = 0x1042}, lcrsf = nil}
 sensorTable["tempESC"] = {sport = {category = CATEGORY_TELEMETRY_SENSOR, appId = 0x0B70}, ccrsf = {category = CATEGORY_TELEMETRY_SENSOR, appId = 0x10A0}, lcrsf = "GPS Speed"}
 sensorTable["tempMCU"] = {sport = {category = CATEGORY_TELEMETRY_SENSOR, appId = 0x0401}, ccrsf = {category = CATEGORY_TELEMETRY_SENSOR, appId = 0x10A3}, lcrsf = "GPS Sats"}
 sensorTable["fuel"] = {sport = {category = CATEGORY_TELEMETRY_SENSOR, appId = 0x0600}, ccrsf = {category = CATEGORY_TELEMETRY_SENSOR, appId = 0x1014}, lcrsf = "Rx Batt%"}

--- a/scripts/rfsuite/widgets/status/status.lua
+++ b/scripts/rfsuite/widgets/status/status.lua
@@ -2825,6 +2825,7 @@ function status.getSensors()
     local adjSOURCE
     local adjvalue
     local current
+    local currentesc1
 
     -- lcd.resetFocusTimeout()
 
@@ -2858,6 +2859,7 @@ function status.getSensors()
         voltageSOURCE = rfsuite.bg.telemetry.getSensorSource("voltage")
         rpmSOURCE = rfsuite.bg.telemetry.getSensorSource("rpm")
         currentSOURCE = rfsuite.bg.telemetry.getSensorSource("current")
+        currentSOURCEESC1 = rfsuite.bg.telemetry.getSensorSource("currentESC1")
         temp_escSOURCE = rfsuite.bg.telemetry.getSensorSource("tempESC")
         temp_mcuSOURCE = rfsuite.bg.telemetry.getSensorSource("tempMCU")
         fuelSOURCE = rfsuite.bg.telemetry.getSensorSource("fuel")
@@ -2898,8 +2900,17 @@ function status.getSensors()
                 if currentSOURCE:maximum() == 50.0 then currentSOURCE:maximum(400.0) end
 
                 current = currentSOURCE:value()
+                if currentSOURCEESC1 ~= nil then
+                        currentesc1 = currentSOURCEESC1:value()
+                else
+                        currentesc1 = 0
+                end
                 if current ~= nil then
-                    current = current * 10
+                    if current == 0 and currentesc1 ~= 0 then
+                        current = currentesc1 * 10
+                    else
+                        current = current * 10
+                    end    
                 else
                     current = 0
                 end
@@ -3135,8 +3146,17 @@ function status.getSensors()
 
             if currentSOURCE ~= nil then
                 current = currentSOURCE:value()
+                if currentSOURCEESC1 ~= nil then
+                        currentesc1 = currentSOURCEESC1:value()
+                else
+                        currentesc1 = 0
+                end
                 if current ~= nil then
-                    current = current * 10
+                    if current == 0 and currentesc1 ~= 0 then
+                        current = currentesc1 * 10
+                    else
+                        current = current * 10
+                    end  
                 else
                     current = 0
                 end


### PR DESCRIPTION
This update simply allows the status widget to check:

- combined esc current sensor
- esc1 current sensor

The sensor that is live and working will be used for the end current sensor source.

Its been done to work around an oddity in the Flyrotor ESC.