### PR TITLE
Speedup init connect by using UUID

### DIFF
--- a/scripts/rfsuite/tasks/bg.lua
+++ b/scripts/rfsuite/tasks/bg.lua
@@ -168,6 +168,8 @@ function bg.wakeup()
         end
     end
 
+    bg.flush_logs()
+
 end
 
 function bg.event(widget, category, value)

--- a/scripts/rfsuite/tasks/msp/api/ACC_TRIM.lua
+++ b/scripts/rfsuite/tasks/msp/api/ACC_TRIM.lua
@@ -137,4 +137,17 @@ local function setTimeout(timeout)
 end
 
 -- Return the module's API functions
-return {read = read, write = write, readComplete = readComplete, writeComplete = writeComplete, readValue = readValue, setValue = setValue, resetWriteStatus = resetWriteStatus, setCompleteHandler = handlers.setCompleteHandler, setErrorHandler = handlers.setErrorHandler, data = data}
+return {
+    read = read,
+    write = write,
+    readComplete = readComplete,
+    writeComplete = writeComplete,
+    readValue = readValue,
+    setValue = setValue,
+    resetWriteStatus = resetWriteStatus,
+    setCompleteHandler = handlers.setCompleteHandler,
+    setErrorHandler = handlers.setErrorHandler,
+    setUUID = setUUID,
+    setTimeout = setTimeout,
+    data = data
+}

--- a/scripts/rfsuite/tasks/msp/api/API_VERSION.lua
+++ b/scripts/rfsuite/tasks/msp/api/API_VERSION.lua
@@ -105,4 +105,16 @@ local function setTimeout(timeout)
 end
 
 -- Return the module's API functions
-return {data = data, read = read, write = write, readComplete = readComplete, writeComplete = writeComplete, readVersion = readVersion, readValue = readValue, readComplete, setCompleteHandler = handlers.setCompleteHandler, setErrorHandler = handlers.setErrorHandler}
+return {
+    data = data,
+    read = read,
+    write = write,
+    readComplete = readComplete,
+    writeComplete = writeComplete,
+    readVersion = readVersion,
+    readValue = readValue,
+    setCompleteHandler = handlers.setCompleteHandler,
+    setErrorHandler = handlers.setErrorHandler,
+    setUUID = setUUID,
+    setTimeout = setTimeout,
+}

