### PR TITLE
1.6.2 Version check revamp

### DIFF
--- a/scripts/rfsuite/app/app.lua
+++ b/scripts/rfsuite/app/app.lua
@@ -350,7 +350,7 @@ local function processPageReply(source, buf, methodType)
         end
 
         -- inject min/max/defaults etc if present
-        if rfsuite.config.ethosRunningVersion >= 1620 and app.Page.fields and buf.structure then
+        if app.Page.fields and buf.structure then
             for i, v in ipairs(buf.structure) do
                 local field = v.field
                 for j, f in ipairs(app.Page.fields) do
@@ -809,8 +809,11 @@ function app.wakeupUI()
 
                 local message
                 local apiVersionAsString = tostring(rfsuite.config.apiVersion)
-                if rfsuite.config.ethosRunningVersion < config.ethosVersionOld then
-                    message = config.ethosVersionOldString
+                if not rfsuite.utils.ethosVersionAtLeast() then
+                    message = string.format("ETHOS < V%d.%d.%d", 
+                    rfsuite.config.ethosVersion[1], 
+                    rfsuite.config.ethosVersion[2], 
+                    rfsuite.config.ethosVersion[3])
                     app.triggers.invalidConnectionSetup = true
                 elseif not rfsuite.bg.active() then
                     message = "Please enable the background task."
@@ -1250,7 +1253,7 @@ function app.create_logtool()
 
     -- config.apiVersion = nil
     config.environment = system.getVersion()
-    config.ethosRunningVersion = rfsuite.utils.ethosVersionOld()
+    config.ethosRunningVersion = {config.environment.major, config.environment.minor, config.environment.revision}
 
     rfsuite.config.lcdWidth, rfsuite.config.lcdHeight = rfsuite.utils.getWindowSize()
     app.radio = assert(loadfile("app/radios.lua"))().msp
@@ -1272,7 +1275,7 @@ function app.create()
 
     -- config.apiVersion = nil
     config.environment = system.getVersion()
-    config.ethosRunningVersion = rfsuite.utils.ethosVersionOld()
+    config.ethosRunningVersion = {config.environment.major, config.environment.minor, config.environment.revision}
 
     rfsuite.config.lcdWidth, rfsuite.config.lcdHeight = rfsuite.utils.getWindowSize()
     app.radio = assert(loadfile("app/radios.lua"))().msp

--- a/scripts/rfsuite/app/app.lua
+++ b/scripts/rfsuite/app/app.lua
@@ -809,8 +809,8 @@ function app.wakeupUI()
 
                 local message
                 local apiVersionAsString = tostring(rfsuite.config.apiVersion)
-                if rfsuite.config.ethosRunningVersion < config.ethosVersion then
-                    message = config.ethosVersionString
+                if rfsuite.config.ethosRunningVersion < config.ethosVersionOld then
+                    message = config.ethosVersionOldString
                     app.triggers.invalidConnectionSetup = true
                 elseif not rfsuite.bg.active() then
                     message = "Please enable the background task."
@@ -1250,7 +1250,7 @@ function app.create_logtool()
 
     -- config.apiVersion = nil
     config.environment = system.getVersion()
-    config.ethosRunningVersion = rfsuite.utils.ethosVersion()
+    config.ethosRunningVersion = rfsuite.utils.ethosVersionOld()
 
     rfsuite.config.lcdWidth, rfsuite.config.lcdHeight = rfsuite.utils.getWindowSize()
     app.radio = assert(loadfile("app/radios.lua"))().msp
@@ -1272,7 +1272,7 @@ function app.create()
 
     -- config.apiVersion = nil
     config.environment = system.getVersion()
-    config.ethosRunningVersion = rfsuite.utils.ethosVersion()
+    config.ethosRunningVersion = rfsuite.utils.ethosVersionOld()
 
     rfsuite.config.lcdWidth, rfsuite.config.lcdHeight = rfsuite.utils.getWindowSize()
     app.radio = assert(loadfile("app/radios.lua"))().msp

--- a/scripts/rfsuite/app/lib/ui.lua
+++ b/scripts/rfsuite/app/lib/ui.lua
@@ -182,7 +182,7 @@ function ui.openMainMenu()
     end
 
     -- hard exit on error
-    if rfsuite.utils.ethosVersion() < rfsuite.config.ethosVersion then return end
+    if rfsuite.utils.ethosVersionOld() < rfsuite.config.ethosVersionOld then return end
 
     local MainMenu = assert(loadfile("app/modules/init.lua"))()
 

--- a/scripts/rfsuite/app/lib/ui.lua
+++ b/scripts/rfsuite/app/lib/ui.lua
@@ -182,7 +182,9 @@ function ui.openMainMenu()
     end
 
     -- hard exit on error
-    if rfsuite.utils.ethosVersionOld() < rfsuite.config.ethosVersionOld then return end
+    if not rfsuite.utils.ethosVersionAtLeast(config.ethosVersion) then
+        return
+    end    
 
     local MainMenu = assert(loadfile("app/modules/init.lua"))()
 
@@ -265,7 +267,7 @@ function ui.openMainMenu()
                     -- do not show icon if not supported by ethos version
                     local hideEntry = false
 
-                    if (pvalue.ethosversion ~= nil and rfsuite.config.ethosRunningVersion < pvalue.ethosversion) then hideEntry = true end
+                    if (pvalue.ethosversion ~= nil and not rfsuite.utils.ethosVersionAtLeast(pvalue.ethosversion)) then hideEntry = true end
 
                     if (pvalue.mspversion ~= nil and rfsuite.config.apiVersion < pvalue.mspversion) then hideEntry = true end
 
@@ -448,13 +450,13 @@ function ui.fieldNumber(i)
         rfsuite.app.saveValue(i)
     end)
 
-    if config.ethosRunningVersion >= 1514 then
-        if f.onFocus ~= nil then
-            rfsuite.app.formFields[i]:onFocus(function()
-                f.onFocus(rfsuite.app.Page)
-            end)
-        end
+
+    if f.onFocus ~= nil then
+        rfsuite.app.formFields[i]:onFocus(function()
+            f.onFocus(rfsuite.app.Page)
+        end)
     end
+
 
     if f.default ~= nil then
         if f.offset ~= nil then f.default = f.default + f.offset end
@@ -532,13 +534,12 @@ function ui.fieldStaticText(i)
 
     rfsuite.app.formFields[i] = form.addStaticText(rfsuite.app.formLines[formLineCnt], posField, rfsuite.utils.getFieldValue(rfsuite.app.Page.fields[i]))
 
