### PR TITLE
improve performance of deep copy

### DIFF
--- a/scripts/rfsuite/tasks/msp/mspQueue.lua
+++ b/scripts/rfsuite/tasks/msp/mspQueue.lua
@@ -153,17 +153,24 @@ function MspQueueController:clear()
 end
 
 local function deepCopy(original)
-
     local copy
     if type(original) == "table" then
         copy = {}
-        for key, value in next, original, nil do copy[deepCopy(key)] = deepCopy(value) end
-        setmetatable(copy, deepCopy(getmetatable(original)))
-    else -- number, string, boolean, etc
+        -- Only deep copy values, not keys
+        for key, value in next, original, nil do 
+            copy[key] = deepCopy(value)
+        end
+        local mt = getmetatable(original)
+        if mt then
+            setmetatable(copy, deepCopy(mt)) -- Copy the metatable if it exists
+        end
+    else
+
         copy = original
     end
     return copy
 end
+
 
 function MspQueueController:add(message)
 


### PR DESCRIPTION
Key changes:
No deep copy of keys: The keys are directly assigned from original to copy, and only the values are recursively copied. This avoids unnecessary deep-copying of keys, which are typically primitive types.

Simplified metatable handling: Only the metatable is copied if it exists (if mt then), which reduces the unnecessary call to deepCopy for nil values.

Efficiency:
Memory overhead: Avoiding the recursive copying of keys reduces the memory overhead in cases where the table contains many entries with non-table keys.
Execution time: Removing the recursion for keys makes the function faster, especially when dealing with large tables.