### PR TITLE
Make mute more robust.

### DIFF
--- a/scripts/rfsuite/tasks/msp/mspQueue.lua
+++ b/scripts/rfsuite/tasks/msp/mspQueue.lua
@@ -49,7 +49,7 @@ function MspQueueController:processQueue()
 
     if rfsuite.rssiSensor then  
         local module = model.getModule(rfsuite.rssiSensor:module())    
-        if module.muteSensorLost ~= nil then
+        if module ~= nil and module.muteSensorLost ~= nil then
             module:muteSensorLost(2.0) -- mute for 2s      
         end
     end    


### PR DESCRIPTION
Some radio variants seem to not have this var and error. (X18 FCC)

This updates adds an additional check to avoid the 

Detect and avoid issue altogether.  

I suspect this error is end user is running a nightly of 1.5.18; but does not hurt to prevent issue with the check!