### PR TITLE
Relative Paths

### DIFF
--- a/scripts/rfsuite/app/app.lua
+++ b/scripts/rfsuite/app/app.lua
@@ -1006,9 +1006,6 @@ function app.create()
                 }
             }
 
-            if tonumber(rfsuite.utils.makeNumber(rfsuite.config.environment.major .. config.environment.minor .. config.environment.revision)) < 1590 then
-                form.openDialog("Warning", config.ethosVersionString, buttons, 1)
-            else
                 form.openDialog({
                     width = rfsuite.config.lcdWidth,
                     title = "Warning",
@@ -1020,7 +1017,6 @@ function app.create()
                     end,
                     options = TEXT_LEFT
                 })
-            end
 
         end
     end

--- a/scripts/rfsuite/app/lib/ui.lua
+++ b/scripts/rfsuite/app/lib/ui.lua
@@ -154,7 +154,6 @@ function ui.openMainMenu()
 
     local MainMenu = assert(compile.loadScript(config.suiteDir .. "app/pages.lua"))()
 
-    if tonumber(rfsuite.utils.makeNumber(config.environment.major .. config.environment.minor .. config.environment.revision)) < config.ethosVersion then return end
 
     -- clear all nav vars
     rfsuite.app.lastIdx = nil

--- a/scripts/rfsuite/app/lib/ui.lua
+++ b/scripts/rfsuite/app/lib/ui.lua
@@ -247,7 +247,7 @@ function ui.openMainMenu()
 
                                 if config.iconSize ~= 0 then
                                     if rfsuite.app.gfx_buttons["mainmenu"][pidx] == nil then
-                                        rfsuite.app.gfx_buttons["mainmenu"][pidx] = lcd.loadMask(config.suiteDir .. "app/gfx/menu/" .. pvalue.image)
+                                        rfsuite.app.gfx_buttons["mainmenu"][pidx] = lcd.loadMask("app/gfx/menu/" .. pvalue.image)
                                     end
                                 else
                                     rfsuite.app.gfx_buttons["mainmenu"][pidx] = nil

--- a/scripts/rfsuite/app/pages/esc.lua
+++ b/scripts/rfsuite/app/pages/esc.lua
@@ -10,7 +10,6 @@ local function openPage(pidx, title, script)
 
     rfsuite.bg.msp.protocol.mspIntervalOveride = nil
 
-    if tonumber(rfsuite.utils.makeNumber(rfsuite.config.environment.major .. rfsuite.config.environment.minor .. rfsuite.config.environment.revision)) < rfsuite.config.ethosVersion then return end
 
     rfsuite.app.triggers.isReady = false
     rfsuite.app.uiState = rfsuite.app.uiStatus.mainMenu

--- a/scripts/rfsuite/app/pages/esc.lua
+++ b/scripts/rfsuite/app/pages/esc.lua
@@ -108,7 +108,7 @@ local function openPage(pidx, title, script)
         if lc >= 0 then bx = (buttonW + padding) * lc end
 
         if rfsuite.config.iconSize ~= 0 then
-            if rfsuite.app.gfx_buttons["escmain"][pidx] == nil then rfsuite.app.gfx_buttons["escmain"][pidx] = lcd.loadMask(rfsuite.config.suiteDir .. "app/gfx/esc/" .. pvalue.image) end
+            if rfsuite.app.gfx_buttons["escmain"][pidx] == nil then rfsuite.app.gfx_buttons["escmain"][pidx] = lcd.loadMask("app/gfx/esc/" .. pvalue.image) end
         else
             rfsuite.app.gfx_buttons["escmain"][pidx] = nil
         end

--- a/scripts/rfsuite/app/pages/servos.lua
+++ b/scripts/rfsuite/app/pages/servos.lua
@@ -90,7 +90,6 @@ local function openPage(pidx, title, script)
 
     rfsuite.bg.msp.protocol.mspIntervalOveride = nil
 
-    if tonumber(rfsuite.utils.makeNumber(rfsuite.config.environment.major .. rfsuite.config.environment.minor .. rfsuite.config.environment.revision)) < rfsuite.config.ethosVersion then return end
 
     rfsuite.app.triggers.isReady = false
     rfsuite.app.uiState = rfsuite.app.uiStatus.pages