-    if config.ethosRunningVersion >= 1514 then
-        if f.onFocus ~= nil then
-            rfsuite.app.formFields[i]:onFocus(function()
-                f.onFocus(rfsuite.app.Page)
-            end)
-        end
+    if f.onFocus ~= nil then
+        rfsuite.app.formFields[i]:onFocus(function()
+            f.onFocus(rfsuite.app.Page)
+        end)
     end
+
 
     if f.decimals ~= nil then rfsuite.app.formFields[i]:decimals(f.decimals) end
     if f.unit ~= nil then rfsuite.app.formFields[i]:suffix(f.unit) end

--- a/scripts/rfsuite/app/modules/about/init.lua
+++ b/scripts/rfsuite/app/modules/about/init.lua
@@ -23,7 +23,7 @@ local init = {
     script = "about.lua", -- run this script
     image = "about.png", -- image for the page
     order = 1, -- order in the section
-    ethosversion = 1519 -- disable button if ethos version is less than this
+    ethosversion = {1, 6, 2} -- disable button if ethos version is less than this
 }
 
 return init

--- a/scripts/rfsuite/app/modules/accelerometer/init.lua
+++ b/scripts/rfsuite/app/modules/accelerometer/init.lua
@@ -23,7 +23,7 @@ local init = {
     script = "accelerometer.lua", -- run this script
     image = "acc.png", -- image for the page
     order = 5, -- order in the section
-    ethosversion = 1519 -- disable button if ethos version is less than this
+    ethosversion = {1, 6, 2} -- disable button if ethos version is less than this
 }
 
 return init

--- a/scripts/rfsuite/app/modules/battery/init.lua
+++ b/scripts/rfsuite/app/modules/battery/init.lua
@@ -23,7 +23,7 @@ local init = {
     script = "battery.lua", -- run this script
     image = "battery.png", -- image for the page
     order = 10, -- order in the section
-    ethosversion = 1519 -- disable button if ethos version is less than this
+    ethosversion = {1, 6, 2} -- disable button if ethos version is less than this
 }
 
 return init

--- a/scripts/rfsuite/app/modules/copyprofiles/init.lua
+++ b/scripts/rfsuite/app/modules/copyprofiles/init.lua
@@ -23,7 +23,7 @@ local init = {
     script = "copyprofiles.lua", -- run this script
     image = "copy.png", -- image for the page
     order = 1, -- order in the section
-    ethosversion = 1519 -- disable button if ethos version is less than this
+    ethosversion = {1, 6, 2} -- disable button if ethos version is less than this
 }
 
 return init

--- a/scripts/rfsuite/app/modules/esc/esc.lua
+++ b/scripts/rfsuite/app/modules/esc/esc.lua
@@ -2,7 +2,7 @@ local function findMFG()
     local mfgsList = {}
 
     local mfgdir = "app/modules/esc/mfg/"
-    local mfgs_path = (rfsuite.utils.ethosVersionToMinorOld() >= 16) and mfgdir or (config.suiteDir .. mfgdir)
+    local mfgs_path = mfgdir 
 
     for _, v in pairs(system.listFiles(mfgs_path)) do
 

--- a/scripts/rfsuite/app/modules/esc/esc.lua
+++ b/scripts/rfsuite/app/modules/esc/esc.lua
@@ -2,7 +2,7 @@ local function findMFG()
     local mfgsList = {}
 
     local mfgdir = "app/modules/esc/mfg/"
-    local mfgs_path = (rfsuite.utils.ethosVersionToMinor() >= 16) and mfgdir or (config.suiteDir .. mfgdir)
+    local mfgs_path = (rfsuite.utils.ethosVersionToMinorOld() >= 16) and mfgdir or (config.suiteDir .. mfgdir)
 
     for _, v in pairs(system.listFiles(mfgs_path)) do
 

--- a/scripts/rfsuite/app/modules/esc/init.lua
+++ b/scripts/rfsuite/app/modules/esc/init.lua
@@ -23,7 +23,7 @@ local init = {
     script = "esc.lua", -- run this script
     image = "esc.png", -- image for the page
     order = 12, -- order in the section
-    ethosversion = 1519 -- disable button if ethos version is less than this
+    ethosversion = {1, 6, 2} -- disable button if ethos version is less than this
 }
 
 return init

--- a/scripts/rfsuite/app/modules/filters/init.lua
+++ b/scripts/rfsuite/app/modules/filters/init.lua
@@ -23,7 +23,7 @@ local init = {
     script = "filters.lua", -- run this script
     image = "filters.png", -- image for the page
     order = 9, -- order in the section
-    ethosversion = 1519 -- disable button if ethos version is less than this
+    ethosversion = {1, 6, 2} -- disable button if ethos version is less than this
 }
 
 return init

--- a/scripts/rfsuite/app/modules/governor/init.lua
+++ b/scripts/rfsuite/app/modules/governor/init.lua
@@ -23,7 +23,7 @@ local init = {
     script = "governor.lua", -- run this script
     image = "governor.png", -- image for the page
     order = 11, -- order in the section
-    ethosversion = 1519 -- disable button if ethos version is less than this
+    ethosversion = {1, 6, 2} -- disable button if ethos version is less than this
 }
 
 return init

--- a/scripts/rfsuite/app/modules/logs/init.lua
+++ b/scripts/rfsuite/app/modules/logs/init.lua
@@ -23,7 +23,7 @@ local init = {
     script = "logs.lua", -- run this script
     image = "logs.png", -- image for the page
     order = 15, -- order in the section
-    ethosversion = 1560 -- disable button if ethos version is less than this,
+    ethosversion = {1, 6, 2} -- disable button if ethos version is less than this,
 }
 
 return init

--- a/scripts/rfsuite/app/modules/logs/logs.lua
+++ b/scripts/rfsuite/app/modules/logs/logs.lua
@@ -29,9 +29,9 @@ end
 local function getLogPath()
 
     -- do some checks to make sure stuff exists
-    local base_path = (rfsuite.utils.ethosVersionToMinor() >= 16) and "./" or (rfsuite.config.suiteDir .. "/")
-    local logs_path = (rfsuite.utils.ethosVersionToMinor() >= 16) and "logs" or (rfsuite.config.suiteDir .. "/logs")
-    local logs_path_telemetry = (rfsuite.utils.ethosVersionToMinor() >= 16) and "logs/telemetry" or (rfsuite.config.suiteDir .. "/logs/telemetry")
+    local base_path = (rfsuite.utils.ethosVersionToMinorOld() >= 16) and "./" or (rfsuite.config.suiteDir .. "/")
+    local logs_path = (rfsuite.utils.ethosVersionToMinorOld() >= 16) and "logs" or (rfsuite.config.suiteDir .. "/logs")
+    local logs_path_telemetry = (rfsuite.utils.ethosVersionToMinorOld() >= 16) and "logs/telemetry" or (rfsuite.config.suiteDir .. "/logs/telemetry")
 
     if not dir_exists(base_path, logs_path) then os.mkdir(logs_path) end
     if not dir_exists(logs_path_telemetry) then os.mkdir(logs_path_telemetry) end
