### PR TITLE
RF 2.1.X MSP variable should be local (#35)

### DIFF
--- a/scripts/rfsuite/tasks/msp/msp.lua
+++ b/scripts/rfsuite/tasks/msp/msp.lua
@@ -26,7 +26,7 @@ local arg = {...}
 local config = arg[1]
 local compile = arg[2]
 
-msp = {}
+local msp = {}
 
 msp.activeProtocol = nil
 msp.onConnectChecksInit = true


### PR DESCRIPTION
MSP Var should be local to avoid global clash