--- a/scripts/rfsuite/app/pages/servos.lua
+++ b/scripts/rfsuite/app/pages/servos.lua
@@ -189,7 +189,7 @@ local function openPage(pidx, title, script)
 
             if rfsuite.config.iconSize ~= 0 then
                 if rfsuite.app.gfx_buttons["servos"][pidx] == nil then
-                    rfsuite.app.gfx_buttons["servos"][pidx] = lcd.loadMask(rfsuite.config.suiteDir .. "app/gfx/servos/" .. pvalue.image)
+                    rfsuite.app.gfx_buttons["servos"][pidx] = lcd.loadMask("app/gfx/servos/" .. pvalue.image)
                 end
             else
                 rfsuite.app.gfx_buttons["servos"][pidx] = nil

--- a/scripts/rfsuite/compile.lua
+++ b/scripts/rfsuite/compile.lua
@@ -23,7 +23,7 @@ compile = {}
 
 local arg = {...}
 local config = arg[1]
-local suiteDir = config.suiteDir
+local suiteDir = "./"
 
 local readConfig
 local switchParam
@@ -58,8 +58,7 @@ end
 
 local function baseName()
     local baseName
-    baseName = config.suiteDir:gsub("/scripts/", "")
-    baseName = baseName:gsub("/", "")
+    baseName = suiteDir:gsub("/", "")
     return baseName
 end
 
@@ -73,6 +72,7 @@ end
 
 function compile.loadScript(script)
 
+     script = script:gsub(config.suiteDir,"")
 
      if os.mkdir ~= nil and dir_exists(suiteDir , "compiled") == false then
                         os.mkdir(suiteDir .. "compiled")
@@ -84,9 +84,9 @@ function compile.loadScript(script)
 
     -- overrides
     if config.useCompiler == true then
-        if file_exists("/scripts/" .. baseName() .. ".nocompile") == true then config.useCompiler = false end
+        if file_exists("../" .. baseName() .. ".nocompile") == true then config.useCompiler = false end
 
-        if file_exists("/scripts/nocompile") == true then config.useCompiler = false end
+        if file_exists("../nocompile") == true then config.useCompiler = false end
     end
 
     -- do not compile if for some reason the compiler cache folder is missing
@@ -101,14 +101,14 @@ function compile.loadScript(script)
             os.rename(script .. 'c', cachefile)
 
             -- if not compiled - we compile; but return non compiled to sort timing issue.
-            --print("Loading: " .. cachefile)
+            print("Loading: " .. cachefile)
             return assert(loadfile(cachefile))
         end
-        -- print("Loading: " .. cachefile)
+         print("Loading: " .. cachefile)
         return assert(loadfile(cachefile))
     else
         if file_exists(cachefile) == true then os.remove(cachefile) end
-        -- print("Loading: " .. script)              
+         print("Loading: " .. script)              
         return assert(loadfile(script))
     end
 

--- a/scripts/rfsuite/compile.lua
+++ b/scripts/rfsuite/compile.lua
@@ -101,14 +101,14 @@ function compile.loadScript(script)
             os.rename(script .. 'c', cachefile)
 
             -- if not compiled - we compile; but return non compiled to sort timing issue.
-            print("Loading: " .. cachefile)
+            --print("Loading: " .. cachefile)
             return assert(loadfile(cachefile))
         end
-         print("Loading: " .. cachefile)
+        -- print("Loading: " .. cachefile)
         return assert(loadfile(cachefile))
     else
         if file_exists(cachefile) == true then os.remove(cachefile) end
-         print("Loading: " .. script)              
+        --print("Loading: " .. script)              
         return assert(loadfile(script))
     end
 

--- a/scripts/rfsuite/lib/utils.lua
+++ b/scripts/rfsuite/lib/utils.lua
@@ -183,7 +183,11 @@ end
 
 function utils.ethosVersion()
     local environment = system.getVersion()