@@ -90,7 +90,7 @@ end
 local function openPage(pidx, title, script, displaymode)
 
     -- hard exit on error
-    if rfsuite.utils.ethosVersion() < rfsuite.config.ethosVersion then return end
+    if rfsuite.utils.ethosVersionOld() < rfsuite.config.ethosVersionOld then return end
 
     currentDisplayMode = displaymode
 

--- a/scripts/rfsuite/app/modules/logs/logs.lua
+++ b/scripts/rfsuite/app/modules/logs/logs.lua
@@ -29,9 +29,9 @@ end
 local function getLogPath()
 
     -- do some checks to make sure stuff exists
-    local base_path = (rfsuite.utils.ethosVersionToMinorOld() >= 16) and "./" or (rfsuite.config.suiteDir .. "/")
-    local logs_path = (rfsuite.utils.ethosVersionToMinorOld() >= 16) and "logs" or (rfsuite.config.suiteDir .. "/logs")
-    local logs_path_telemetry = (rfsuite.utils.ethosVersionToMinorOld() >= 16) and "logs/telemetry" or (rfsuite.config.suiteDir .. "/logs/telemetry")
+    local base_path = "./"
+    local logs_path = "logs"
+    local logs_path_telemetry = "logs/telemetry" 
 
     if not dir_exists(base_path, logs_path) then os.mkdir(logs_path) end
     if not dir_exists(logs_path_telemetry) then os.mkdir(logs_path_telemetry) end
@@ -90,7 +90,9 @@ end
 local function openPage(pidx, title, script, displaymode)
 
     -- hard exit on error
-    if rfsuite.utils.ethosVersionOld() < rfsuite.config.ethosVersionOld then return end
+    if not rfsuite.utils.ethosVersionAtLeast() then
+        return
+    end
 
     currentDisplayMode = displaymode
 

--- a/scripts/rfsuite/app/modules/logs/logs_tool.lua
+++ b/scripts/rfsuite/app/modules/logs/logs_tool.lua
@@ -290,7 +290,7 @@ end
 
 local function getLogDir()
 
-    local logs_path = (rfsuite.utils.ethosVersionToMinor() >= 16) and "logs/" or (rfsuite.config.suiteDir .. "/logs/")
+    local logs_path = (rfsuite.utils.ethosVersionToMinorOld() >= 16) and "logs/" or (rfsuite.config.suiteDir .. "/logs/")
 
     return logs_path .. "telemetry/"
 

--- a/scripts/rfsuite/app/modules/logs/logs_tool.lua
+++ b/scripts/rfsuite/app/modules/logs/logs_tool.lua
@@ -170,11 +170,8 @@ function createFileReader(filename)
     -- Return the function to read the next chunk of 10KB
     return function()
         -- Seek to the current position in the file
-        if rfsuite.config.ethosRunningVersion > 1600 then
-            file:seek("set", file_pos)  -- Explicitly set the seek mode
-        else
-            file:seek(file_pos)
-        end
+        file:seek("set", file_pos)  -- Explicitly set the seek mode
+
 
         -- Read the next 10KB chunk
         local chunk = file:read(10 * 1024)
@@ -290,7 +287,7 @@ end
 
 local function getLogDir()
 
-    local logs_path = (rfsuite.utils.ethosVersionToMinorOld() >= 16) and "logs/" or (rfsuite.config.suiteDir .. "/logs/")
+    local logs_path = "logs/"
 
     return logs_path .. "telemetry/"
 
@@ -611,9 +608,9 @@ local function wakeup()
             end, function(newValue)
                 sliderPosition = newValue
             end)
-            if rfsuite.config.ethosRunningVersion >= 1620 then
+  
             rfsuite.app.formFields[1]:step(1)
-            end
+
 
             -- set log line count only once!
             logLineCount = #logData[currentDataIndex]['data']

--- a/scripts/rfsuite/app/modules/mixer/init.lua
+++ b/scripts/rfsuite/app/modules/mixer/init.lua
@@ -24,7 +24,7 @@ local init = {
     image = "mixer.png", -- image for the page
     order = 4, -- order in the section
     developer = false, -- hide this page if true
-    ethosversion = 1519 -- disable button if ethos version is less than this
+    ethosversion = {1, 6, 2} -- disable button if ethos version is less than this
 }
 
 return init

--- a/scripts/rfsuite/app/modules/motors/init.lua
+++ b/scripts/rfsuite/app/modules/motors/init.lua
@@ -23,7 +23,7 @@ local init = {
     script = "motors.lua", -- run this script
     image = "motors.png", -- image for the page
     order = 1, -- order in the section
-    ethosversion = 1519 -- disable button if ethos version is less than this
+    ethosversion = {1, 6, 2} -- disable button if ethos version is less than this
 }
 
 return init

--- a/scripts/rfsuite/app/modules/msp_exp/init.lua
+++ b/scripts/rfsuite/app/modules/msp_exp/init.lua
@@ -24,7 +24,7 @@ local init = {
     image = "msp_exp.png", -- image for the page
     order = 100, -- order in the section
     developer = true, -- show if developer mode enabled
-    ethosversion = 1519 -- disable button if ethos version is less than this
+    ethosversion = {1, 6, 2} -- disable button if ethos version is less than this
 }
 
 return init

--- a/scripts/rfsuite/app/modules/msp_speed/init.lua
+++ b/scripts/rfsuite/app/modules/msp_speed/init.lua
@@ -24,7 +24,7 @@ local init = {
     image = "msp_speed.png", -- image for the page
     order = 102, -- order in the section
     developer = true, -- show if developer mode enabled    
-    ethosversion = 1519 -- disable button if ethos version is less than this
+    ethosversion = {1, 6, 2} -- disable button if ethos version is less than this
 }
 
 return init

--- a/scripts/rfsuite/app/modules/pids/init.lua
+++ b/scripts/rfsuite/app/modules/pids/init.lua
@@ -23,7 +23,7 @@ local init = {
     script = "pids.lua", -- run this script
     image = "pids.png", -- image for the page
     order = 1, -- order in the section
-    ethosversion = 1519 -- disable button if ethos version is less than this
+    ethosversion = {1, 6, 2} -- disable button if ethos version is less than this
 }
 
 return init

