### PR TITLE
ELRS Reset on sensor delete

### DIFF
--- a/scripts/rfsuite/tasks/tasks.lua
+++ b/scripts/rfsuite/tasks/tasks.lua
@@ -252,6 +252,13 @@ function tasks.wakeup()
         end
     end
 
+    -- in the event we delete the sensors - then we need on elrs to force a full reset
+    -- if we dont do this; elrs custom telem gets into a proper mess
+    if elrsSensor and not system.getSource("Rx RSSI1") then
+            rfsuite.session.resetSensors = true
+            return
+    end
+
     for _, task in ipairs(tasksList) do
         if now - task.last_run >= task.interval then
             if tasks[task.name].wakeup then


### PR DESCRIPTION
Elrs custom telem does not like sensors being nuked and recreated.

This mod makes the system 'reset' its state when that event happens