### PR TITLE
RF 2.1.X - Status Widget Error

### DIFF
--- a/scripts/rfsuite/widgets/status/status.lua
+++ b/scripts/rfsuite/widgets/status/status.lua
@@ -3148,6 +3148,7 @@ function status.getSensors()
                 current = currentSOURCE:value()
                 if currentSOURCEESC1 ~= nil then
                         currentesc1 = currentSOURCEESC1:value()
+                        if currentesc1 == nil then currentesc1 = 0 end
                 else
                         currentesc1 = 0
                 end


### PR DESCRIPTION
Catch an exeption where a sensor does not exit due to no current sensor being sent in RF config. If nil.. set value to 0.