--- a/scripts/rfsuite/app/modules/profile_autolevel/init.lua
+++ b/scripts/rfsuite/app/modules/profile_autolevel/init.lua
@@ -23,7 +23,7 @@ local init = {
     script = "autolevel.lua", -- run this script
     image = "autolevel.png", -- image for the page
     order = 3, -- order in the section
-    ethosversion = 1519 -- disable button if ethos version is less than this
+    ethosversion = {1, 6, 2} -- disable button if ethos version is less than this
 }
 
 return init

--- a/scripts/rfsuite/app/modules/profile_governor/init.lua
+++ b/scripts/rfsuite/app/modules/profile_governor/init.lua
@@ -23,7 +23,7 @@ local init = {
     script = "profile_governor.lua", -- run this script
     image = "governor.png", -- image for the page
     order = 5, -- order in the section
-    ethosversion = 1519 -- disable button if ethos version is less than this
+    ethosversion = {1, 6, 2} -- disable button if ethos version is less than this
 }
 
 return init

--- a/scripts/rfsuite/app/modules/profile_mainrotor/init.lua
+++ b/scripts/rfsuite/app/modules/profile_mainrotor/init.lua
@@ -23,7 +23,7 @@ local init = {
     script = "mainrotor.lua", -- run this script
     image = "mainrotor.png", -- image for the page
     order = 3, -- order in the section
-    ethosversion = 1519 -- disable button if ethos version is less than this
+    ethosversion = {1, 6, 2} -- disable button if ethos version is less than this
 }
 
 return init

--- a/scripts/rfsuite/app/modules/profile_pidbandwidth/init.lua
+++ b/scripts/rfsuite/app/modules/profile_pidbandwidth/init.lua
@@ -23,7 +23,7 @@ local init = {
     script = "pidbandwidth.lua", -- run this script
     image = "pids-bandwidth.png", -- image for the page
     order = 2, -- order in the section
-    ethosversion = 1519 -- disable button if ethos version is less than this
+    ethosversion = {1, 6, 2} -- disable button if ethos version is less than this
 }
 
 return init

--- a/scripts/rfsuite/app/modules/profile_pidcontroller/init.lua
+++ b/scripts/rfsuite/app/modules/profile_pidcontroller/init.lua
@@ -23,7 +23,7 @@ local init = {
     script = "pidcontroller.lua", -- run this script
     image = "pids-controller.png", -- image for the page
     order = 1, -- order in the section
-    ethosversion = 1519 -- disable button if ethos version is less than this
+    ethosversion = {1, 6, 2} -- disable button if ethos version is less than this
 }
 
 return init

--- a/scripts/rfsuite/app/modules/profile_rescue/init.lua
+++ b/scripts/rfsuite/app/modules/profile_rescue/init.lua
@@ -23,7 +23,7 @@ local init = {
     script = "rescue.lua", -- run this script
     image = "rescue.png", -- image for the page
     order = 7, -- order in the section
-    ethosversion = 1519 -- disable button if ethos version is less than this
+    ethosversion = {1, 6, 2} -- disable button if ethos version is less than this
 }
 
 return init

--- a/scripts/rfsuite/app/modules/profile_select/init.lua
+++ b/scripts/rfsuite/app/modules/profile_select/init.lua
@@ -23,7 +23,7 @@ local init = {
     script = "select_profile.lua", -- run this script
     image = "select_profile.png", -- image for the page
     order = 4, -- order in the section
-    ethosversion = 1519 -- disable button if ethos version is less than this
+    ethosversion = {1, 6, 2} -- disable button if ethos version is less than this
 }
 
 return init

--- a/scripts/rfsuite/app/modules/profile_tailrotor/init.lua
+++ b/scripts/rfsuite/app/modules/profile_tailrotor/init.lua
@@ -23,7 +23,7 @@ local init = {
     script = "tailrotor.lua", -- run this script
     image = "tailrotor.png", -- image for the page
     order = 4, -- order in the section
-    ethosversion = 1519 -- disable button if ethos version is less than this
+    ethosversion = {1, 6, 2} -- disable button if ethos version is less than this
 }
 
 return init

--- a/scripts/rfsuite/app/modules/radio_config/init.lua
+++ b/scripts/rfsuite/app/modules/radio_config/init.lua
@@ -23,7 +23,7 @@ local init = {
     script = "radio_config.lua", -- run this script
     image = "radio_config.png", -- image for the page
     order = 9, -- order in the section
-    ethosversion = 1519 -- disable button if ethos version is less than this
+    ethosversion = {1, 6, 2} -- disable button if ethos version is less than this
 }
 
 return init

--- a/scripts/rfsuite/app/modules/rates/init.lua
+++ b/scripts/rfsuite/app/modules/rates/init.lua
@@ -23,7 +23,7 @@ local init = {
     script = "rates.lua", -- run this script
     image = "rates.png", -- image for the page
     order = 2, -- order in the section
-    ethosversion = 1519 -- disable button if ethos version is less than this
+    ethosversion = {1, 6, 2} -- disable button if ethos version is less than this
 }
 
 return init

--- a/scripts/rfsuite/app/modules/rates_advanced/init.lua
+++ b/scripts/rfsuite/app/modules/rates_advanced/init.lua
@@ -23,7 +23,7 @@ local init = {
     script = "rates_advanced.lua", -- run this script
     image = "rates.png", -- image for the page
     order = 8, -- order in the section
-    ethosversion = 1519 -- disable button if ethos version is less than this
+    ethosversion = {1, 6, 2} -- disable button if ethos version is less than this
 }
 
 return init

--- a/scripts/rfsuite/app/modules/sbusout/init.lua
+++ b/scripts/rfsuite/app/modules/sbusout/init.lua
@@ -23,7 +23,7 @@ local init = {
     script = "sbusout.lua", -- run this script
     image = "sbusout.png", -- image for the page
     order = 3, -- order in the section
-    ethosversion = 1519, -- disable button if ethos version is less than this
+    ethosversion = {1,6,2}, -- disable button if ethos version is less than this
     mspversion = 12.07 -- disable button if msp version is less than this
 }
 

--- a/scripts/rfsuite/app/modules/servos/init.lua
+++ b/scripts/rfsuite/app/modules/servos/init.lua
@@ -23,7 +23,7 @@ local init = {
     script = "servos.lua", -- run this script
     image = "servos.png", -- image for the page
     order = 2, -- order in the section
-    ethosversion = 1519 -- disable button if ethos version is less than this
+    ethosversion = {1, 6, 2} -- disable button if ethos version is less than this
 }
 
 return init