-    return tonumber(environment.major .. environment.minor .. environment.revision)
+    v = tonumber(environment.major .. environment.minor .. environment.revision)
+    if environment.revision == 0 then
+        v = v * 10
+    end
+    return v
 end
 
 function utils.getRssiSensor()

--- a/scripts/rfsuite/lib/utils.lua
+++ b/scripts/rfsuite/lib/utils.lua
@@ -56,13 +56,27 @@ function utils.playFile(pkg,file)
         local av = system.getAudioVoice()
         av = string.gsub(av, "SD:", "")
         av = string.gsub(av, "RADIO:", "")
-
+        av = string.gsub(av, "AUDIO:", "")        
+        av = string.gsub(av, "VOICE1:", "")
+        av = string.gsub(av, "VOICE2:", "")
+        av = string.gsub(av, "VOICE3:", "")
+        
         if rfsuite.config.soundPack == nil then  
-                wavLocale = rfsuite.config.suiteDir ..  av .. "/" .. pkg .. "/" .. file
-                wavDefault = rfsuite.config.suiteDir .. "/audio/en/default/" .. pkg .. "/" .. file                    
+                if config.ethosRunningVersion <= 1518 then
+                    wavLocale = rfsuite.config.suiteDir ..  av .. "/" .. pkg .. "/" .. file
+                    wavDefault = rfsuite.config.suiteDir .. "/audio/en/default/" .. pkg .. "/" .. file
+                else
+                    wavLocale = av .. "/" .. pkg .. "/" .. file
+                    wavDefault = "audio/en/default/" .. pkg .. "/" .. file                
+                end
         else
-                wavLocale = rfsuite.config.suiteDir .. "/audio/" .. rfsuite.config.soundPack .. "/" .. pkg .. "/" .. file
-                wavDefault = rfsuite.config.suiteDir .. "/audio/en/default/" .. pkg .. "/" .. file        
+                if config.ethosRunningVersion <= 1518 then        
+                    wavLocale = rfsuite.config.suiteDir .. "/audio/" .. rfsuite.config.soundPack .. "/" .. pkg .. "/" .. file
+                    wavDefault = rfsuite.config.suiteDir .. "/audio/en/default/" .. pkg .. "/" .. file  
+                else
+                    wavLocale = "audio/" .. rfsuite.config.soundPack .. "/" .. pkg .. "/" .. file
+                    wavDefault = "audio/en/default/" .. pkg .. "/" .. file                  
+                end
         end
              
         if rfsuite.utils.file_exists(wavLocale) then
@@ -76,7 +90,12 @@ end
 
 function utils.playFileCommon(file)
 
-        local wav = rfsuite.config.suiteDir .. "/audio/" .. file
+        local wav
+        if config.ethosRunningVersion <= 1518 then
+            wav = rfsuite.config.suiteDir .. "/audio/" .. file
+        else
+            wav = "audio/" .. file
+        end
 
         system.playFile(wav)
       

--- a/scripts/rfsuite/tasks/bg.lua
+++ b/scripts/rfsuite/tasks/bg.lua
@@ -94,6 +94,10 @@ function bg.wakeup()
     end
     if system:getVersion().simulation == true then rfsuite.rssiSensorChanged = false end
 
+    if config.ethosRunningVersion == nil then
+        config.ethosRunningVersion = rfsuite.utils.ethosVersion()
+    end
+
     -- high priority and must alway run regardless of tlm state
     bg.msp.wakeup()
     bg.telemetry.wakeup()

--- a/scripts/rfsuite/tasks/msp/crsf.lua
+++ b/scripts/rfsuite/tasks/msp/crsf.lua
@@ -31,10 +31,19 @@ local CRSF_FRAMETYPE_MSP_WRITE = 0x7C -- write with 60 byte chunked binary
 
 local crsfMspCmd = 0
 
