### PR TITLE
RF2.2.X RF Suite Govenor Updates

### DIFF
--- a/scripts/rfsuite/app/pages/profile_governor.lua
+++ b/scripts/rfsuite/app/pages/profile_governor.lua
@@ -7,12 +7,7 @@ local governorDisabledMsg = false
 
 if rfsuite.config.governorMode == 1 then
 
-    -- passthru mode is only possible to set max and min
-
-    if tonumber(rfsuite.config.apiVersion) >= 12.07 then
-        fields[#fields + 1] = {t = "Min throttle", help = "govMinThrottle", min = 0, max = 100, default = 10, unit = "%", vals = {14}}
-    end
-
+    -- passthru mode is only possible to set max
     fields[#fields + 1] = {t = "Max throttle", help = "govMaxThrottle", min = 40, max = 100, default = 100, unit = "%", vals = {13}}
 
 elseif rfsuite.config.governorMode >= 2 then

--- a/scripts/rfsuite/tasks/msp/msp.lua
+++ b/scripts/rfsuite/tasks/msp/msp.lua
@@ -182,8 +182,10 @@ function msp.onConnectBgChecks()
                     if #buf >= 2 then  --24.  but we only need first
                         local governorMode = msp.mspHelper.readU8(buf)
                         -- update master one in case changed
-                        rfsuite.utils.log("Governor mode: " .. governorMode)
-                        rfsuite.config.governorMode = governorMode
+                        if governorMode ~= nil then
+                            rfsuite.utils.log("Governor mode: " .. governorMode)
+                            rfsuite.config.governorMode = governorMode
+                        end    
                     end
                 end,
                 simulatorResponse = {3, 100, 0, 100, 0, 20, 0, 20, 0, 30, 0, 10, 0, 0, 0, 0, 0, 50, 0, 10, 5, 10, 0, 10}


### PR DESCRIPTION
Small fix to add a check for governor mode to prevent the initial query accidently returning a nil value due to not test for it!
removes min throttle when in passthru mode as not a valid field