### PR TITLE
RF2.2.X Max negative number in ethos - custom sensor creation

### DIFF
--- a/scripts/rfsuite/tasks/sensors/elrs.lua
+++ b/scripts/rfsuite/tasks/sensors/elrs.lua
@@ -57,7 +57,7 @@ local function createTelemetrySensor(uid, name, unit, dec, value, min, max)
     sensors['uid'][uid]:name(name)
     sensors['uid'][uid]:appId(uid)
     sensors['uid'][uid]:module(1)
-    sensors['uid'][uid]:minimum(min or -2147483647)
+    sensors['uid'][uid]:minimum(min or -1000000000)
     sensors['uid'][uid]:maximum(max or 2147483647)
     if dec then
         sensors['uid'][uid]:decimals(dec)


### PR DESCRIPTION
Ethos does not allow a custom sensor lower than -1000000000

This change adjusts our code to fix that.