--- a/scripts/rfsuite/app/modules/status/init.lua
+++ b/scripts/rfsuite/app/modules/status/init.lua
@@ -23,7 +23,7 @@ local init = {
     script = "status.lua", -- run this script
     image = "status.png", -- image for the page
     order = 10, -- order in the section
-    ethosversion = 1519 -- disable button if ethos version is less than this
+    ethosversion = {1, 6, 2} -- disable button if ethos version is less than this
 }
 
 return init

--- a/scripts/rfsuite/app/modules/trim/init.lua
+++ b/scripts/rfsuite/app/modules/trim/init.lua
@@ -23,7 +23,7 @@ local init = {
     script = "trim.lua", -- run this script
     image = "trim.png", -- image for the page
     order = 6, -- order in the section
-    ethosversion = 1519 -- disable button if ethos version is less than this
+    ethosversion = {1, 6, 2} -- disable button if ethos version is less than this
 }
 
 return init

--- a/scripts/rfsuite/app/modules/validate_sensors/init.lua
+++ b/scripts/rfsuite/app/modules/validate_sensors/init.lua
@@ -23,7 +23,7 @@ local init = {
     script = "validate.lua", -- run this script
     image = "sensors.png", -- image for the page
     order = 10, -- order in the section
-    ethosversion = 1600 -- disable button if ethos version is less than this
+    ethosversion = {1, 6, 2} -- disable button if ethos version is less than this
 }
 
 return init

--- a/scripts/rfsuite/lib/utils.lua
+++ b/scripts/rfsuite/lib/utils.lua
@@ -230,22 +230,11 @@ end
 -- it should not be used once bgtasks are running
 -- you can use rssiSOURCE = rfsuite.bg.telemetry.getSensorSource("rssi") 
 function utils.getRssiSensor()
-    -- Try to find the sport sensor
-    local rssiSensor = system.getSource({appId = 0xF101})
-    if rssiSensor then
-        return rssiSensor
-    end
+    local rssiSensor
 
-    -- Try to find the ELRS sensor
-    --system.getSource({crsfId=0x14, subIdStart=0, subIdEnd=1})  -- this will replace below loop once 1.6.2 is out
-
-    local rssiNames = {"Rx RSSI1", "Rx RSSI2"}
-    for _, name in ipairs(rssiNames) do
-        rssiSensor = system.getSource(name)
-        if rssiSensor then
-            return rssiSensor
-        end
-    end
+    -- look for sport (0xF101) or elrs (0x14) rssi sensor
+    rssiSensor = system.getSource({appId = 0xF101}) or system.getSource({crsfId=0x14, subIdStart=0, subIdEnd=1}) 
+    if rssiSensor then return rssiSensor end
 
     return nil
 end

--- a/scripts/rfsuite/lib/utils.lua
+++ b/scripts/rfsuite/lib/utils.lua
@@ -62,7 +62,7 @@ function utils.playFile(pkg, file)
     av = av:gsub("SD:", ""):gsub("RADIO:", ""):gsub("AUDIO:", ""):gsub("VOICE[1-4]:", "")
 
     -- Pre-define the base directory paths
-    local baseDir = rfsuite.config.suiteDir
+    local baseDir = "./"
     local soundPack = rfsuite.config.soundPack
     local audioPath = soundPack and ("/audio/" .. soundPack) or (av)
 
@@ -70,13 +70,9 @@ function utils.playFile(pkg, file)
     local wavLocale
     local wavDefault
 
-    if utils.ethosVersionToMinorOld() < 16 then
-        wavLocale = baseDir .. audioPath .. "/" .. pkg .. "/" .. file
-        wavDefault = baseDir .. "/audio/en/default/" .. pkg .. "/" .. file
-    else
-        wavLocale = audioPath .. "/" .. pkg .. "/" .. file
-        wavDefault = "audio/en/default/" .. pkg .. "/" .. file
-    end
+    wavLocale = audioPath .. "/" .. pkg .. "/" .. file
+    wavDefault = "audio/en/default/" .. pkg .. "/" .. file
+
 
     -- Check if locale file exists, else use the default
     if rfsuite.utils.file_exists(wavLocale) then
@@ -88,12 +84,7 @@ end
 
 function utils.playFileCommon(file)
 
-    local wav
-    if utils.ethosVersionToMinorOld() < 16 then
-        wav = rfsuite.config.suiteDir .. "/audio/" .. file
-    else
-        wav = "audio/" .. file
-    end
+    local wav = "audio/" .. file
     system.playFile(wav)
 
 end
@@ -197,23 +188,43 @@ function utils.getCurrentProfile()
     end
 end
 
-function utils.ethosVersionOld()
-    local environment = system.getVersion()
-    local v = tonumber(environment.major .. environment.minor .. environment.revision)
+-- Function to compare the current system version with a target version
+-- Function to compare the current system version with a target version
+function utils.ethosVersionAtLeast(targetVersion)
+    local env = system.getVersion()
+    local currentVersion = {env.major, env.minor, env.revision}
 
-    if environment.revision == 0 then v = v * 10 end
+    -- Fallback to default config if targetVersion is not provided
+    if targetVersion == nil then 
+        if rfsuite and rfsuite.config and rfsuite.config.ethosVersion then
+            targetVersion = rfsuite.config.ethosVersion
+        else
+            -- Fail-safe: if no targetVersion is provided and config is missing
+            return false
+        end
+    elseif type(targetVersion) == "number" then
+        print("WARNING: utils.ethosVersionAtLeast() called with a number instead of a table (" .. targetVersion .. ")")
+        return false    
+    end
 
-    -- Check if v is a 3-digit number, and if so, multiply it by 10
-    if v < 1000 then v = v * 10 end
+    -- Ensure the targetVersion has three components (major, minor, revision)
+    for i = 1, 3 do
+        targetVersion[i] = targetVersion[i] or 0  -- Default to 0 if not provided
+    end
 
-    return v
+    -- Compare major, minor, and revision explicitly
+    for i = 1, 3 do
+        if currentVersion[i] > targetVersion[i] then
+            return true  -- Current version is higher
+        elseif currentVersion[i] < targetVersion[i] then
+            return false -- Current version is lower
+        end
+    end
+
+    return true  -- Versions are equal (>= condition met)
 end
 
-function utils.ethosVersionToMinorOld()
-    local environment = system.getVersion()
-    local v = tonumber(environment.major .. environment.minor)
-    return v
-end
+
 
 -- this function is only uised on init connect to verify presense of a link
 -- it should not be used once bgtasks are running