+if crsf.getSensor ~= nil then
+    local sensor = crsf.getSensor()
+    transport.popFrame = function() return sensor:popFrame() end
+    transport.pushFrame = function(x, y) return sensor:pushFrame(x, y) end
+else
+    transport.popFrame = function() return crsf.popFrame() end
+    transport.pushFrame = function(x, y) return crsf.pushFrame(x, y) end
+end
+
 transport.mspSend = function(payload)
     local payloadOut = {CRSF_ADDRESS_BETAFLIGHT, CRSF_ADDRESS_RADIO_TRANSMITTER}
     for i = 1, #(payload) do payloadOut[i + 2] = payload[i] end
-    return crsf.pushFrame(crsfMspCmd, payloadOut)
+    return transport.pushFrame(crsfMspCmd, payloadOut)
 end
 
 transport.mspRead = function(cmd)
@@ -49,7 +58,7 @@ end
 
 transport.mspPoll = function()
     while true do
-        local cmd, data = crsf.popFrame()
+        local cmd, data = transport.popFrame()
         if cmd == CRSF_FRAMETYPE_MSP_RESP and data[1] == CRSF_ADDRESS_RADIO_TRANSMITTER and data[2] == CRSF_ADDRESS_BETAFLIGHT then
             --[[
                         --rfsuite.utils.log("cmd:0x"..string.format("%X", cmd))

--- a/scripts/rfsuite/tasks/sensors/elrs.lua
+++ b/scripts/rfsuite/tasks/sensors/elrs.lua
@@ -28,6 +28,15 @@ local compile = arg[2]
 
 local elrs = {}
 
+if crsf.getSensor ~= nil then
+    local sensor = crsf.getSensor()
+    elrs.popFrame = function() return sensor:popFrame() end
+    elrs.pushFrame = function(x, y) return sensor:pushFrame(x, y) end
+else
+    elrs.popFrame = function() return crsf.popFrame() end
+    elrs.pushFrame = function(x, y) return crsf.pushFrame(x, y) end
+end
+
 local sensors = {}
 sensors['uid'] = {}
 sensors['lastvalue'] = {}
@@ -397,7 +406,7 @@ function elrs.crossfirePop()
         return false
     else
 
-        local command, data = crsf.popFrame()
+        local command, data = elrs.popFrame()
         if command and data then
 
             if command == CRSF_FRAME_CUSTOM_TELEM then

--- a/scripts/rfsuite/widgets/status/status.lua
+++ b/scripts/rfsuite/widgets/status/status.lua
@@ -272,8 +272,8 @@ function status.create(widget)
     status.initTime = os.clock()
 
     status.gfx_model = lcd.loadBitmap(model.bitmap())
-    status.gfx_heli = lcd.loadBitmap(suiteDir .. "widgets/status/gfx/heli.png")
-    status.gfx_close = lcd.loadBitmap(suiteDir .. "widgets/status/gfx/close.png")
+    status.gfx_heli = lcd.loadBitmap("widgets/status/gfx/heli.png")
+    status.gfx_close = lcd.loadBitmap("widgets/status/gfx/close.png")
     -- status.rssiSensor = status.getRssiSensor()
 
     if tonumber(status.sensorMakeNumber(environment.version)) < 159 then
@@ -3521,7 +3521,7 @@ function status.sensorsMAXMIN(sensors)
             name = string.gsub(model.name(), "%s+", "_")
             name = string.gsub(name, "%W", "_")
 
-            local file = suiteDir .. "widgets/status/logs/" .. name .. ".log"
+            local file = "widgets/status/logs/" .. name .. ".log"
 
             local f = io.open(file, 'w')
             f:write("")
@@ -3690,7 +3690,7 @@ function status.readHistory()
     name = string.gsub(model.name(), "%s+", "_")
     name = string.gsub(name, "%W", "_")
 
-    file = suiteDir .. "widgets/status/logs/" .. name .. ".log"
+    file = "widgets/status/logs/" .. name .. ".log"
     local f = io.open(file, "rb")
 
     if f ~= nil then


### PR DESCRIPTION
Ethos 1.6 has forced a change from absolute to relative paths.

This issue is to circumvent an issue that occurs when using mixed mod sd+eMMC storage.

This commit switches the system to use relative pathing rather than absolute.

The change is backward compatable with 1.5.18 so no issue merging - but suggest we do this post RF2.1 as 1.6 is not out yet and more things could change.
