### PR TITLE
RF2.2.X Load an run tasks via scheduler system

### DIFF
--- a/scripts/rfsuite/main.lua
+++ b/scripts/rfsuite/main.lua
@@ -42,8 +42,8 @@ config.mspTxRxDebug = false                                         -- simple pr
 config.flightLog = true                                             -- will write a flight log into /scripts/rfsuite/logs/<modelname>/*.log
 config.reloadOnSave = false                                         -- trigger a reload on save [default = false]
 config.skipRssiSensorCheck = false                                  -- skip checking for a valid rssi [ default = false]
-config.enternalElrsSensors = true                                   -- disable the integrated elrs telemetry processing [default = true]
-config.internalSportSensors = true                                  -- disable the integrated smart port telemetry processing [default = true]
+config.enableElrsSensors = true                                     -- disable the integrated elrs telemetry processing [default = true]
+config.enableSportSensors = true                                    -- disable the integrated smart port telemetry processing [default = true]
 config.adjFunctionAlerts = false                                    -- do not alert on adjfunction telemetry.  [default = false]
 config.adjValueAlerts = true                                        -- play adjvalue alerts if sensor changes [default = true]  
 config.saveWhenArmedWarning = true                                  -- do not display the save when armed warning. [default = true]

--- a/scripts/rfsuite/tasks/adjfunctions/init.lua
+++ b/scripts/rfsuite/tasks/adjfunctions/init.lua
@@ -18,24 +18,11 @@
  * 
 
 ]]--
---
-local arg = {...}
-local config = arg[1]
 
-local sensors = {}
+local init = {
+    interval = 0.5,                 --run every 0.5s
+    script = "adjfunctions.lua",    --run this script
+    msp = false                     --do not run if busy with msp
+}
 
-sensors.elrs = assert(loadfile("tasks/sensors/elrs.lua"))(config)
-sensors.frsky = assert(loadfile("tasks/sensors/frsky.lua"))(config)
-
-function sensors.wakeup()
-
-    -- we cant do anything if bg task not running
-    if not rfsuite.bg.active() then return end
-    
-    if rfsuite.bg.msp.protocol.mspProtocol == "crsf" and config.enableElrsSensors == true then sensors.elrs.wakeup() end
-
-    if rfsuite.bg.msp.protocol.mspProtocol == "smartPort" and config.enableSportSensors == true then sensors.frsky.wakeup() end
-
-end
-
-return sensors
+return init

--- a/scripts/rfsuite/tasks/bg.lua
+++ b/scripts/rfsuite/tasks/bg.lua
@@ -170,7 +170,8 @@ function bg.wakeup()
                     if not rfsuite.app.triggers.mspBusy then
                         bg[task.name].wakeup()
                     end                
-                end     
+                end   
+                task.last_run = now
             end
          end
     end

--- a/scripts/rfsuite/tasks/logging/init.lua
+++ b/scripts/rfsuite/tasks/logging/init.lua
@@ -18,24 +18,11 @@
  * 
 
 ]]--
---
-local arg = {...}
-local config = arg[1]
 
-local sensors = {}
+local init = {
+    interval = 0.5,         --run every 0.5s
+    script = "logging.lua", --run this script
+    msp = false             --do not run if busy with msp 
+}
 
-sensors.elrs = assert(loadfile("tasks/sensors/elrs.lua"))(config)
-sensors.frsky = assert(loadfile("tasks/sensors/frsky.lua"))(config)
-
-function sensors.wakeup()
-
-    -- we cant do anything if bg task not running
-    if not rfsuite.bg.active() then return end
-    
-    if rfsuite.bg.msp.protocol.mspProtocol == "crsf" and config.enableElrsSensors == true then sensors.elrs.wakeup() end
-
-    if rfsuite.bg.msp.protocol.mspProtocol == "smartPort" and config.enableSportSensors == true then sensors.frsky.wakeup() end
-
-end
-
-return sensors
+return init

--- a/scripts/rfsuite/tasks/msp/init.lua
+++ b/scripts/rfsuite/tasks/msp/init.lua
@@ -18,24 +18,11 @@
  * 
 
 ]]--
---
-local arg = {...}
-local config = arg[1]
 
-local sensors = {}
+local init = {
+    interval = 0.000001,   --run as often as possible
+    script = "msp.lua",    --run this script
+    msp = true             --do not run if busy with msp [as this is msp we set to true as must run]
+}
 
-sensors.elrs = assert(loadfile("tasks/sensors/elrs.lua"))(config)
-sensors.frsky = assert(loadfile("tasks/sensors/frsky.lua"))(config)
-
-function sensors.wakeup()
-
-    -- we cant do anything if bg task not running
-    if not rfsuite.bg.active() then return end
-    
-    if rfsuite.bg.msp.protocol.mspProtocol == "crsf" and config.enableElrsSensors == true then sensors.elrs.wakeup() end
-
-    if rfsuite.bg.msp.protocol.mspProtocol == "smartPort" and config.enableSportSensors == true then sensors.frsky.wakeup() end
-
-end
-
-return sensors
+return init

--- a/scripts/rfsuite/tasks/sensors/elrs.lua
+++ b/scripts/rfsuite/tasks/sensors/elrs.lua
@@ -447,7 +447,6 @@ function elrs.crossfirePop()
 end
 
 function elrs.wakeup()
-
     if rfsuite.bg.telemetry.active() and rfsuite.rssiSensor then while elrs.crossfirePop() do if (CRSF_PAUSE_TELEMETRY == true or rfsuite.app.triggers.mspBusy == true) then break end end end
 end
 

--- a/scripts/rfsuite/tasks/sensors/init.lua
+++ b/scripts/rfsuite/tasks/sensors/init.lua
@@ -18,24 +18,11 @@
  * 
 
 ]]--
---
-local arg = {...}
-local config = arg[1]
 
-local sensors = {}
+local init = {
+    interval = 0.005,         --run every 0.005s
+    script = "sensors.lua",   --run this script
+    msp = false               --do not run if busy with msp 
+}
 
-sensors.elrs = assert(loadfile("tasks/sensors/elrs.lua"))(config)
-sensors.frsky = assert(loadfile("tasks/sensors/frsky.lua"))(config)
-
-function sensors.wakeup()
-
-    -- we cant do anything if bg task not running
-    if not rfsuite.bg.active() then return end
-    
-    if rfsuite.bg.msp.protocol.mspProtocol == "crsf" and config.enableElrsSensors == true then sensors.elrs.wakeup() end
-
-    if rfsuite.bg.msp.protocol.mspProtocol == "smartPort" and config.enableSportSensors == true then sensors.frsky.wakeup() end
-
-end
-
-return sensors
+return init

--- a/scripts/rfsuite/tasks/telemetry/init.lua
+++ b/scripts/rfsuite/tasks/telemetry/init.lua
@@ -18,24 +18,11 @@
  * 
 
 ]]--
---
-local arg = {...}
-local config = arg[1]
 
-local sensors = {}
+local init = {
+    interval = 0.5,             --run every 0.5s
+    script = "telemetry.lua",   --run this script
+    msp = false                 --do not run if busy with msp 
+}
 
-sensors.elrs = assert(loadfile("tasks/sensors/elrs.lua"))(config)
-sensors.frsky = assert(loadfile("tasks/sensors/frsky.lua"))(config)
-
-function sensors.wakeup()
-
-    -- we cant do anything if bg task not running
-    if not rfsuite.bg.active() then return end
-    
-    if rfsuite.bg.msp.protocol.mspProtocol == "crsf" and config.enableElrsSensors == true then sensors.elrs.wakeup() end
-
-    if rfsuite.bg.msp.protocol.mspProtocol == "smartPort" and config.enableSportSensors == true then sensors.frsky.wakeup() end
-
-end
-
-return sensors
+return init


### PR DESCRIPTION
This code change makes the loading of tasks a bit more 'dynamic'.

rfsuite/tasks/<taskname>/init.lua contains info similar to this

local init = {
    interval = 0.5,                   --run every 0.5s
    script = "telemetry.lua",   --run this script
    msp = false                      --do not run if busy with msp 
}
return init


This means in future if we add a new task to run in the background; we dont need to edit the main scripts as the new task just loads in using the schedular info provided.