@@ -609,7 +620,7 @@ function utils.findModules()
     local modulesList = {}
 
     local moduledir = "app/modules/"
-    local modules_path = (rfsuite.utils.ethosVersionToMinorOld() >= 16) and moduledir or (config.suiteDir .. moduledir)
+    local modules_path = moduledir
 
     for _, v in pairs(system.listFiles(modules_path)) do
 
@@ -639,7 +650,7 @@ function utils.findWidgets()
     local widgetsList = {}
 
     local widgetdir = "widgets/"
-    local widgets_path = (rfsuite.utils.ethosVersionToMinorOld() >= 16) and widgetdir or (config.suiteDir .. widgetdir)
+    local widgets_path = widgetdir
 
     for _, v in pairs(system.listFiles(widgets_path)) do
 

--- a/scripts/rfsuite/lib/utils.lua
+++ b/scripts/rfsuite/lib/utils.lua
@@ -70,7 +70,7 @@ function utils.playFile(pkg, file)
     local wavLocale
     local wavDefault
 
-    if utils.ethosVersionToMinor() < 16 then
+    if utils.ethosVersionToMinorOld() < 16 then
         wavLocale = baseDir .. audioPath .. "/" .. pkg .. "/" .. file
         wavDefault = baseDir .. "/audio/en/default/" .. pkg .. "/" .. file
     else
@@ -89,7 +89,7 @@ end
 function utils.playFileCommon(file)
 
     local wav
-    if utils.ethosVersionToMinor() < 16 then
+    if utils.ethosVersionToMinorOld() < 16 then
         wav = rfsuite.config.suiteDir .. "/audio/" .. file
     else
         wav = "audio/" .. file
@@ -197,7 +197,7 @@ function utils.getCurrentProfile()
     end
 end
 
-function utils.ethosVersion()
+function utils.ethosVersionOld()
     local environment = system.getVersion()
     local v = tonumber(environment.major .. environment.minor .. environment.revision)
 
@@ -209,7 +209,7 @@ function utils.ethosVersion()
     return v
 end
 
-function utils.ethosVersionToMinor()
+function utils.ethosVersionToMinorOld()
     local environment = system.getVersion()
     local v = tonumber(environment.major .. environment.minor)
     return v
@@ -609,7 +609,7 @@ function utils.findModules()
     local modulesList = {}
 
     local moduledir = "app/modules/"
-    local modules_path = (rfsuite.utils.ethosVersionToMinor() >= 16) and moduledir or (config.suiteDir .. moduledir)
+    local modules_path = (rfsuite.utils.ethosVersionToMinorOld() >= 16) and moduledir or (config.suiteDir .. moduledir)
 
     for _, v in pairs(system.listFiles(modules_path)) do
 
@@ -639,7 +639,7 @@ function utils.findWidgets()
     local widgetsList = {}
 
     local widgetdir = "widgets/"
-    local widgets_path = (rfsuite.utils.ethosVersionToMinor() >= 16) and widgetdir or (config.suiteDir .. widgetdir)
+    local widgets_path = (rfsuite.utils.ethosVersionToMinorOld() >= 16) and widgetdir or (config.suiteDir .. widgetdir)
 
     for _, v in pairs(system.listFiles(widgets_path)) do
 

--- a/scripts/rfsuite/main.lua
+++ b/scripts/rfsuite/main.lua
@@ -23,12 +23,10 @@ local config = {}
 
 -- LuaFormatter off
 config.toolName = "Rotorflight"                                     -- name of the tool
-config.suiteDir = "/scripts/rfsuite/"                               -- base path the script is installed into
 config.icon = lcd.loadMask("app/gfx/icon.png")                      -- icon
 config.icon_logtool = lcd.loadMask("app/gfx/icon_logtool.png")      -- icon
-config.Version = "1.0.0"                                            -- version number of this software release
-config.ethosVersionOld = 1620                                          -- min version of ethos supported by this script
-config.ethosVersionOldString = "ETHOS < V1.6.2"                        -- string to print if ethos version error occurs
+config.Version = "1.0.0"                                            -- version number of this software replace
+config.ethosVersion = {1, 6, 2}                                     -- min version of ethos supported by this script                                                     
 config.defaultRateProfile = 4 -- ACTUAL                             -- default rate table [default = 4]
 config.supportedMspApiVersion = {"12.06", "12.07","12.08"}          -- supported msp versions
 config.simulatorApiVersionResponse = {0, 12, 8}                    -- version of api return by simulator
@@ -79,7 +77,14 @@ rfsuite.bg = assert(loadfile("tasks/bg.lua"))(config)
 
 -- LuaFormatter off
 
+
 local function init()
+
+    -- prevent this even getting close to running if version is not good
+    if not rfsuite.utils.ethosVersionAtLeast() then
+        error("Ethos version is not supported")
+        return
+    end
 
     -- function that most always been there and are not handled dynamically on init
     system.registerSystemTool({event = rfsuite.app.event, name = config.toolName, icon = config.icon, create = rfsuite.app.create, wakeup = rfsuite.app.wakeup, paint = rfsuite.app.paint, close = rfsuite.app.close})

--- a/scripts/rfsuite/main.lua
+++ b/scripts/rfsuite/main.lua
@@ -27,8 +27,8 @@ config.suiteDir = "/scripts/rfsuite/"                               -- base path
 config.icon = lcd.loadMask("app/gfx/icon.png")                      -- icon
 config.icon_logtool = lcd.loadMask("app/gfx/icon_logtool.png")      -- icon
 config.Version = "1.0.0"                                            -- version number of this software release
-config.ethosVersion = 1620                                          -- min version of ethos supported by this script
-config.ethosVersionString = "ETHOS < V1.6.2"                        -- string to print if ethos version error occurs
+config.ethosVersionOld = 1620                                          -- min version of ethos supported by this script
+config.ethosVersionOldString = "ETHOS < V1.6.2"                        -- string to print if ethos version error occurs
 config.defaultRateProfile = 4 -- ACTUAL                             -- default rate table [default = 4]
 config.supportedMspApiVersion = {"12.06", "12.07","12.08"}          -- supported msp versions
 config.simulatorApiVersionResponse = {0, 12, 8}                    -- version of api return by simulator

--- a/scripts/rfsuite/tasks/bg.lua
+++ b/scripts/rfsuite/tasks/bg.lua
@@ -46,7 +46,7 @@ if rfsuite.app.moduleList == nil then rfsuite.app.moduleList = rfsuite.utils.fin
 function bg.findTasks()
 
     local taskdir = "tasks"
