### PR TITLE
Recheck if int/ext module on connect

### DIFF
--- a/scripts/rfsuite/tasks/msp/msp.lua
+++ b/scripts/rfsuite/tasks/msp/msp.lua
@@ -35,8 +35,6 @@ local protocol = assert(compile.loadScript(config.suiteDir .. "tasks/msp/protoco
 
 msp.sensor = sport.getSensor({primId = 0x32})
 msp.mspQueue = mspQueue
-if rfsuite.rssiSensor then rfsuite.sensor:module(rfsuite.rssiSensor:module()) end
-msp.mspQueue = mspQueue
 
 -- set active protocol to use
 msp.protocol = protocol.getProtocol()
@@ -61,6 +59,13 @@ assert(compile.loadScript(config.suiteDir .. "tasks/msp/common.lua"))()
 function msp.onConnectBgChecks()
 
     if msp.mspQueue ~= nil and msp.mspQueue:isProcessed() then
+
+        -- set module to use. this happens on connect as
+        -- it forces a recheck whenever the rx has been disconnected
+        -- or a model swapped
+        if rfsuite.rssiSensor then 
+            msp.sensor:module(rfsuite.rssiSensor:module()) 
+        end
 
         if rfsuite.config.apiVersion == nil and msp.mspQueue:isProcessed() then
 

--- a/scripts/rfsuite/tasks/sensors/frsky.lua
+++ b/scripts/rfsuite/tasks/sensors/frsky.lua
@@ -89,6 +89,7 @@ local function createSensor(physId, primId, appId, frameValue)
                 frsky.createSensorCache[appId]:name(v.name)
                 frsky.createSensorCache[appId]:appId(appId)
                 frsky.createSensorCache[appId]:physId(physId)
+                frsky.createSensorCache[appId]:module(rfsuite.rssiSensor:module())
 
                 frsky.createSensorCache[appId]:minimum(min or -2147483647)
                 frsky.createSensorCache[appId]:maximum(max or 2147483647)


### PR DESCRIPTION
This change moves a check of the external module and an associated change of module used for msp comms to a different point in the code.

It will now 'recheck' whenever you disconnect/reconnect the rx.  likewise if you switch models from one model memory to the other.

Reason for the change is to ensure that when using an external TWLITE module (frsky external module) on the X20; that msp comms continue to work.


