### PR TITLE
Focus Cycling - to garuantee form update

### DIFF
--- a/scripts/rfsuite/app/app.lua
+++ b/scripts/rfsuite/app/app.lua
@@ -631,6 +631,9 @@ function app.mspApiUpdateFormAttributes(values, structure)
     end
     collectgarbage()
     rfsuite.utils.reportMemoryUsage("app.mspApiUpdateFormAttributes")
+
+    -- set focus back to menu
+    rfsuite.app.formNavigationFields['menu']:focus(true)
 end
 
 
@@ -958,7 +961,7 @@ function app.wakeupUI()
     -- close progress loader.  this essentially just accelerates 
     -- the close of the progress bar once the data is loaded.
     -- so if not yet at 100%.. it says.. move there quickly
-    if app.triggers.closeProgressLoader == true then
+    if app.triggers.closeProgressLoader == true  then
         if app.dialogs.progressCounter >= 90 then
             app.dialogs.progressCounter = app.dialogs.progressCounter + 0.5
             if app.dialogs.progress ~= nil then app.ui.progressDisplayValue(app.dialogs.progressCounter) end
@@ -967,7 +970,7 @@ function app.wakeupUI()
             if app.dialogs.progress ~= nil then app.ui.progressDisplayValue(app.dialogs.progressCounter) end
         end
 
-        if app.dialogs.progressCounter >= 101 then
+        if app.dialogs.progressCounter >= 101 and rfsuite.tasks.msp.mspQueue:isProcessed() then
             app.dialogs.progressWatchDog = nil
             app.dialogs.progressDisplay = false
             if app.dialogs.progress ~= nil then app.ui.progressDisplayClose() end

--- a/scripts/rfsuite/app/lib/ui.lua
+++ b/scripts/rfsuite/app/lib/ui.lua
@@ -1319,6 +1319,9 @@ function ui.injectApiAttributes(formField, f, v)
         formField:help(v.help)
     end  
 
+    -- force focus to ensure field updates
+    formField:focus(true)
+
 end
 
 

--- a/scripts/rfsuite/app/modules/esc_tools/esc_tool.lua
+++ b/scripts/rfsuite/app/modules/esc_tools/esc_tool.lua
@@ -242,7 +242,7 @@ local function openPage(pidx, title, script)
     end
 
     rfsuite.app.triggers.escToolEnableButtons = false
-    getESCDetails()
+    --getESCDetails()
     collectgarbage()
 end
 


### PR DESCRIPTION
Discovered an issue on flyrotor where if timing on msp call coming is is slightly out of sync with dialog close; the form field would not update.

So I now 'cycle focus' through each form element; then set back to menu.

This forces ethos to update the form