-    local tasks_path = (rfsuite.utils.ethosVersionToMinor() >= 16) and "tasks/" or (config.suiteDir .. "/tasks/")
+    local tasks_path = (rfsuite.utils.ethosVersionToMinorOld() >= 16) and "tasks/" or (config.suiteDir .. "/tasks/")
 
     for _, v in pairs(system.listFiles(tasks_path)) do
 
@@ -83,7 +83,7 @@ function bg.flush_logs()
 
     if #bg.log_queue > 0 and rfsuite.bg.msp.mspQueue:isProcessed() then
         -- Determine the log file path based on the ethos version
-        local log_file_path = rfsuite.utils.ethosVersionToMinor() < 16 and config.suiteDir .. "/logs/rfsuite.log" or "logs/rfsuite.log"
+        local log_file_path = rfsuite.utils.ethosVersionToMinorOld() < 16 and config.suiteDir .. "/logs/rfsuite.log" or "logs/rfsuite.log"
 
         -- Attempt to open the log file once
         local f, err = io.open(log_file_path, 'a')
@@ -124,7 +124,7 @@ end
 function bg.wakeup()
 
     -- kill if version is bad
-    if rfsuite.utils.ethosVersion() < rfsuite.config.ethosVersion then return end
+    if rfsuite.utils.ethosVersionOld() < rfsuite.config.ethosVersionOld then return end
 
     -- initialise tasks
     if bg.init == false then

--- a/scripts/rfsuite/tasks/bg.lua
+++ b/scripts/rfsuite/tasks/bg.lua
@@ -46,7 +46,7 @@ if rfsuite.app.moduleList == nil then rfsuite.app.moduleList = rfsuite.utils.fin
 function bg.findTasks()
 
     local taskdir = "tasks"
-    local tasks_path = (rfsuite.utils.ethosVersionToMinorOld() >= 16) and "tasks/" or (config.suiteDir .. "/tasks/")
+    local tasks_path = "tasks/"
 
     for _, v in pairs(system.listFiles(tasks_path)) do
 
@@ -83,7 +83,7 @@ function bg.flush_logs()
 
     if #bg.log_queue > 0 and rfsuite.bg.msp.mspQueue:isProcessed() then
         -- Determine the log file path based on the ethos version
-        local log_file_path = rfsuite.utils.ethosVersionToMinorOld() < 16 and config.suiteDir .. "/logs/rfsuite.log" or "logs/rfsuite.log"
+        local log_file_path = "logs/rfsuite.log"
 
         -- Attempt to open the log file once
         local f, err = io.open(log_file_path, 'a')
@@ -124,7 +124,9 @@ end
 function bg.wakeup()
 
     -- kill if version is bad
-    if rfsuite.utils.ethosVersionOld() < rfsuite.config.ethosVersionOld then return end
+    if not rfsuite.utils.ethosVersionAtLeast() then
+        return
+    end
 
     -- initialise tasks
     if bg.init == false then

--- a/scripts/rfsuite/tasks/logging/logging.lua
+++ b/scripts/rfsuite/tasks/logging/logging.lua
@@ -75,7 +75,7 @@ end
 -- Update log directory based on model name
 local function checkLogdirExists()
     local logdir = "telemetry"
-    local logs_path = (rfsuite.utils.ethosVersionToMinorOld() >= 16) and "logs/" or (config.suiteDir .. "/logs/")
+    local logs_path = "logs/" 
 
     if not dir_exists(logs_path, logdir) then os.mkdir(logs_path .. logdir) end
 end
@@ -90,7 +90,7 @@ function logging.flushLogs(forceFlush)
     local max_lines_per_flush = forceFlush or not rfsuite.bg.telemetry.active() and 1 or 10
 
     if #log_queue > 0 and rfsuite.bg.msp.mspQueue:isProcessed() then
