### PR TITLE
RF2.2.X - ELRS - Suppress Alerts when config tool running

### DIFF
--- a/scripts/rfsuite/tasks/bg.lua
+++ b/scripts/rfsuite/tasks/bg.lua
@@ -23,6 +23,7 @@
 --
 local arg = {...}
 local config = arg[1]
+local currentRssiSensor
 
 -- declare vars
 local bg = {}
@@ -101,7 +102,7 @@ function bg.wakeup()
     -- doing this is heavy - lets run it every few seconds only
     local now = os.clock()
     if rssiCheckScheduler ~= nil and (now - rssiCheckScheduler) >= 2 then
-        local currentRssiSensor = rfsuite.utils.getRssiSensor()
+        currentRssiSensor = rfsuite.utils.getRssiSensor()
 
         if currentRssiSensor ~= nil then
 
@@ -112,13 +113,17 @@ function bg.wakeup()
             end
 
             lastRssiSensorName = currentRssiSensor.name
-            rfsuite.rssiSensor = currentRssiSensor.sensor
+            
         else
             rfsuite.rssiSensorChanged = false
         end
         rssiCheckScheduler = now
     end
     if system:getVersion().simulation == true then rfsuite.rssiSensorChanged = false end
+
+    if currentRssiSensor ~= nil then
+        rfsuite.rssiSensor = currentRssiSensor.sensor
+    end    
 
     -- high priority and must alway run regardless of tlm state
     bg.msp.wakeup()

--- a/scripts/rfsuite/tasks/sensors/elrs.lua
+++ b/scripts/rfsuite/tasks/sensors/elrs.lua
@@ -415,6 +415,10 @@ elrs.telemetryFrameCount = 0
 function elrs.crossfirePop()
 
     if (CRSF_PAUSE_TELEMETRY == true or rfsuite.app.triggers.mspBusy == true) then
+        local module = model.getModule(rfsuite.rssiSensor:module())
+        if module ~= nil and module.muteSensorLost ~= nil then
+            module:muteSensorLost(5.0)
+        end    
         return false
     else
 


### PR DESCRIPTION
This update prevents telemetry warnings in ethos 1.6 when the ELRS config tool is running.