### PR TITLE
Added ESC1 Status, ESC1 & ESC2 Model ID sensors to FrSky telemetry

### DIFF
--- a/scripts/rfsuite/tasks/sensors/frsky.lua
+++ b/scripts/rfsuite/tasks/sensors/frsky.lua
@@ -59,7 +59,10 @@ createSensorList[0x51A4] = {name = "Throttle %", unit = UNIT_PERCENT, decimals =
 createSensorList[0x5258] = {name = "ESC1 Capacity", unit = UNIT_MILLIAMPERE_HOUR}
 createSensorList[0x5268] = {name = "ESC1 Power", unit = UNIT_PERCENT}
 createSensorList[0x5269] = {name = "ESC1 Throttle", unit = UNIT_PERCENT}
+createSensorList[0x512A] = {name = "ESC1 Status", unit = UNIT_RAW}
+createSensorList[0x512B] = {name = "ESC1 Model ID", unit = UNIT_RAW}
 createSensorList[0x525A] = {name = "ESC2 Capacity", unit = UNIT_MILLIAMPERE_HOUR}
+createSensorList[0x512C] = {name = "ESC2 Model ID", unit = UNIT_RAW}
 createSensorList[0x51D0] = {name = "CPU Load", unit = UNIT_PERCENT}
 createSensorList[0x51D1] = {name = "System Load", unit = UNIT_PERCENT}
 createSensorList[0x51D2] = {name = "RT Load", unit = UNIT_PERCENT}


### PR DESCRIPTION
Included ESC1 Status, ESC1 & ESC2 Model ID sensors in FrSky telemetry stream for support of ESC status widget equal to ELRS

Related PRs...
- https://github.com/rotorflight/rotorflight-firmware/pull/261
- https://github.com/rotorflight/rotorflight-configurator/pull/270

e.g.
![image](https://github.com/user-attachments/assets/27ae77b7-7f05-4a1a-9dd4-adfee49c1ddf)
![image](https://github.com/user-attachments/assets/eb756157-c3bf-4616-8fd2-11d903c73529)
