### PR TITLE
RF2.2.X Governor Min Throttle Support

### DIFF
--- a/scripts/rfsuite/app/help/fields.lua
+++ b/scripts/rfsuite/app/help/fields.lua
@@ -40,7 +40,7 @@ return {
     govVoltageFilterHz = {t = "Cutoff for the battery voltage lowpass filter."},
     govTTABandwidth = {t = "Cutoff for the TTA lowpass filter."},
     govTTAPrecomp = {t = "Cutoff for the cyclic/collective collective precomp lowpass filter."},
-
+    govSpoolupThrottle = {t = "Minimum throttle to use for slow spoolup, in percent. For electric motors the default is 5%, for nitro this should be set so the clutch starts to engage for a smooth spoolup 10-15%."},
     --
     -- profile_governor.lua
     --

--- a/scripts/rfsuite/app/pages/governor.lua
+++ b/scripts/rfsuite/app/pages/governor.lua
@@ -1,8 +1,24 @@
 local labels = {}
 local fields = {}
+local simulatorResponse
+local minBytes
+
+if rfsuite.config.apiVersion >= 12.08 then
+    simulatorResponse = {3, 100, 0, 100, 0, 20, 0, 20, 0, 30, 0, 10, 0, 0, 0, 0, 0, 50, 0, 10, 5, 10, 0, 10,5}
+    minBytes = 25
+else
+    simulatorResponse = {3, 100, 0, 100, 0, 20, 0, 20, 0, 30, 0, 10, 0, 0, 0, 0, 0, 50, 0, 10, 5, 10, 0, 10}
+    minBytes = 24
+end
+
 
 fields[#fields + 1] = {t = "Mode", min = 0, max = 4, vals = {1}, table = {[0] = "OFF", "PASSTHROUGH", "STANDARD", "MODE1", "MODE2"}}
 fields[#fields + 1] = {t = "Handover throttle%", help = "govHandoverThrottle", min = 10, max = 50, unit = "%", default = 20, vals = {20}}
+
+if rfsuite.config.apiVersion >= 12.08 then
+    fields[#fields + 1] = {t = "Min  spoolup throttle", help = "govSpoolupThrottle", min = 0, max = 50, unit = "%", default = 0, vals = {25}}
+end
+
 fields[#fields + 1] = {t = "Startup time", help = "govStartupTime", min = 0, max = 600, unit = "s", default = 200, vals = {2, 3}, decimals = 1, scale = 10}
 fields[#fields + 1] = {t = "Spoolup time", help = "govSpoolupTime", min = 0, max = 600, unit = "s", default = 100, vals = {4, 5}, decimals = 1, scale = 10}
 fields[#fields + 1] = {t = "Tracking time", help = "govTrackingTime", min = 0, max = 100, unit = "s", default = 10, vals = {6, 7}, decimals = 1, scale = 10}
@@ -24,18 +40,21 @@ fields[#fields + 1] = {t = "Volt. filter cutoff", help = "govVoltageFilterHz", m
 fields[#fields + 1] = {t = "TTA bandwidth", help = "govTTABandwidth", min = 0, max = 250, unit = "Hz", default = 0, vals = {23}}
 fields[#fields + 1] = {t = "Precomp bandwidth", help = "govTTAPrecomp", min = 0, max = 250, unit = "Hz", default = 10, vals = {24}}
 
+
+
 local function postLoad(self)
     rfsuite.app.triggers.isReady = true
 end
+
 
 return {
     read = 142, -- msp_GOVERNOR_CONFIG
     write = 143, -- msp_SET_GOVERNOR_CONFIG
     title = "Governor",
     reboot = true,
-    simulatorResponse = {3, 100, 0, 100, 0, 20, 0, 20, 0, 30, 0, 10, 0, 0, 0, 0, 0, 50, 0, 10, 5, 10, 0, 10},
+    simulatorResponse = simulatorResponse,  -- variable based on version code above
     eepromWrite = true,
-    minBytes = 24,
+    minBytes = minBytes, -- variable based on version code above
     labels = labels,
     fields = fields,
     postLoad = postLoad

--- a/scripts/rfsuite/app/pages/governor.lua
+++ b/scripts/rfsuite/app/pages/governor.lua
@@ -16,7 +16,7 @@ fields[#fields + 1] = {t = "Mode", min = 0, max = 4, vals = {1}, table = {[0] = 
 fields[#fields + 1] = {t = "Handover throttle%", help = "govHandoverThrottle", min = 10, max = 50, unit = "%", default = 20, vals = {20}}
 
 if rfsuite.config.apiVersion >= 12.08 then
-    fields[#fields + 1] = {t = "Min  spoolup throttle", help = "govSpoolupThrottle", min = 0, max = 50, unit = "%", default = 0, vals = {25}}
+    fields[#fields + 1] = {t = "Min  spoolup throttle%", help = "govSpoolupThrottle", min = 0, max = 50, unit = "%", default = 0, vals = {25}}
 end
 
 fields[#fields + 1] = {t = "Startup time", help = "govStartupTime", min = 0, max = 600, unit = "s", default = 200, vals = {2, 3}, decimals = 1, scale = 10}

--- a/scripts/rfsuite/main.lua
+++ b/scripts/rfsuite/main.lua
@@ -30,7 +30,8 @@ config.Version = "1.0.0"                                            -- version n
 config.ethosVersion = 1518                                          -- min version of ethos supported by this script
 config.ethosVersionString = "ETHOS < V1.5.18"                       -- string to print if ethos version error occurs
 config.defaultRateProfile = 4 -- ACTUAL                             -- default rate table [default = 4]
-config.supportedMspApiVersion = {"12.06", "12.07"}                  -- supported msp versions
+config.supportedMspApiVersion = {"12.06", "12.07","12.08"}          -- supported msp versions
+config.simulatorApiVersionResponse = {0, 12, 8}                     -- version of api return by simulator
 config.watchdogParam = 10                                           -- watchdog timeout for progress boxes [default = 10]
 
 -- features

--- a/scripts/rfsuite/tasks/msp/msp.lua
+++ b/scripts/rfsuite/tasks/msp/msp.lua
@@ -77,7 +77,7 @@ function msp.onConnectBgChecks()
                         rfsuite.utils.log("MSP Version: " .. rfsuite.config.apiVersion)
                     end
                 end,
-                simulatorResponse = {0, 12, 7}
+                simulatorResponse = rfsuite.config.simulatorApiVersionResponse
             }
             msp.mspQueue:add(message)
         elseif rfsuite.config.clockSet == nil and msp.mspQueue:isProcessed() then


### PR DESCRIPTION
This PR does three things.

1.  bumps the supported msp version in rfsuite to 12.08
2.  makes simulator version response configurable for testing this all works
3. makes governor page show/hide the governor min throttle based on msp version.