### PR TITLE
Twlite External Module Support

### DIFF
--- a/scripts/rfsuite/app/app.lua
+++ b/scripts/rfsuite/app/app.lua
@@ -1006,9 +1006,6 @@ function app.create()
                 }
             }
 
-            if tonumber(rfsuite.utils.makeNumber(rfsuite.config.environment.major .. config.environment.minor .. config.environment.revision)) < 1590 then
-                form.openDialog("Warning", config.ethosVersionString, buttons, 1)
-            else
                 form.openDialog({
                     width = rfsuite.config.lcdWidth,
                     title = "Warning",
@@ -1020,7 +1017,6 @@ function app.create()
                     end,
                     options = TEXT_LEFT
                 })
-            end
 
         end
     end

--- a/scripts/rfsuite/app/lib/ui.lua
+++ b/scripts/rfsuite/app/lib/ui.lua
@@ -154,7 +154,6 @@ function ui.openMainMenu()
 
     local MainMenu = assert(compile.loadScript(config.suiteDir .. "app/pages.lua"))()
 
-    if tonumber(rfsuite.utils.makeNumber(config.environment.major .. config.environment.minor .. config.environment.revision)) < config.ethosVersion then return end
 
     -- clear all nav vars
     rfsuite.app.lastIdx = nil

--- a/scripts/rfsuite/app/pages/esc.lua
+++ b/scripts/rfsuite/app/pages/esc.lua
@@ -10,7 +10,6 @@ local function openPage(pidx, title, script)
 
     rfsuite.bg.msp.protocol.mspIntervalOveride = nil
 
-    if tonumber(rfsuite.utils.makeNumber(rfsuite.config.environment.major .. rfsuite.config.environment.minor .. rfsuite.config.environment.revision)) < rfsuite.config.ethosVersion then return end
 
     rfsuite.app.triggers.isReady = false
     rfsuite.app.uiState = rfsuite.app.uiStatus.mainMenu

--- a/scripts/rfsuite/app/pages/servos.lua
+++ b/scripts/rfsuite/app/pages/servos.lua
@@ -90,7 +90,6 @@ local function openPage(pidx, title, script)
 
     rfsuite.bg.msp.protocol.mspIntervalOveride = nil
 
-    if tonumber(rfsuite.utils.makeNumber(rfsuite.config.environment.major .. rfsuite.config.environment.minor .. rfsuite.config.environment.revision)) < rfsuite.config.ethosVersion then return end
 
     rfsuite.app.triggers.isReady = false
     rfsuite.app.uiState = rfsuite.app.uiStatus.pages

--- a/scripts/rfsuite/lib/utils.lua
+++ b/scripts/rfsuite/lib/utils.lua
@@ -183,7 +183,11 @@ end
 
 function utils.ethosVersion()
     local environment = system.getVersion()
-    return tonumber(environment.major .. environment.minor .. environment.revision)
+    v = tonumber(environment.major .. environment.minor .. environment.revision)
+    if environment.revision == 0 then
+        v = v * 10
+    end
+    return v
 end
 
 function utils.getRssiSensor()

--- a/scripts/rfsuite/tasks/msp/crsf.lua
+++ b/scripts/rfsuite/tasks/msp/crsf.lua
@@ -31,10 +31,19 @@ local CRSF_FRAMETYPE_MSP_WRITE = 0x7C -- write with 60 byte chunked binary
 
 local crsfMspCmd = 0
 
+if crsf.getSensor ~= nil then
+    local sensor = crsf.getSensor()
+    transport.popFrame = function() return sensor:popFrame() end
+    transport.pushFrame = function(x, y) return sensor:pushFrame(x, y) end
+else
+    transport.popFrame = function() return crsf.popFrame() end
+    transport.pushFrame = function(x, y) return crsf.pushFrame(x, y) end
+end
+
 transport.mspSend = function(payload)
     local payloadOut = {CRSF_ADDRESS_BETAFLIGHT, CRSF_ADDRESS_RADIO_TRANSMITTER}
     for i = 1, #(payload) do payloadOut[i + 2] = payload[i] end
-    return crsf.pushFrame(crsfMspCmd, payloadOut)
+    return transport.pushFrame(crsfMspCmd, payloadOut)
 end
 
 transport.mspRead = function(cmd)
@@ -49,7 +58,7 @@ end
 
 transport.mspPoll = function()
     while true do
-        local cmd, data = crsf.popFrame()
+        local cmd, data = transport.popFrame()
         if cmd == CRSF_FRAMETYPE_MSP_RESP and data[1] == CRSF_ADDRESS_RADIO_TRANSMITTER and data[2] == CRSF_ADDRESS_BETAFLIGHT then
             --[[
                         --rfsuite.utils.log("cmd:0x"..string.format("%X", cmd))

--- a/scripts/rfsuite/tasks/msp/msp.lua
+++ b/scripts/rfsuite/tasks/msp/msp.lua
@@ -35,8 +35,7 @@ local protocol = assert(compile.loadScript(config.suiteDir .. "tasks/msp/protoco
 
 msp.sensor = sport.getSensor({primId = 0x32})
 msp.mspQueue = mspQueue
-if rfsuite.rssiSensor then rfsuite.sensor:module(rfsuite.rssiSensor:module()) end
-msp.mspQueue = mspQueue
+
 
 -- set active protocol to use
 msp.protocol = protocol.getProtocol()
@@ -211,6 +210,10 @@ function msp.wakeup()
         msp.protocol.mspSend = transport.mspSend
         msp.protocol.mspWrite = transport.mspWrite
         msp.protocol.mspPoll = transport.mspPoll
+
+        if rfsuite.rssiSensor and msp.activeProtocol == "smartPort" then 
+            msp.sensor:module(rfsuite.rssiSensor:module()) 
+        end
 
         msp.resetState()
         msp.onConnectChecksInit = true

--- a/scripts/rfsuite/tasks/sensors/elrs.lua
+++ b/scripts/rfsuite/tasks/sensors/elrs.lua
@@ -28,6 +28,15 @@ local compile = arg[2]
 
 local elrs = {}
 
+if crsf.getSensor ~= nil then
+    local sensor = crsf.getSensor()
+    elrs.popFrame = function() return sensor:popFrame() end
+    elrs.pushFrame = function(x, y) return sensor:pushFrame(x, y) end
+else
+    elrs.popFrame = function() return crsf.popFrame() end
+    elrs.pushFrame = function(x, y) return crsf.pushFrame(x, y) end
+end
+
 local sensors = {}
 sensors['uid'] = {}
 sensors['lastvalue'] = {}
@@ -397,7 +406,7 @@ function elrs.crossfirePop()
         return false
     else
 
-        local command, data = crsf.popFrame()
+        local command, data = elrs.popFrame()
         if command and data then
 
             if command == CRSF_FRAME_CUSTOM_TELEM then


### PR DESCRIPTION
To support the twlite module (twmx receivers) on older ethos radios without the built in support.

Change required moving the logic to a later point in the loop in which I detect if the telemetry sensor is switched.

This should have been moved when the code was re-facted; but clearly was missed.

Suggest this is added to the RC1 release as its a minor change.