### PR TITLE
RF2.2.X Improve deployment scripts

### DIFF
--- a/bin/deploy-radio.cmd
+++ b/bin/deploy-radio.cmd
@@ -1,14 +1,53 @@
-echo off
+@echo off
+
+REM Accept an optional parameter for file extension
+set "fileext=%~1"
+
+if not "%fileext%"==".lua" (
+    echo No file extension specified or unsupported parameter. Proceeding with default behavior.
+)
 
 set tgt=rfsuite
-
 set srcfolder=%DEV_RFSUITE_GIT_SRC%
 set dstfolder=%DEV_RADIO_SRC%
 
-REM "Remove destination folder"
-RMDIR "%dstfolder%\%tgt%" /S /Q
+REM Preserve the logs folder by moving it temporarily
+if exist "%dstfolder%\%tgt%\logs\" (
+    mkdir "%dstfolder%\logs_temp"
+    xcopy "%dstfolder%\%tgt%\logs\*" "%dstfolder%\logs_temp" /h /i /c /k /e /r /y
+)
 
+REM If .lua parameter is set, handle .lua files specifically
+if "%fileext%"==".lua" (
+    echo Removing all .lua files from target...
+    for /r "%dstfolder%\%tgt%" %%F in (*.lua) do del "%%F"
+    
+    echo Syncing only .lua files to target...
+    mkdir "%dstfolder%\%tgt%"
+    xcopy "%srcfolder%\scripts\%tgt%\*.lua" "%dstfolder%\%tgt%" /h /i /c /k /e /r /y
+) else (
+    REM Remove the entire destination folder
+    RMDIR "%dstfolder%\%tgt%" /S /Q
 
-REM "copy files to folder"
-mkdir "%dstfolder%\%tgt%"
-xcopy "%srcfolder%\scripts\%tgt%" "%dstfolder%\%tgt%"  /h /i /c /k /e /r /y
+    REM Recreate the destination folder
+    mkdir "%dstfolder%\%tgt%"
+    
+    REM Restore the logs folder
+    if exist "%dstfolder%\logs_temp\" (
+        mkdir "%dstfolder%\%tgt%\logs"
+        xcopy "%dstfolder%\logs_temp\*" "%dstfolder%\%tgt%\logs" /h /i /c /k /e /r /y
+        RMDIR "%dstfolder%\logs_temp" /S /Q
+    )
+    
+    REM Copy all files to the destination folder
+    xcopy "%srcfolder%\scripts\%tgt%" "%dstfolder%\%tgt%" /h /i /c /k /e /r /y
+)
+
+REM Restore logs if not handled already
+if exist "%dstfolder%\logs_temp\" (
+    mkdir "%dstfolder%\%tgt%\logs"
+    xcopy "%dstfolder%\logs_temp\*" "%dstfolder%\%tgt%\logs" /h /i /c /k /e /r /y
+    RMDIR "%dstfolder%\logs_temp" /S /Q
+)
+
+echo Script execution completed.

--- a/bin/deploy-sim.cmd
+++ b/bin/deploy-sim.cmd
@@ -1,15 +1,53 @@
-echo off
+@echo off
+
+REM Accept an optional parameter for file extension
+set "fileext=%~1"
+
+if not "%fileext%"==".lua" (
+    echo No file extension specified or unsupported parameter. Proceeding with default behavior.
+)
 
 set tgt=rfsuite
-
 set srcfolder=%DEV_RFSUITE_GIT_SRC%
 set dstfolder=%DEV_SIM_SRC%
 
-REM "Remove destination folder"
-RMDIR "%dstfolder%\%tgt%" /S /Q
+REM Preserve the logs folder by moving it temporarily
+if exist "%dstfolder%\%tgt%\logs\" (
+    mkdir "%dstfolder%\logs_temp"
+    xcopy "%dstfolder%\%tgt%\logs\*" "%dstfolder%\logs_temp" /h /i /c /k /e /r /y
+)
 
+REM If .lua parameter is set, handle .lua files specifically
+if "%fileext%"==".lua" (
+    echo Removing all .lua files from target...
+    for /r "%dstfolder%\%tgt%" %%F in (*.lua) do del "%%F"
+    
+    echo Syncing only .lua files to target...
+    mkdir "%dstfolder%\%tgt%"
+    xcopy "%srcfolder%\scripts\%tgt%\*.lua" "%dstfolder%\%tgt%" /h /i /c /k /e /r /y
+) else (
+    REM Remove the entire destination folder
+    RMDIR "%dstfolder%\%tgt%" /S /Q
 
+    REM Recreate the destination folder
+    mkdir "%dstfolder%\%tgt%"
+    
+    REM Restore the logs folder
+    if exist "%dstfolder%\logs_temp\" (
+        mkdir "%dstfolder%\%tgt%\logs"
+        xcopy "%dstfolder%\logs_temp\*" "%dstfolder%\%tgt%\logs" /h /i /c /k /e /r /y
+        RMDIR "%dstfolder%\logs_temp" /S /Q
+    )
+    
+    REM Copy all files to the destination folder
+    xcopy "%srcfolder%\scripts\%tgt%" "%dstfolder%\%tgt%" /h /i /c /k /e /r /y
+)
 
-REM "copy files to folder"
-mkdir "%dstfolder%\%tgt%"
-xcopy "%srcfolder%\scripts\%tgt%" "%dstfolder%\%tgt%"  /h /i /c /k /e /r /y
+REM Restore logs if not handled already
+if exist "%dstfolder%\logs_temp\" (
+    mkdir "%dstfolder%\%tgt%\logs"
+    xcopy "%dstfolder%\logs_temp\*" "%dstfolder%\%tgt%\logs" /h /i /c /k /e /r /y
+    RMDIR "%dstfolder%\logs_temp" /S /Q
+)
+
+echo Script execution completed.


### PR DESCRIPTION
The two deployment scripts needed a revamp to make them more usefull.

**Changes are:**

- never delete logs folder when syncing.
- add a parameter for file extention ($1).
    
    Adding an extention to the command line will result in only those files being synced to the destination folder.

    deploy-sim.cmd   .lua
   
**Setting this up needs three env vars setup in windows:**
   
_%DEV_RFSUITE_GIT_SRC%
%DEV_RADIO_SRC%
%DEV_SIM_SRC%_

On my system I have:

DEV_RADIO_SRC = h:\scripts\
DEV_RFSUITE_GIT_SRC = C:\GitHub\RT-RC\rotorflight-lua-ethos-suite\
DEV_SIM_SRC = c:\Program Files (x86)\FrSky\Ethos\X20S\scripts\
    

    
    