--- a/scripts/rfsuite/tasks/msp/api/BATTERY_CONFIG.lua
+++ b/scripts/rfsuite/tasks/msp/api/BATTERY_CONFIG.lua
@@ -21,8 +21,18 @@ local MSP_API_SIMULATOR_RESPONSE = {138, 2, 3, 1, 1, 74, 1, 174, 1, 154, 1, 94, 
 local MSP_MIN_BYTES = 15
 
 -- Define the MSP response data structures
-local MSP_API_STRUCTURE_READ = {{field = "batteryCapacity", type = "U16"}, {field = "batteryCellCount", type = "U8"}, {field = "voltageMeterSource", type = "U8"}, {field = "currentMeterSource", type = "U8"}, {field = "vbatmincellvoltage", type = "U16"}, {field = "vbatmaxcellvoltage", type = "U16"}, {field = "vbatfullcellvoltage", type = "U16"}, {field = "vbatwarningcellvoltage", type = "U16"},
-                                {field = "lvcPercentage", type = "U8"}, {field = "consumptionWarningPercentage", type = "U8"}}
+local MSP_API_STRUCTURE_READ = {
+    {field = "batteryCapacity", type = "U16"},
+    {field = "batteryCellCount", type = "U8"},
+    {field = "voltageMeterSource", type = "U8"},
+    {field = "currentMeterSource", type = "U8"},
+    {field = "vbatmincellvoltage", type = "U16"},
+    {field = "vbatmaxcellvoltage", type = "U16"},
+    {field = "vbatfullcellvoltage", type = "U16"},
+    {field = "vbatwarningcellvoltage", type = "U16"},
+    {field = "lvcPercentage", type = "U8"},
+    {field = "consumptionWarningPercentage", type = "U8"}
+}
 
 local MSP_API_STRUCTURE_WRITE = MSP_API_STRUCTURE_READ -- Assuming identical structure for now
 
@@ -139,4 +149,17 @@ local function setTimeout(timeout)
 end
 
 -- Return the module's API functions
-return {read = read, write = write, readComplete = readComplete, writeComplete = writeComplete, readValue = readValue, setValue = setValue, resetWriteStatus = resetWriteStatus, setCompleteHandler = handlers.setCompleteHandler, setErrorHandler = handlers.setErrorHandler, data = data}
+return {
+    read = read,
+    write = write,
+    readComplete = readComplete,
+    writeComplete = writeComplete,
+    readValue = readValue,
+    setValue = setValue,
+    resetWriteStatus = resetWriteStatus,
+    setCompleteHandler = handlers.setCompleteHandler,
+    setErrorHandler = handlers.setErrorHandler,
+    data = data,
+    setUUID = setUUID,
+    setTimeout = setTimeout,
+}

--- a/scripts/rfsuite/tasks/msp/api/EEPROM_WRITE.lua
+++ b/scripts/rfsuite/tasks/msp/api/EEPROM_WRITE.lua
@@ -137,4 +137,17 @@ local function setTimeout(timeout)
 end
 
 -- Return the module's API functions
-return {read = read, write = write, readComplete = readComplete, writeComplete = writeComplete, readValue = readValue, setValue = setValue, resetWriteStatus = resetWriteStatus, setCompleteHandler = handlers.setCompleteHandler, setErrorHandler = handlers.setErrorHandler, data = data}
+return {
+    read = read,
+    write = write,
+    readComplete = readComplete,
+    writeComplete = writeComplete,
+    readValue = readValue,
+    setValue = setValue,
+    resetWriteStatus = resetWriteStatus,
+    setCompleteHandler = handlers.setCompleteHandler,
+    setErrorHandler = handlers.setErrorHandler,
+    data = data,
+    setUUID = setUUID,
+    setTimeout = setTimeout,
+}

--- a/scripts/rfsuite/tasks/msp/api/FILTER_CONFIG.lua
+++ b/scripts/rfsuite/tasks/msp/api/FILTER_CONFIG.lua
@@ -150,4 +150,4 @@ local function setTimeout(timeout)
 end
 
 -- Return the module's API functions
-return {read = read, write = write, readComplete = readComplete, writeComplete = writeComplete, readValue = readValue, setValue = setValue, resetWriteStatus = resetWriteStatus, setCompleteHandler = handlers.setCompleteHandler, setErrorHandler = handlers.setErrorHandler, data = data}
+return {read = read, write = write, readComplete = readComplete, writeComplete = writeComplete, readValue = readValue, setValue = setValue, resetWriteStatus = resetWriteStatus, setCompleteHandler = handlers.setCompleteHandler, setErrorHandler = handlers.setErrorHandler, data = data, setUUID = setUUID, setTimeout = setTimeout}

--- a/scripts/rfsuite/tasks/msp/api/GOVERNOR_CONFIG.lua
+++ b/scripts/rfsuite/tasks/msp/api/GOVERNOR_CONFIG.lua
@@ -180,4 +180,4 @@ local function setTimeout(timeout)
 end
 
 -- Return the module's API functions
-return {read = read, write = write, readComplete = readComplete, writeComplete = writeComplete, readValue = readValue, setValue = setValue, resetWriteStatus = resetWriteStatus, setCompleteHandler = handlers.setCompleteHandler, setErrorHandler = handlers.setErrorHandler, data = data}
+return {read = read, write = write, readComplete = readComplete, writeComplete = writeComplete, readValue = readValue, setValue = setValue, resetWriteStatus = resetWriteStatus, setCompleteHandler = handlers.setCompleteHandler, setErrorHandler = handlers.setErrorHandler, data = data, setUUID = setUUID, setTimeout = setTimeout}

--- a/scripts/rfsuite/tasks/msp/api/GOVERNOR_PROFILE.lua
+++ b/scripts/rfsuite/tasks/msp/api/GOVERNOR_PROFILE.lua
@@ -138,4 +138,4 @@ local function setTimeout(timeout)
 end
 
 -- Return the module's API functions
-return {read = read, write = write, readComplete = readComplete, writeComplete = writeComplete, readValue = readValue, setValue = setValue, resetWriteStatus = resetWriteStatus, setCompleteHandler = handlers.setCompleteHandler, setErrorHandler = handlers.setErrorHandler, data = data}
+return {read = read, write = write, readComplete = readComplete, writeComplete = writeComplete, readValue = readValue, setValue = setValue, resetWriteStatus = resetWriteStatus, setCompleteHandler = handlers.setCompleteHandler, setErrorHandler = handlers.setErrorHandler, data = data, setUUID = setUUID, setTimeout = setTimeout}

--- a/scripts/rfsuite/tasks/msp/api/MIXER_CONFIG.lua
+++ b/scripts/rfsuite/tasks/msp/api/MIXER_CONFIG.lua
@@ -35,6 +35,23 @@ local defaultData = {}
 -- Create a new instance
 local handlers = rfsuite.bg.msp.api.createHandlers()
 
+-- Add setCompleteHandler and setErrorHandler methods to handlers
+function handlers.setCompleteHandler(handler)
+    handlers.completeHandler = handler
+end
+
+function handlers.setErrorHandler(handler)
+    handlers.errorHandler = handler
+end
+
+function handlers.getCompleteHandler()
+    return handlers.completeHandler
+end
+
+function handlers.getErrorHandler()
+    return handlers.errorHandler
+end
+
 -- Variables to store optional the UUID and timeout for payload
 local MSP_API_UUID
 local MSP_API_MSG_TIMEOUT
@@ -139,4 +156,17 @@ local function setTimeout(timeout)
 end
 
 -- Return the module's API functions
-return {read = read, write = write, readComplete = readComplete, writeComplete = writeComplete, readValue = readValue, setValue = setValue, resetWriteStatus = resetWriteStatus, setCompleteHandler = handlers.setCompleteHandler, setErrorHandler = handlers.setErrorHandler, data = data}
+return {
+    read = read,
+    write = write,
+    readComplete = readComplete,
+    writeComplete = writeComplete,
+    readValue = readValue,
+    setValue = setValue,
+    resetWriteStatus = resetWriteStatus,
+    setCompleteHandler = handlers.setCompleteHandler,
+    setErrorHandler = handlers.setErrorHandler,
+    data = data,
+    setUUID = setUUID,
+    setTimeout = setTimeout,
+}

--- a/scripts/rfsuite/tasks/msp/api/MOTOR_CONFIG.lua
+++ b/scripts/rfsuite/tasks/msp/api/MOTOR_CONFIG.lua
@@ -205,4 +205,4 @@ local function setTimeout(timeout)
 end
 
 -- Return the module's API functions
-return {read = read, write = write, readComplete = readComplete, writeComplete = writeComplete, readValue = readValue, setValue = setValue, resetWriteStatus = resetWriteStatus, setCompleteHandler = handlers.setCompleteHandler, setErrorHandler = handlers.setErrorHandler, data = data}
+return {read = read, write = write, readComplete = readComplete, writeComplete = writeComplete, readValue = readValue, setValue = setValue, resetWriteStatus = resetWriteStatus, setCompleteHandler = handlers.setCompleteHandler, setErrorHandler = handlers.setErrorHandler, data = data, setUUID = setUUID, setTimeout = setTimeout}

--- a/scripts/rfsuite/tasks/msp/api/NAME.lua
+++ b/scripts/rfsuite/tasks/msp/api/NAME.lua
@@ -70,7 +70,7 @@ local function read()
         command = MSP_API_CMD_READ, -- Specify the MSP command
         processReply = function(self, buf)
             -- Parse the MSP data using the defined structure
-            mspData = parseMSPData(buf, MSP_API_STRUCTURE)
+            mspData = parseMSPData(buf, MSP_API_STRUCTURE_READ)
             if #buf >= MSP_MIN_BYTES then
                 local completeHandler = handlers.getCompleteHandler()
                 if completeHandler then completeHandler(self, buf) end
@@ -161,4 +161,17 @@ local function setTimeout(timeout)
 end
 
 -- Return the module's API functions
-return {read = read, write = write, readComplete = readComplete, writeComplete = writeComplete, readValue = readValue, setValue = setValue, resetWriteStatus = resetWriteStatus, setCompleteHandler = handlers.setCompleteHandler, setErrorHandler = handlers.setErrorHandler, data = data}
+return {
+    read = read,
+    write = write,
+    readComplete = readComplete,
+    writeComplete = writeComplete,
+    readValue = readValue,
+    setValue = setValue,
+    resetWriteStatus = resetWriteStatus,
+    setCompleteHandler = handlers.setCompleteHandler,
+    setErrorHandler = handlers.setErrorHandler,
+    data = data,
+    setUUID = setUUID,
+    setTimeout = setTimeout,    
+}

--- a/scripts/rfsuite/tasks/msp/api/PID_PROFILE.lua
+++ b/scripts/rfsuite/tasks/msp/api/PID_PROFILE.lua
@@ -38,6 +38,23 @@ local defaultData = {}
 -- Create a new instance
 local handlers = rfsuite.bg.msp.api.createHandlers()
 
+-- Add missing methods to handlers
+function handlers.setCompleteHandler(handler)
+    handlers.completeHandler = handler
+end
+
+function handlers.setErrorHandler(handler)
+    handlers.errorHandler = handler
+end
+
+function handlers.getCompleteHandler()
+    return handlers.completeHandler
+end
+
+function handlers.getErrorHandler()
+    return handlers.errorHandler
+end
+
 -- Variables to store optional the UUID and timeout for payload
 local MSP_API_UUID
 local MSP_API_MSG_TIMEOUT
@@ -142,4 +159,17 @@ local function setTimeout(timeout)
 end
 
 -- Return the module's API functions
-return {read = read, write = write, readComplete = readComplete, writeComplete = writeComplete, readValue = readValue, setValue = setValue, resetWriteStatus = resetWriteStatus, setCompleteHandler = handlers.setCompleteHandler, setErrorHandler = handlers.setErrorHandler, data = data}
+return {
+    read = read,
+    write = write,
+    readComplete = readComplete,
+    writeComplete = writeComplete,
+    readValue = readValue,
+    setValue = setValue,
+    resetWriteStatus = resetWriteStatus,
+    setCompleteHandler = handlers.setCompleteHandler,
+    setErrorHandler = handlers.setErrorHandler,
+    data = data,
+    setUUID = setUUID,
+    setTimeout = setTimeout,
+}

--- a/scripts/rfsuite/tasks/msp/api/PID_TUNING.lua
+++ b/scripts/rfsuite/tasks/msp/api/PID_TUNING.lua
@@ -156,4 +156,17 @@ local function setTimeout(timeout)
 end
 
 -- Return the module's API functions
-return {read = read, write = write, readComplete = readComplete, writeComplete = writeComplete, readValue = readValue, setValue = setValue, resetWriteStatus = resetWriteStatus, setCompleteHandler = handlers.setCompleteHandler, setErrorHandler = handlers.setErrorHandler, data = data}
+return {
+    read = read,
+    write = write,
+    readComplete = readComplete,
+    writeComplete = writeComplete,
+    readValue = readValue,
+    setValue = setValue,
+    resetWriteStatus = resetWriteStatus,
+    setCompleteHandler = handlers.setCompleteHandler,
+    setErrorHandler = handlers.setErrorHandler,
+    data = data,
+    setUUID = setUUID,
+    setTimeout = setTimeout,
+}

--- a/scripts/rfsuite/tasks/msp/api/PILOT_CONFIG.lua
+++ b/scripts/rfsuite/tasks/msp/api/PILOT_CONFIG.lua
@@ -138,4 +138,17 @@ local function setTimeout(timeout)
 end
 
 -- Return the module's API functions
-return {read = read, write = write, readComplete = readComplete, writeComplete = writeComplete, readValue = readValue, setValue = setValue, resetWriteStatus = resetWriteStatus, setCompleteHandler = handlers.setCompleteHandler, setErrorHandler = handlers.setErrorHandler, data = data}
+return {
+    read = read,
+    write = write,
+    readComplete = readComplete,
+    writeComplete = writeComplete,
+    readValue = readValue,
+    setValue = setValue,
+    resetWriteStatus = resetWriteStatus,
+    setCompleteHandler = handlers.setCompleteHandler,
+    setErrorHandler = handlers.setErrorHandler,
+    data = data,
+    setUUID = setUUID,
+    setTimeout = setTimeout,
+}

--- a/scripts/rfsuite/tasks/msp/api/RC_CONFIG.lua
+++ b/scripts/rfsuite/tasks/msp/api/RC_CONFIG.lua
@@ -137,4 +137,17 @@ local function setTimeout(timeout)
 end
 
 -- Return the module's API functions
-return {read = read, write = write, readComplete = readComplete, writeComplete = writeComplete, readValue = readValue, setValue = setValue, resetWriteStatus = resetWriteStatus, setCompleteHandler = handlers.setCompleteHandler, setErrorHandler = handlers.setErrorHandler, data = data}
+return {
+    read = read,
+    write = write,
+    readComplete = readComplete,
+    writeComplete = writeComplete,
+    readValue = readValue,
+    setValue = setValue,
+    resetWriteStatus = resetWriteStatus,
+    setCompleteHandler = handlers.setCompleteHandler,
+    setErrorHandler = handlers.setErrorHandler,
+    data = data,
+    setUUID = setUUID,
+    setTimeout = setTimeout,
+}

--- a/scripts/rfsuite/tasks/msp/api/RC_TUNING.lua
+++ b/scripts/rfsuite/tasks/msp/api/RC_TUNING.lua
@@ -139,4 +139,17 @@ local function setTimeout(timeout)
 end
 
 -- Return the module's API functions
-return {read = read, write = write, readComplete = readComplete, writeComplete = writeComplete, readValue = readValue, setValue = setValue, resetWriteStatus = resetWriteStatus, setCompleteHandler = handlers.setCompleteHandler, setErrorHandler = handlers.setErrorHandler, data = data}
+return {
+    read = read,
+    write = write,
+    readComplete = readComplete,
+    writeComplete = writeComplete,
+    readValue = readValue,
+    setValue = setValue,
+    resetWriteStatus = resetWriteStatus,
+    setCompleteHandler = handlers.setCompleteHandler,
+    setErrorHandler = handlers.setErrorHandler,
+    data = data,
+    setUUID = setUUID,
+    setTimeout = setTimeout,
+}

--- a/scripts/rfsuite/tasks/msp/api/REBOOT.lua
+++ b/scripts/rfsuite/tasks/msp/api/REBOOT.lua
@@ -138,4 +138,17 @@ local function setTimeout(timeout)
 end
 
 -- Return the module's API functions
-return {read = read, write = write, readComplete = readComplete, writeComplete = writeComplete, readValue = readValue, setValue = setValue, resetWriteStatus = resetWriteStatus, setCompleteHandler = handlers.setCompleteHandler, setErrorHandler = handlers.setErrorHandler, data = data}
+return {
+    read = read,
+    write = write,
+    readComplete = readComplete,
+    writeComplete = writeComplete,
+    readValue = readValue,
+    setValue = setValue,
+    resetWriteStatus = resetWriteStatus,
+    setCompleteHandler = handlers.setCompleteHandler,
+    setErrorHandler = handlers.setErrorHandler,
+    data = data,
+    setUUID = setUUID,
+    setTimeout = setTimeout,
+}

--- a/scripts/rfsuite/tasks/msp/api/RESCUE_PROFILE.lua
+++ b/scripts/rfsuite/tasks/msp/api/RESCUE_PROFILE.lua
@@ -141,4 +141,17 @@ local function setTimeout(timeout)
 end
 
 -- Return the module's API functions
-return {read = read, write = write, readComplete = readComplete, writeComplete = writeComplete, readValue = readValue, setValue = setValue, resetWriteStatus = resetWriteStatus, setCompleteHandler = handlers.setCompleteHandler, setErrorHandler = handlers.setErrorHandler, data = data}
+return {
+    read = read,
+    write = write,
+    readComplete = readComplete,
+    writeComplete = writeComplete,
+    readValue = readValue,
+    setValue = setValue,
+    resetWriteStatus = resetWriteStatus,
+    setCompleteHandler = handlers.setCompleteHandler,
+    setErrorHandler = handlers.setErrorHandler,
+    data = data,
+    setUUID = setUUID,
+    setTimeout = setTimeout,
+}

--- a/scripts/rfsuite/tasks/msp/api/RTC.lua
+++ b/scripts/rfsuite/tasks/msp/api/RTC.lua
@@ -144,4 +144,17 @@ local function setTimeout(timeout)
 end
 
 -- Return the module's API functions
-return {read = read, write = write, setValue = setValue, getValue = getValue, readComplete = readComplete, writeComplete = writeComplete, resetWriteStatus = resetWriteStatus, getDefaults = getDefaults, setCompleteHandler = handlers.setCompleteHandler, setErrorHandler = handlers.setErrorHandler, data = data}
+return {
+    write = write,
+    setValue = setValue,
+    writeComplete = writeComplete,
+    resetWriteStatus = resetWriteStatus,
+    getDefaults = getDefaults,
+    setCompleteHandler = handlers.setCompleteHandler,
+    setErrorHandler = handlers.setErrorHandler,
+    data = data,
+    setUUID = setUUID,
+    setTimeout = setTimeout,
+    setUUID = setUUID,
+    setTimeout = setTimeout,
+}

--- a/scripts/rfsuite/tasks/msp/api/SBUS_OUTPUT_CONFIG.lua
+++ b/scripts/rfsuite/tasks/msp/api/SBUS_OUTPUT_CONFIG.lua
@@ -157,4 +157,17 @@ local function setTimeout(timeout)
 end
 
 -- Return the module's API functions
-return {read = read, write = write, readComplete = readComplete, writeComplete = writeComplete, readValue = readValue, setValue = setValue, resetWriteStatus = resetWriteStatus, setCompleteHandler = handlers.setCompleteHandler, setErrorHandler = handlers.setErrorHandler, data = data}
+return {
+    read = read,
+    write = write,
+    readComplete = readComplete,
+    writeComplete = writeComplete,
+    readValue = readValue,
+    setValue = setValue,
+    resetWriteStatus = resetWriteStatus,
+    setCompleteHandler = handlers.setCompleteHandler,
+    setErrorHandler = handlers.setErrorHandler,
+    data = data,
+    setUUID = setUUID,
+    setTimeout = setTimeout,
+}

--- a/scripts/rfsuite/tasks/msp/api/SERVO_CONFIGURATIONS.lua
+++ b/scripts/rfsuite/tasks/msp/api/SERVO_CONFIGURATIONS.lua
@@ -187,4 +187,17 @@ local function setTimeout(timeout)
 end
 
 -- Return the module's API functions
-return {read = read, write = write, readComplete = readComplete, writeComplete = writeComplete, readValue = readValue, setValue = setValue, resetWriteStatus = resetWriteStatus, setCompleteHandler = handlers.setCompleteHandler, setErrorHandler = handlers.setErrorHandler, data = data}
+return {
+    read = read,
+    write = write,
+    readComplete = readComplete,
+    writeComplete = writeComplete,
+    readValue = readValue,
+    setValue = setValue,
+    resetWriteStatus = resetWriteStatus,
+    setCompleteHandler = handlers.setCompleteHandler,
+    setErrorHandler = handlers.setErrorHandler,
+    data = data,
+    setUUID = setUUID,
+    setTimeout = setTimeout,
+}

--- a/scripts/rfsuite/tasks/msp/api/SERVO_OVERRIDE.lua
+++ b/scripts/rfsuite/tasks/msp/api/SERVO_OVERRIDE.lua
@@ -144,4 +144,17 @@ local function setTimeout(timeout)
 end
 
 -- Return the module's API functions
-return {read = read, write = write, readComplete = readComplete, writeComplete = writeComplete, readValue = readValue, setValue = setValue, resetWriteStatus = resetWriteStatus, setCompleteHandler = handlers.setCompleteHandler, setErrorHandler = handlers.setErrorHandler, data = data}
+return {
+    read = read,
+    write = write,
+    readComplete = readComplete,
+    writeComplete = writeComplete,
+    readValue = readValue,
+    setValue = setValue,
+    resetWriteStatus = resetWriteStatus,
+    setCompleteHandler = handlers.setCompleteHandler,
+    setErrorHandler = handlers.setErrorHandler,
+    data = data,
+    setUUID = setUUID,
+    setTimeout = setTimeout,
+}

--- a/scripts/rfsuite/tasks/msp/api/STATUS.lua
+++ b/scripts/rfsuite/tasks/msp/api/STATUS.lua
@@ -158,4 +158,17 @@ local function setTimeout(timeout)
 end
 
 -- Return the module's API functions
-return {read = read, write = write, readComplete = readComplete, writeComplete = writeComplete, readValue = readValue, setValue = setValue, resetWriteStatus = resetWriteStatus, setCompleteHandler = handlers.setCompleteHandler, setErrorHandler = handlers.setErrorHandler, data = data}
+return {
+    read = read,
+    write = write,
+    readComplete = readComplete,
+    writeComplete = writeComplete,
+    readValue = readValue,
+    setValue = setValue,
+    resetWriteStatus = resetWriteStatus,
+    setCompleteHandler = handlers.setCompleteHandler,
+    setErrorHandler = handlers.setErrorHandler,
+    data = data,
+    setUUID = setUUID,
+    setTimeout = setTimeout,
+}

--- a/scripts/rfsuite/tasks/msp/api/api_template.lua
+++ b/scripts/rfsuite/tasks/msp/api/api_template.lua
@@ -21,7 +21,14 @@ local MSP_API_SIMULATOR_RESPONSE = {70, 0, 225, 0, 90, 0, 120, 0, 100, 0, 200, 0
 local MSP_MIN_BYTES = 34
 
 -- Define the MSP response data structures
-local MSP_API_STRUCTURE_READ = {{field = "gov_mode", type = "U8"}, {field = "gov_startup_time", type = "U16"}, {field = "gov_spoolup_time", type = "U16"}, {field = "gov_tracking_time", type = "U16"}, {field = "gov_spoolup_min_throttle", type = "U8"}}
+local MSP_API_STRUCTURE_READ = {
+    {field = "gov_mode", type = "U8"},
+    {field = "gov_startup_time", type = "U16"},
+    {field = "gov_spoolup_time", type = "U16"},
+    {field = "gov_tracking_time", type = "U16"},
+    {field = "gov_spoolup_min_throttle", type = "U8"}
+}
+
 local MSP_API_STRUCTURE_WRITE = MSP_API_STRUCTURE_READ -- Assuming identical structure for now
 
 -- Variable to store parsed MSP data
@@ -136,4 +143,17 @@ local function setTimeout(timeout)
     MSP_API_MSG_TIMEOUT = timeout
 end
 -- Return the module's API functions
-return {read = read, write = write, readComplete = readComplete, writeComplete = writeComplete, readValue = readValue, setValue = setValue, resetWriteStatus = resetWriteStatus, setCompleteHandler = handlers.setCompleteHandler, setErrorHandler = handlers.setErrorHandler, data = data}
+return {
+    read = read,
+    write = write,
+    readComplete = readComplete,
+    writeComplete = writeComplete,
+    readValue = readValue,
+    setValue = setValue,
+    resetWriteStatus = resetWriteStatus,
+    setCompleteHandler = handlers.setCompleteHandler,
+    setErrorHandler = handlers.setErrorHandler,
+    data = data,
+    setUUID = setUUID,
+    setTimeout = setTimeout,
+}

--- a/scripts/rfsuite/tasks/msp/msp.lua
+++ b/scripts/rfsuite/tasks/msp/msp.lua
@@ -65,9 +65,10 @@ function msp.onConnectBgChecks()
         if rfsuite.rssiSensor then msp.sensor:module(rfsuite.rssiSensor:module()) end
 
         -- get the api version
-        if rfsuite.config.apiVersion == nil and msp.mspQueue:isProcessed() then
+        if rfsuite.config.apiVersion == nil then
 
             local API = msp.api.load("API_VERSION")
+            API.setUUID("INIT_API_VERSION")
             API.setCompleteHandler(function(self, buf)
                 rfsuite.config.apiVersion = API.readVersion()
                 rfsuite.utils.log("API version: " .. rfsuite.config.apiVersion)
@@ -75,9 +76,10 @@ function msp.onConnectBgChecks()
             API.read()
             -- sync the clock
             print(rfsuite.config.apiVersion)
-        elseif rfsuite.config.clockSet == nil and msp.mspQueue:isProcessed() then
+        elseif rfsuite.config.clockSet == nil then
 
             local API = msp.api.load("RTC", 1)
+            API.setUUID("INIT_RTC")
             API.setCompleteHandler(function(self, buf)
                 rfsuite.config.clockSet = true
                 rfsuite.utils.log("Sync clock: " .. os.clock())
@@ -93,9 +95,10 @@ function msp.onConnectBgChecks()
             rfsuite.config.clockSetAlart = true
 
             -- find tail and swash mode
-        elseif (rfsuite.config.tailMode == nil or rfsuite.config.swashMode == nil) and msp.mspQueue:isProcessed() then
+        elseif (rfsuite.config.tailMode == nil or rfsuite.config.swashMode == nil) then
 
             local API = msp.api.load("MIXER_CONFIG")
+            API.setUUID("INIT_MIXER_CONFIG")
             API.setCompleteHandler(function(self, buf)
                 rfsuite.config.tailMode = API.readValue("tail_rotor_mode")
                 rfsuite.config.swashMode = API.readValue("swash_type")
@@ -105,9 +108,10 @@ function msp.onConnectBgChecks()
             API.read()
 
             -- get servo configuration
-        elseif (rfsuite.config.servoCount == nil) and msp.mspQueue:isProcessed() then
+        elseif (rfsuite.config.servoCount == nil) then
 
             local API = msp.api.load("SERVO_CONFIGURATIONS")
+            API.setUUID("INIT_SERVO_CONFIGURATIONS")
             API.setCompleteHandler(function(self, buf)
                 rfsuite.config.servoCount = API.readValue("servo_count")
                 rfsuite.utils.log("Servo count: " .. rfsuite.config.servoCount)
@@ -115,10 +119,11 @@ function msp.onConnectBgChecks()
             API.read()
 
             -- work out if fbl has any servos in overide mode
-        elseif (rfsuite.config.servoOverride == nil) and msp.mspQueue:isProcessed() then
+        elseif (rfsuite.config.servoOverride == nil) then
 
             local API = msp.api.load("SERVO_OVERRIDE")
             API.read(rfsuite.config.servoCount)
+            API.setUUID("INIT_SERVO_OVERRIDE")
             if API.readComplete() then
                 local data = API.data()
                 local buf = data['buffer']
@@ -134,9 +139,10 @@ function msp.onConnectBgChecks()
             end
 
             -- find out if we have a governor
-        elseif (rfsuite.config.governorMode == nil) and msp.mspQueue:isProcessed() then
+        elseif (rfsuite.config.governorMode == nil) then
 
             local API = msp.api.load("GOVERNOR_CONFIG")
+            API.setUUID("INIT_GOVERNOR_CONFIG")
             API.setCompleteHandler(function(self, buf)
                 local governorMode = API.readValue("gov_mode")
                 rfsuite.utils.log("Governor mode: " .. governorMode)
@@ -145,9 +151,10 @@ function msp.onConnectBgChecks()
             API.read()
 
             -- get the model id
-        elseif (rfsuite.config.modelID == nil) and msp.mspQueue:isProcessed() then
+        elseif (rfsuite.config.modelID == nil) then
 
             local API = msp.api.load("PILOT_CONFIG")
+            API.setUUID("INIT_PILOT_CONFIG")
             API.setCompleteHandler(function(self, buf)
                 local model_id = API.readValue("model_id")
                 rfsuite.utils.log("Model id: " .. model_id)
@@ -156,9 +163,10 @@ function msp.onConnectBgChecks()
             API.read()
 
             -- find the craft name on the fbl
-        elseif (rfsuite.config.craftName == nil) and msp.mspQueue:isProcessed() then
+        elseif (rfsuite.config.craftName == nil) then
 
             local API = msp.api.load("NAME")
+            API.setUUID("INIT_NAME")
             API.read()
             if API.readComplete() and API.readValue("name") ~= nil then
                 local data = API.data()


### PR DESCRIPTION
The new MSP api includes the ability to add a UUID to each query.

Doing this means I dont have to wait for the queue to flush - essentially grabbing data async.

Result is a faster initial connect.