### PR TITLE
Mandatory Fields and Form Disabling

### DIFF
--- a/scripts/rfsuite/app/app.lua
+++ b/scripts/rfsuite/app/app.lua
@@ -409,6 +409,11 @@ function app.mspApiUpdateFormAttributes(values, structure)
                             rfsuite.app.Page.fields[i].value = values[mspapiNAME][apikey] / scale
                         end
 
+                        if values[mspapiNAME][apikey] == nil then
+                            rfsuite.utils.log("API field value is nil: " .. mspapiNAME .. " " .. apikey, "info")
+                            formField:enable(false)
+                        end
+
                         break -- Found field, can move on
                     end
                 end

--- a/scripts/rfsuite/app/lib/ui.lua
+++ b/scripts/rfsuite/app/lib/ui.lua
@@ -400,7 +400,6 @@ function ui.fieldNumber(i)
         posText  = p.posText
         posField = p.posField
         form.addStaticText(formLines[rfsuite.session.formLineCnt], posText, f.t)
-        rfsuite.utils.log("Adding inline text: " .. f.t .. " to line " .. rfsuite.session.formLineCnt, "info")
     else
         if f.t then
             if f.label then
@@ -411,7 +410,6 @@ function ui.fieldNumber(i)
         end
 
         rfsuite.session.formLineCnt = rfsuite.session.formLineCnt + 1
-        rfsuite.utils.log("Adding line: " .. f.t .. " id " .. rfsuite.session.formLineCnt, "info")
         formLines[rfsuite.session.formLineCnt] = form.addLine(f.t)
         posField = f.position or nil
     end

--- a/scripts/rfsuite/app/lib/utils.lua
+++ b/scripts/rfsuite/app/lib/utils.lua
@@ -150,3 +150,4 @@ function utils.getInlineSize(id, lPage)
 end
 
 return utils
+

--- a/scripts/rfsuite/tasks/msp/api.lua
+++ b/scripts/rfsuite/tasks/msp/api.lua
@@ -252,20 +252,17 @@ function apiLoader.calculateMinBytes(structure)
 
     for _, param in ipairs(structure) do
         local insert_param = false
-
+    
         -- API version check logic
         if not param.apiVersion or (apiVersion and apiVersion >= param.apiVersion) then
             insert_param = true
         end
-
-        if insert_param then
+    
+        -- Mandatory check
+        if insert_param and (param.mandatory ~= false) then
             totalBytes = totalBytes + get_type_size(param.type)
         end
     end
-
-    -- Subtract 4 bytes to allow for overlap times when developnent is in progress
-    -- essentialy this allows a margin in which dev fbl firmware can be tested
-    totalBytes = totalBytes - 4
 
     return totalBytes
 end

--- a/scripts/rfsuite/tasks/msp/api.lua
+++ b/scripts/rfsuite/tasks/msp/api.lua
@@ -263,9 +263,9 @@ function apiLoader.calculateMinBytes(structure)
         end
     end
 
-    -- Subtract 2 bytes to allow for overlap times when developnent is in progress
+    -- Subtract 4 bytes to allow for overlap times when developnent is in progress
     -- essentialy this allows a margin in which dev fbl firmware can be tested
-    totalBytes = totalBytes - 2
+    totalBytes = totalBytes - 4
 
     return totalBytes
 end

