### PR TITLE
MSP Should have been declared as local

### DIFF
--- a/scripts/rfsuite/tasks/msp/msp.lua
+++ b/scripts/rfsuite/tasks/msp/msp.lua
@@ -26,7 +26,7 @@ local arg = {...}
 local config = arg[1]
 local compile = arg[2]
 
-msp = {}
+local msp = {}
 
 msp.activeProtocol = nil
 msp.onConnectChecksInit = true


### PR DESCRIPTION
This var should have been local. 

As a global - it ends up getting 'overwritten' by other scripts - which is really not very nice.