### PR TITLE
Added missing sensors to frsky legacy (2.1.1) and set esc / motor poll count step to 2

### DIFF
--- a/scripts/rfsuite/app/modules/esc_motors/esc_motors.lua
+++ b/scripts/rfsuite/app/modules/esc_motors/esc_motors.lua
@@ -16,7 +16,7 @@ local mspapi = {
             {t = "Main",                              api = "MOTOR_CONFIG:main_rotor_gear_ratio_1",       label = 1, inline = 1},
             {t = "Rear",                              api = "MOTOR_CONFIG:tail_rotor_gear_ratio_0",       label = 2, inline = 2},
             {t = "Front",                             api = "MOTOR_CONFIG:tail_rotor_gear_ratio_1",       label = 2, inline = 1},
-            {t = "Motor Pole Count",                  api = "MOTOR_CONFIG:motor_pole_count_0"},
+            {t = "Motor Pole Count",                  api = "MOTOR_CONFIG:motor_pole_count_0",            step = 2},
             {t = "0% Throttle PWM Value",             api = "MOTOR_CONFIG:minthrottle"},
             {t = "100% Throttle PWM value",           api = "MOTOR_CONFIG:maxthrottle"},
             {t = "Motor Stop PWM Value",              api = "MOTOR_CONFIG:mincommand"},

--- a/scripts/rfsuite/tasks/sensors/frsky_legacy.lua
+++ b/scripts/rfsuite/tasks/sensors/frsky_legacy.lua
@@ -77,6 +77,10 @@ createSensorList[0x5472] = {name = "Rate Profile", unit = UNIT_RAW}
 createSensorList[0x5440] = {name = "Throttle %", unit = UNIT_PERCENT}
 createSensorList[0x5250] = {name = "Consumption", unit = UNIT_MILLIAMPERE_HOUR}
 createSensorList[0x5462] = {name = "Arming Flags", unit = UNIT_RAW}
+createSensorList[0x5463] = {name = "Arming Disable", unit = UNIT_RAW}
+createSensorList[0x5464] = {name = "Cell Count", unit = UNIT_RAW}
+createSensorList[0x5465] = {name = "ESC1 Status", unit = UNIT_RAW}
+createSensorList[0x5466] = {name = "ESC1 Model ID", unit = UNIT_RAW}
 
 -- drop
 local dropSensorList = {}


### PR DESCRIPTION
- Included arming-disable, cell-count, esc-status and esc-model to s.port frsky_legacy telemetry stream for 2.1.x FC's
We'll be putting this version of rfsuite into use w/ rf007's w/ RF 2.1.1 until 2.2 is ready
Note: the names mirror the ELRS names as pre 2.2 FrSky names and appids are different anyway

- motor poll count can never be an odd number, 'step' set to 2 for this field to make entry easier