--- a/scripts/rfsuite/tasks/msp/api/ESC_SENSOR_CONFIG.lua
+++ b/scripts/rfsuite/tasks/msp/api/ESC_SENSOR_CONFIG.lua
@@ -25,16 +25,16 @@ local MSP_API_CMD_WRITE = 216 -- Command identifier for saving Mixer Config Sett
 local escTypes = {"NONE","BLHELI32", "HOBBYWING V4", "HOBBYWING V5", "SCORPION", "KONTRONIK", "OMPHOBBY", "ZTW", "APD", "APD", "OPENYGE", "FLYROTOR", "GRAUPNER", "XDFLY","RECORD"}
 local onOff = {"OFF","ON"}
 local MSP_API_STRUCTURE_READ_DATA = {
-    {field = "protocol",                     type = "U8",  apiVersion = 12.06, simResponse = {0},     table = escTypes, tableIdxInc= -1},
-    {field = "half_duplex",                  type = "U8",  apiVersion = 12.06, simResponse = {0},     default = 0, min= 1, max = 2, table = onOff, tableIdxInc = -1, help="Half duplex mode for ESC telemetry"},
-    {field = "update_hz",                    type = "U16", apiVersion = 12.06, simResponse = {200, 0}, default = 200, min = 10, max = 500, unit = "Hz", help="ESC telemetry update rate"},
-    {field = "current_offset",               type = "U16", apiVersion = 12.06, simResponse = {0, 15}, min = 0, max = 1000, default = 0, help="Current sensor offset adjustment"}, -- I am not convinced that this offset is used anywhere as the 0,15 translates to 32769
-    {field = "hw4_current_offset",           type = "U16", apiVersion = 12.06, simResponse = {0, 0},  min = 0, max = 1000, default = 0, help="Hobbywing v4 current offset adjustment"},
-    {field = "hw4_current_gain",             type = "U8",  apiVersion = 12.06, simResponse = {0},     min = 0, max = 250, default = 0,  help="Hobbywing v4 current gain adjustment"},
-    {field = "hw4_voltage_gain",             type = "U8",  apiVersion = 12.06, simResponse = {30},    min = 0, max = 250,  default = 30, help="Hobbywing v4 voltage gain adjustment"},
-    {field = "pin_swap",                     type = "U8",  apiVersion = 12.07, simResponse = {0},     table = onOff, tableIdxInc = -1, help="Swap the TX and RX pins for the ESC telemetry"},
-    {field = "current_correction_factor",    type = "U16", apiVersion = 12.08, simResponse = {100, 0}, scale=100, decimals=1, default = 1, min = 0, max = 100, help = "Adjust the current sensor reading to match the actual current draw. 1.0 and lower will reduce the gain.  1.0 and higher will increase the gain."},
-    {field = "consumption_correction_factor",type = "U16", apiVersion = 12.08, simResponse = {100, 0}, scale=100, decimals=1, default = 1, min = 0, max = 100, help = "Adjust the consumption sensor reading to match the actual consumption. 1.0 and lower will reduce the gain.  1.0 and higher will increase the gain."},
+    {field = "protocol",                                       type = "U8",  apiVersion = 12.06, simResponse = {0},     table = escTypes, tableIdxInc= -1},
+    {field = "half_duplex",                                     type = "U8",  apiVersion = 12.06, simResponse = {0},     default = 0, min= 1, max = 2, table = onOff, tableIdxInc = -1, help="Half duplex mode for ESC telemetry"},
+    {field = "update_hz",                                       type = "U16", apiVersion = 12.06, simResponse = {200, 0}, default = 200, min = 10, max = 500, unit = "Hz", help="ESC telemetry update rate"},
+    {field = "current_offset",                                  type = "U16", apiVersion = 12.06, simResponse = {0, 15}, min = 0, max = 1000, default = 0, help="Current sensor offset adjustment"}, -- I am not convinced that this offset is used anywhere as the 0,15 translates to 32769
+    {field = "hw4_current_offset",                              type = "U16", apiVersion = 12.06, simResponse = {0, 0},  min = 0, max = 1000, default = 0, help="Hobbywing v4 current offset adjustment"},
+    {field = "hw4_current_gain",                                type = "U8",  apiVersion = 12.06, simResponse = {0},     min = 0, max = 250, default = 0,  help="Hobbywing v4 current gain adjustment"},
+    {field = "hw4_voltage_gain",                                type = "U8",  apiVersion = 12.06, simResponse = {30},    min = 0, max = 250,  default = 30, help="Hobbywing v4 voltage gain adjustment"},
+    {field = "pin_swap",                                        type = "U8",  apiVersion = 12.07, simResponse = {0},     table = onOff, tableIdxInc = -1, help="Swap the TX and RX pins for the ESC telemetry"},
+    {field = "current_correction_factor",    mandatory = false, type = "U16", apiVersion = 12.08, simResponse = {100, 0}, scale=100, decimals=1, default = 1, min = 0, max = 100, help = "Adjust the current sensor reading to match the actual current draw. 1.0 and lower will reduce the gain.  1.0 and higher will increase the gain."},
+    {field = "consumption_correction_factor",mandatory = false, type = "U16", apiVersion = 12.08, simResponse = {100, 0}, scale=100, decimals=1, default = 1, min = 0, max = 100, help = "Adjust the consumption sensor reading to match the actual consumption. 1.0 and lower will reduce the gain.  1.0 and higher will increase the gain."},
 }
 
 -- filter the structure to remove any params not supported by the running api version

--- a/scripts/rfsuite/tasks/msp/api/NAME.lua
+++ b/scripts/rfsuite/tasks/msp/api/NAME.lua
@@ -22,7 +22,7 @@ local MSP_MIN_BYTES = 0
 
 -- Define the MSP response data structures
 local MSP_API_STRUCTURE_READ_DATA = {
-    { field = "name", type = "U8", apiVersion = 12.06, simResponse = {80, 105, 108, 111, 116}}
+    { field = "name", mandatory = false, type = "U8", apiVersion = 12.06, simResponse = {80, 105, 108, 111, 116}}
 }
 
 -- filter the structure to remove any params not supported by the running api version


### PR DESCRIPTION
Added in protocol option 

mandatory == false

this allows 'new' msp data to be added while firmware testing underway; and still passing minbytes checks

if a value received via msp is 'nil' then the field on the form is disabled.