### PR TITLE
RF2.2.X - Log Tool Layout Error

### DIFF
--- a/scripts/rfsuite/app/pages/logs_tool.lua
+++ b/scripts/rfsuite/app/pages/logs_tool.lua
@@ -1,12 +1,17 @@
 -- display vars
 local LCD_W, LCD_H = rfsuite.utils.getWindowSize()
 
+local res = system.getVersion()
+local RES_W = res.lcdWidth 
+local RES_H = res.lcdHeight
+
+
 local graphPos = {}
 graphPos['menu_offset'] = rfsuite.app.radio.logGraphMenuOffset
 graphPos['x_start'] = 0
 graphPos['y_start'] = 0 + graphPos['menu_offset']
 graphPos['width'] = math.floor(LCD_W * rfsuite.app.radio.logGraphWidthPercentage)
-graphPos['height'] = LCD_H - graphPos['menu_offset'] - 50
+graphPos['height'] = RES_H - graphPos['menu_offset'] - 125
 
 local triggerOverRide = false
 local triggerOverRideAll = false
@@ -413,7 +418,7 @@ local function drawCurrentIndex(points, position, totalPoints, keyindex, keyunit
 
     -- draw the vertical line
     lcd.color(COLOR_WHITE)
-    lcd.drawLine(linePos, graphPos['menu_offset'] - 5, linePos, LCD_H - 45)
+    lcd.drawLine(linePos, graphPos['menu_offset'] - 5, linePos, RES_H - 125)
 
     -- show value
     lcd.font(FONT_BOLD)
@@ -425,7 +430,7 @@ local function drawCurrentIndex(points, position, totalPoints, keyindex, keyunit
 
     -- display time
     local tw, th = lcd.getTextSize(time_str)
-    local ty = (LCD_H - 70)
+    local ty = (RES_H - 70)
     if linePos >= tw / 4 then lcd.drawText(idxPos, ty, time_str, textAlign) end
 
 end
@@ -571,7 +576,7 @@ local function wakeup()
         if currentDataIndex >= #logColumns then
 
             -- put slider at bottom of form
-            local posField = {x = graphPos['x_start'], y = LCD_H - 40, w = graphPos['width'] - 10, h = 40}
+            local posField = {x = graphPos['x_start'], y = RES_H - 115, w = graphPos['width'] - 10, h = 40}
             rfsuite.app.formFields[1] = form.addSliderField(nil, posField, 0, 100, function()
                 return sliderPosition
             end, function(newValue)

--- a/scripts/rfsuite/app/pages/logs_tool.lua
+++ b/scripts/rfsuite/app/pages/logs_tool.lua
@@ -1,17 +1,16 @@
 -- display vars
-local LCD_W, LCD_H = rfsuite.utils.getWindowSize()
-
 local res = system.getVersion()
-local RES_W = res.lcdWidth 
-local RES_H = res.lcdHeight
-
+local LCD_W = res.lcdWidth 
+local LCD_H = res.lcdHeight
 
 local graphPos = {}
 graphPos['menu_offset'] = rfsuite.app.radio.logGraphMenuOffset
+graphPos['height_offset'] = rfsuite.app.radio.logGraphHeightOffset or 0
 graphPos['x_start'] = 0
 graphPos['y_start'] = 0 + graphPos['menu_offset']
 graphPos['width'] = math.floor(LCD_W * rfsuite.app.radio.logGraphWidthPercentage)
-graphPos['height'] = RES_H - graphPos['menu_offset'] - 125
+graphPos['height'] = LCD_H - graphPos['menu_offset'] - graphPos['menu_offset'] - 40 + graphPos['height_offset']
+graphPos['slider_y'] = LCD_H - (graphPos['menu_offset'] + 30 ) + graphPos['height_offset']
 
 local triggerOverRide = false
 local triggerOverRideAll = false
@@ -418,7 +417,7 @@ local function drawCurrentIndex(points, position, totalPoints, keyindex, keyunit
 
     -- draw the vertical line
     lcd.color(COLOR_WHITE)
-    lcd.drawLine(linePos, graphPos['menu_offset'] - 5, linePos, RES_H - 125)
+    lcd.drawLine(linePos, graphPos['menu_offset'] - 5, linePos, graphPos['height'] + graphPos['menu_offset'])
 
     -- show value
     lcd.font(FONT_BOLD)
@@ -430,7 +429,7 @@ local function drawCurrentIndex(points, position, totalPoints, keyindex, keyunit
 
     -- display time
     local tw, th = lcd.getTextSize(time_str)
-    local ty = (RES_H - 70)
+    local ty = (LCD_H - 70)
     if linePos >= tw / 4 then lcd.drawText(idxPos, ty, time_str, textAlign) end
 
 end
@@ -576,7 +575,7 @@ local function wakeup()
         if currentDataIndex >= #logColumns then
 
             -- put slider at bottom of form
-            local posField = {x = graphPos['x_start'], y = RES_H - 115, w = graphPos['width'] - 10, h = 40}
+            local posField = {x = graphPos['x_start'], y = graphPos['slider_y'] , w = graphPos['width'] - 10, h = 40}
             rfsuite.app.formFields[1] = form.addSliderField(nil, posField, 0, 100, function()
                 return sliderPosition
             end, function(newValue)

--- a/scripts/rfsuite/app/radios.lua
+++ b/scripts/rfsuite/app/radios.lua
@@ -24,6 +24,7 @@ local supportedRadios = {
             logGraphWidthPercentage = 0.75,
             logGraphButtonsPerRow = 5,
             logGraphKeyHeight = 65,
+            logGraphHeightOffset = -15,
             logKeyFont = FONT_S
         }
     },
@@ -50,6 +51,7 @@ local supportedRadios = {
             logGraphWidthPercentage = 0.62,
             logGraphButtonsPerRow = 4,
             logGraphKeyHeight = 45,
+            logGraphHeightOffset = 10,            
             logKeyFont = FONT_XS
         }
     },
@@ -75,6 +77,7 @@ local supportedRadios = {
             logGraphWidthPercentage = 0.65,
             logGraphButtonsPerRow = 4,
             logGraphKeyHeight = 38,
+            logGraphHeightOffset = 0,            
             logKeyFont = FONT_XS
         }
     },
@@ -101,6 +104,7 @@ local supportedRadios = {
             logGraphWidthPercentage = 0.65,
             logGraphButtonsPerRow = 4,
             logGraphKeyHeight = 50,
+            logGraphHeightOffset = 0,            
             logKeyFont = FONT_XS
         }
     }


### PR DESCRIPTION
Fix error caused by screen resolution being skewed as a result of a large number of logs being created.