### PR TITLE
Async logging

### DIFF
--- a/scripts/rfsuite/lib/utils.lua
+++ b/scripts/rfsuite/lib/utils.lua
@@ -460,8 +460,6 @@ function utils.log(msg)
 
     if config.logEnable == true then
 
-        if config.logEnableScreen == true then print(msg) end
-
         if rfsuite.bg.log_queue ~= nil then
             table.insert(rfsuite.bg.log_queue, msg)
         end

--- a/scripts/rfsuite/lib/utils.lua
+++ b/scripts/rfsuite/lib/utils.lua
@@ -462,10 +462,10 @@ function utils.log(msg)
 
         if config.logEnableScreen == true then print(msg) end
 
-        local f = io.open("logs/rfsuite.log", 'a')
-        io.write(f, tostring(msg) .. "\n")
-        io.close(f)
-
+        if rfsuite.bg.log_queue ~= nil then
+            table.insert(rfsuite.bg.log_queue, msg)
+        end
+        
     end
 end
 

--- a/scripts/rfsuite/tasks/bg.lua
+++ b/scripts/rfsuite/tasks/bg.lua
@@ -37,7 +37,8 @@ bg.msp = assert(loadfile("tasks/msp/msp.lua"))(config)
 bg.adjfunctions = assert(loadfile("tasks/adjfunctions/adjfunctions.lua"))(config)
 bg.sensors = assert(loadfile("tasks/sensors/sensors.lua"))(config)
 
-local bg.log_queue = {}
+bg.log_queue = {}
+
 
 rfsuite.rssiSensorChanged = true
 
@@ -45,6 +46,30 @@ local rssiCheckScheduler = os.clock()
 local lastRssiSensorName = nil
 
 bg.wasOn = false
+
+function bg.flush_logs()
+    local max_lines_per_flush = 5
+
+    if #bg.log_queue > 0 and rfsuite.bg.msp.mspQueue:isProcessed() then
+    
+        local f
+            
+        for i = 1, math.min(#bg.log_queue, max_lines_per_flush) do
+            
+            if rfsuite.config.logEnableScreen == true then print(bg.log_queue[1]) end
+            
+            if rfsuite.utils.ethosVersionToMinor() < 16 then
+                f = io.open(config.suiteDir .. "/logs/rfsuite.log", 'a')
+            else
+                f = io.open("logs/rfsuite.log", 'a')
+            end
+            io.write(f, table.remove(bg.log_queue, 1) .. "\n")
+            io.close(f)
+       
+        end
+            
+    end
+end
 
 function bg.active()
 
@@ -100,7 +125,7 @@ function bg.wakeup()
     bg.telemetry.wakeup()
     bg.sensors.wakeup()
     bg.adjfunctions.wakeup()
-
+    bg.flush_logs()
 end
 
 function bg.event(widget, category, value)

--- a/scripts/rfsuite/tasks/bg.lua
+++ b/scripts/rfsuite/tasks/bg.lua
@@ -37,6 +37,8 @@ bg.msp = assert(loadfile("tasks/msp/msp.lua"))(config)
 bg.adjfunctions = assert(loadfile("tasks/adjfunctions/adjfunctions.lua"))(config)
 bg.sensors = assert(loadfile("tasks/sensors/sensors.lua"))(config)
 
+local bg.log_queue = {}
+
 rfsuite.rssiSensorChanged = true
 
 local rssiCheckScheduler = os.clock()


### PR DESCRIPTION
Logging to disk is slow.  We do this 'async' to avoid interupting MSP data transfer.