### PR TITLE
RF2.2.X Improved UI response on timeouts

### DIFF
--- a/scripts/rfsuite/app/lib/ui.lua
+++ b/scripts/rfsuite/app/lib/ui.lua
@@ -150,6 +150,14 @@ function ui.progressDisplayNoLinkValue(value, message)
 
 end
 
+function ui.disableAllFields()
+
+end
+
+function ui.enableAllFields()
+
+end
+
 function ui.openMainMenu()
 
     local MainMenu = assert(loadfile("app/pages.lua"))()
@@ -335,9 +343,11 @@ function ui.fieldChoice(i)
     end
 
     rfsuite.app.formFields[i] = form.addChoiceField(rfsuite.app.formLines[formLineCnt], posField, rfsuite.utils.convertPageValueTable(f.table, f.tableIdxInc), function()
-        local value = rfsuite.utils.getFieldValue(rfsuite.app.Page.fields[i])
-
-        return value
+        if rfsuite.app.Page.fields == nil or rfsuite.app.Page.fields[i] == nil then 
+            ui.disableAllFields()
+            return nil
+        end
+        return rfsuite.utils.getFieldValue(rfsuite.app.Page.fields[i])
     end, function(value)
         -- we do this hook to allow rates to be reset
         if f.postEdit then f.postEdit(rfsuite.app.Page, value) end
@@ -399,10 +409,11 @@ function ui.fieldNumber(i)
     if minValue == nil then minValue = 0 end
     if maxValue == nil then maxValue = 0 end
     rfsuite.app.formFields[i] = form.addNumberField(rfsuite.app.formLines[formLineCnt], posField, minValue, maxValue, function()
-
-        local value = rfsuite.utils.getFieldValue(rfsuite.app.Page.fields[i])
-
-        return value
+        if rfsuite.app.Page.fields == nil or rfsuite.app.Page.fields[i] == nil then 
+            ui.disableAllFields()
+            return nil
+        end
+        return rfsuite.utils.getFieldValue(rfsuite.app.Page.fields[i])
     end, function(value)
         if f.postEdit then f.postEdit(rfsuite.app.Page) end
         if f.onChange then f.onChange(rfsuite.app.Page) end
@@ -441,6 +452,9 @@ function ui.fieldNumber(i)
     end
 
 end
+
+
+
 
 function ui.fieldStaticText(i)
 
@@ -535,8 +549,11 @@ function ui.fieldText(i)
     end
 
     rfsuite.app.formFields[i] = form.addTextField(rfsuite.app.formLines[formLineCnt], posField, function()
-        local value = rfsuite.utils.getFieldValue(rfsuite.app.Page.fields[i])
-        return value
+        if rfsuite.app.Page.fields == nil or rfsuite.app.Page.fields[i] == nil then 
+            ui.disableAllFields()
+            return nil
+        end    
+        return rfsuite.utils.getFieldValue(rfsuite.app.Page.fields[i])
     end, function(value)
         if f.postEdit then f.postEdit(rfsuite.app.Page) end
         if f.onChange then f.onChange(rfsuite.app.Page) end

--- a/scripts/rfsuite/app/lib/ui.lua
+++ b/scripts/rfsuite/app/lib/ui.lua
@@ -184,6 +184,12 @@ function ui.enableNavigationField(x)
     end
 end
 
+function ui.disableNavigationField(x)
+    if rfsuite.app.formNavigationFields[x] ~= nil then
+           rfsuite.app.formNavigationFields[x]:enable(false) 
+    end
+end
+
 function ui.openMainMenu()
 
     local MainMenu = assert(loadfile("app/pages.lua"))()
@@ -373,7 +379,6 @@ function ui.fieldChoice(i)
             ui.disableAllFields()
             ui.disableAllNavigationFields()
             ui.enableNavigationField('menu')
-            ui.enableNavigationField('reload')
             return nil
         end
         return rfsuite.utils.getFieldValue(rfsuite.app.Page.fields[i])
@@ -441,8 +446,7 @@ function ui.fieldNumber(i)
         if rfsuite.app.Page.fields == nil or rfsuite.app.Page.fields[i] == nil then 
             ui.disableAllFields()
             ui.disableAllNavigationFields()
-            ui.enableNavigationField('menu')
-            ui.enableNavigationField('reload')        
+            ui.enableNavigationField('menu')      
             return nil
         end
         return rfsuite.utils.getFieldValue(rfsuite.app.Page.fields[i])
@@ -584,8 +588,7 @@ function ui.fieldText(i)
         if rfsuite.app.Page.fields == nil or rfsuite.app.Page.fields[i] == nil then 
             ui.disableAllFields()
             ui.disableAllNavigationFields()
-            ui.enableNavigationField('menu')
-            ui.enableNavigationField('reload')     
+            ui.enableNavigationField('menu')   
             return nil
         end    
         return rfsuite.utils.getFieldValue(rfsuite.app.Page.fields[i])

--- a/scripts/rfsuite/app/lib/ui.lua
+++ b/scripts/rfsuite/app/lib/ui.lua
@@ -151,11 +151,37 @@ function ui.progressDisplayNoLinkValue(value, message)
 end
 
 function ui.disableAllFields()
-
+        for i in ipairs(rfsuite.app.formFields) do
+                rfsuite.app.formFields[i]:enable(false)
+        end
 end
 
 function ui.enableAllFields()
+        for i in ipairs(rfsuite.app.formFields) do
+                rfsuite.app.formFields[i]:enable(true)
+        end
+end
 
+function ui.disableAllNavigationFields()
+    for i,v in pairs(rfsuite.app.formNavigationFields) do
+        if x ~= v then
+            rfsuite.app.formNavigationFields[i]:enable(false)
+        end    
+    end
+end
+
+function ui.enableAllNavigationFields()
+    for i,v in pairs(rfsuite.app.formNavigationFields) do
+        if x ~= v then
+            rfsuite.app.formNavigationFields[i]:enable(true)
+        end    
+    end
+end
+
+function ui.enableNavigationField(x)
+    if rfsuite.app.formNavigationFields[x] ~= nil then
+           rfsuite.app.formNavigationFields[x]:enable(true) 
+    end
 end
 
 function ui.openMainMenu()
@@ -345,6 +371,9 @@ function ui.fieldChoice(i)
     rfsuite.app.formFields[i] = form.addChoiceField(rfsuite.app.formLines[formLineCnt], posField, rfsuite.utils.convertPageValueTable(f.table, f.tableIdxInc), function()
         if rfsuite.app.Page.fields == nil or rfsuite.app.Page.fields[i] == nil then 
             ui.disableAllFields()
+            ui.disableAllNavigationFields()
+            ui.enableNavigationField('menu')
+            ui.enableNavigationField('reload')
             return nil
         end
         return rfsuite.utils.getFieldValue(rfsuite.app.Page.fields[i])
@@ -411,6 +440,9 @@ function ui.fieldNumber(i)
     rfsuite.app.formFields[i] = form.addNumberField(rfsuite.app.formLines[formLineCnt], posField, minValue, maxValue, function()
         if rfsuite.app.Page.fields == nil or rfsuite.app.Page.fields[i] == nil then 
             ui.disableAllFields()
+            ui.disableAllNavigationFields()
+            ui.enableNavigationField('menu')
+            ui.enableNavigationField('reload')        
             return nil
         end
         return rfsuite.utils.getFieldValue(rfsuite.app.Page.fields[i])
@@ -551,6 +583,9 @@ function ui.fieldText(i)
     rfsuite.app.formFields[i] = form.addTextField(rfsuite.app.formLines[formLineCnt], posField, function()
         if rfsuite.app.Page.fields == nil or rfsuite.app.Page.fields[i] == nil then 
             ui.disableAllFields()
+            ui.disableAllNavigationFields()
+            ui.enableNavigationField('menu')
+            ui.enableNavigationField('reload')     
             return nil
         end    
         return rfsuite.utils.getFieldValue(rfsuite.app.Page.fields[i])


### PR DESCRIPTION
In the event of a timeout (a failed msp request or non existant msp id) the system can be left in a state where expected variables are missing.

This pr disables all form elements on a page - including navigation buttons.

The aim being to leave only the 'menu' button active so you can exit and restart the process.