-        local filePath = (rfsuite.utils.ethosVersionToMinorOld() < 16) and (config.suiteDir .. "/logs/telemetry/" .. logFileName) or ("logs/telemetry/" .. logFileName)
+        local filePath = "logs/telemetry/" .. logFileName
 
         local f = io.open(filePath, 'a')
         for i = 1, math.min(#log_queue, max_lines_per_flush) do io.write(f, table.remove(log_queue, 1) .. "\n") end

--- a/scripts/rfsuite/tasks/logging/logging.lua
+++ b/scripts/rfsuite/tasks/logging/logging.lua
@@ -75,7 +75,7 @@ end
 -- Update log directory based on model name
 local function checkLogdirExists()
     local logdir = "telemetry"
-    local logs_path = (rfsuite.utils.ethosVersionToMinor() >= 16) and "logs/" or (config.suiteDir .. "/logs/")
+    local logs_path = (rfsuite.utils.ethosVersionToMinorOld() >= 16) and "logs/" or (config.suiteDir .. "/logs/")
 
     if not dir_exists(logs_path, logdir) then os.mkdir(logs_path .. logdir) end
 end
@@ -90,7 +90,7 @@ function logging.flushLogs(forceFlush)
     local max_lines_per_flush = forceFlush or not rfsuite.bg.telemetry.active() and 1 or 10
 
     if #log_queue > 0 and rfsuite.bg.msp.mspQueue:isProcessed() then
-        local filePath = (rfsuite.utils.ethosVersionToMinor() < 16) and (config.suiteDir .. "/logs/telemetry/" .. logFileName) or ("logs/telemetry/" .. logFileName)
+        local filePath = (rfsuite.utils.ethosVersionToMinorOld() < 16) and (config.suiteDir .. "/logs/telemetry/" .. logFileName) or ("logs/telemetry/" .. logFileName)
 
         local f = io.open(filePath, 'a')
         for i = 1, math.min(#log_queue, max_lines_per_flush) do io.write(f, table.remove(log_queue, 1) .. "\n") end

--- a/scripts/rfsuite/tasks/msp/api.lua
+++ b/scripts/rfsuite/tasks/msp/api.lua
@@ -26,7 +26,7 @@ local apiCache = {}
 
 -- Define the API directory path based on the ethos version
 local apidir = "tasks/msp/api/"
-local api_path = (rfsuite.utils.ethosVersionToMinorOld() >= 16) and apidir or (config.suiteDir .. apidir)
+local api_path = apidir
 local active_api_name -- variable to store the api name in use
 local validate_structure = true
 

--- a/scripts/rfsuite/tasks/msp/api.lua
+++ b/scripts/rfsuite/tasks/msp/api.lua
@@ -26,7 +26,7 @@ local apiCache = {}
 
 -- Define the API directory path based on the ethos version
 local apidir = "tasks/msp/api/"
-local api_path = (rfsuite.utils.ethosVersionToMinor() >= 16) and apidir or (config.suiteDir .. apidir)
+local api_path = (rfsuite.utils.ethosVersionToMinorOld() >= 16) and apidir or (config.suiteDir .. apidir)
 local active_api_name -- variable to store the api name in use
 local validate_structure = true
 

--- a/scripts/rfsuite/widgets/craftimage/craftimage.lua
+++ b/scripts/rfsuite/widgets/craftimage/craftimage.lua
@@ -56,8 +56,8 @@ function rf2craftimage.paint(widget)
     local w = LCD_W
     local h = LCD_H
 
-    if rfsuite.utils.ethosVersion() < rfsuite.config.ethosVersion then
-        screenError(rfsuite.config.ethosVersionString)
+    if rfsuite.utils.ethosVersionOld() < rfsuite.config.ethosVersionOld then
+        screenError(rfsuite.config.ethosVersionOldString)
         return
     end
 

--- a/scripts/rfsuite/widgets/craftimage/craftimage.lua
+++ b/scripts/rfsuite/widgets/craftimage/craftimage.lua
@@ -56,8 +56,12 @@ function rf2craftimage.paint(widget)
     local w = LCD_W
     local h = LCD_H
 
-    if rfsuite.utils.ethosVersionOld() < rfsuite.config.ethosVersionOld then
-        screenError(rfsuite.config.ethosVersionOldString)
+    if not rfsuite.utils.ethosVersionAtLeast() then
+        status.screenError(string.format("ETHOS < V%d.%d.%d", 
+            rfsuite.config.ethosVersion[1], 
+            rfsuite.config.ethosVersion[2], 
+            rfsuite.config.ethosVersion[3])
+        )
         return
     end
 

--- a/scripts/rfsuite/widgets/craftname/craftname.lua
+++ b/scripts/rfsuite/widgets/craftname/craftname.lua
@@ -55,8 +55,8 @@ end
 -- Paint function
 function rf2craftname.paint(widget)
 
-    if rfsuite.utils.ethosVersion() < rfsuite.config.ethosVersion then
-        screenError(rfsuite.config.ethosVersionString)
+    if rfsuite.utils.ethosVersionOld() < rfsuite.config.ethosVersionOld then
+        screenError(rfsuite.config.ethosVersionOldString)
         return
     end
 

--- a/scripts/rfsuite/widgets/craftname/craftname.lua
+++ b/scripts/rfsuite/widgets/craftname/craftname.lua
@@ -55,8 +55,12 @@ end
 -- Paint function
 function rf2craftname.paint(widget)
 
-    if rfsuite.utils.ethosVersionOld() < rfsuite.config.ethosVersionOld then
-        screenError(rfsuite.config.ethosVersionOldString)
+    if not rfsuite.utils.ethosVersionAtLeast() then
+        status.screenError(string.format("ETHOS < V%d.%d.%d", 
+            rfsuite.config.ethosVersion[1], 
+            rfsuite.config.ethosVersion[2], 
+            rfsuite.config.ethosVersion[3])
+        )
         return
     end
 

--- a/scripts/rfsuite/widgets/governor/governor.lua
+++ b/scripts/rfsuite/widgets/governor/governor.lua
@@ -54,8 +54,12 @@ end
 
 function rf2gov.paint(widget)
 
-    if rfsuite.utils.ethosVersionOld() < rfsuite.config.ethosVersionOld then
-        screenError(rfsuite.config.ethosVersionOldString)
+    if not rfsuite.utils.ethosVersionAtLeast() then
+        status.screenError(string.format("ETHOS < V%d.%d.%d", 
+            rfsuite.config.ethosVersion[1], 
+            rfsuite.config.ethosVersion[2], 
+            rfsuite.config.ethosVersion[3])
+        )
         return
     end
 

--- a/scripts/rfsuite/widgets/governor/governor.lua
+++ b/scripts/rfsuite/widgets/governor/governor.lua
@@ -54,8 +54,8 @@ end
 
 function rf2gov.paint(widget)
 
-    if rfsuite.utils.ethosVersion() < rfsuite.config.ethosVersion then
-        screenError(rfsuite.config.ethosVersionString)
+    if rfsuite.utils.ethosVersionOld() < rfsuite.config.ethosVersionOld then
+        screenError(rfsuite.config.ethosVersionOldString)
         return
     end
 

--- a/scripts/rfsuite/widgets/status/status.lua
+++ b/scripts/rfsuite/widgets/status/status.lua
@@ -276,11 +276,6 @@ function status.create(widget)
     status.lastBitmap = model.bitmap()
     default_image = lcd.loadBitmap(model.bitmap()) or rfsuite.utils.loadImage("widgets/status/default_image.png") or nil
 
-    if rfsuite.utils.ethosVersionOld() < rfsuite.config.ethosVersionOld then
-        status.screenError(rfsuite.config.ethosVersionOldString)
-        return
-    end
-
     return {
         fmsrc = 0,
         btype = 0,
@@ -1308,7 +1303,14 @@ end
 
 function status.paint(widget)
 
-    if not rfsuite.bg.active() then
+    if not rfsuite.utils.ethosVersionAtLeast() then
+        status.screenError(string.format("ETHOS < V%d.%d.%d", 
+            rfsuite.config.ethosVersion[1], 
+            rfsuite.config.ethosVersion[2], 
+            rfsuite.config.ethosVersion[3])
+        )
+        return
+    elseif not rfsuite.bg.active() then
 
         if (os.clock() - status.initTime) >= 2 then status.screenError("PLEASE ENABLE THE BACKGROUND TASK") end
         lcd.invalidate()

--- a/scripts/rfsuite/widgets/status/status.lua
+++ b/scripts/rfsuite/widgets/status/status.lua
@@ -276,8 +276,8 @@ function status.create(widget)
     status.lastBitmap = model.bitmap()
     default_image = lcd.loadBitmap(model.bitmap()) or rfsuite.utils.loadImage("widgets/status/default_image.png") or nil
 
-    if rfsuite.utils.ethosVersion() < rfsuite.config.ethosVersion then
-        status.screenError(rfsuite.config.ethosVersionString)
+    if rfsuite.utils.ethosVersionOld() < rfsuite.config.ethosVersionOld then
+        status.screenError(rfsuite.config.ethosVersionOldString)
         return
     end
 


### PR DESCRIPTION
Dropping legacy support means that we can cleanup a ton of conditionals to handle older file pathing.

While doing this update I have improved version checking:

I now explicitly check agains major,minor,revision to do a check.