### PR TITLE
RF2.1.X Cleanup vars on exit

### DIFF
--- a/scripts/rfsuite/app/app.lua
+++ b/scripts/rfsuite/app/app.lua
@@ -190,6 +190,12 @@ function app.resetState()
     app.audio = {}
     app.triggers.wasConnected = false
     app.triggers.invalidConnectionSetup = false
+    rfsuite.app.triggers.profileswitchLast = nil
+    rfsuite.config.activeProfileLast = nil
+    rfsuite.config.activeProfile = nil
+    rfsuite.config.activeRateProfile = nil
+    rfsuite.config.activeRateProfileLast = nil
+    rfsuite.config.activeProfile = nil    
 
 end
 


### PR DESCRIPTION
A few variables that where not being flushed on exit.

In some edge cases this could cause the profile switching display to not render correctly (after plugging in usb port and switching to suite mode when inside the suite)