### PR TITLE
Section checks - depending on msp version

### DIFF
--- a/scripts/rfsuite/app/modules/esc_tools/esc_tool.lua
+++ b/scripts/rfsuite/app/modules/esc_tools/esc_tool.lua
@@ -195,7 +195,14 @@ local function openPage(pidx, title, script)
 
     for pidx, pvalue in ipairs(ESC.pages) do 
 
-        if not pvalue.disablebutton or (pvalue and pvalue.disablebutton(mspBytes) == false) then
+
+        local section = pvalue
+        local hideSection = (section.ethosversion and rfsuite.session.ethosRunningVersion < section.ethosversion) or
+                            (section.mspversion and (rfsuite.session.apiVersion or 1) < section.mspversion) 
+                            --or
+                            --(section.developer and not rfsuite.config.developerMode)
+
+        if not pvalue.disablebutton or (pvalue and pvalue.disablebutton(mspBytes) == false) or not hideSection then
 
             if lc == 0 then
                 if rfsuite.preferences.iconSize == 0 then y = form.height() + rfsuite.app.radio.buttonPaddingSmall end

--- a/scripts/rfsuite/app/modules/esc_tools/mfg/flrtr/pages.lua
+++ b/scripts/rfsuite/app/modules/esc_tools/mfg/flrtr/pages.lua
@@ -15,6 +15,6 @@ end
 PageFiles[#PageFiles + 1] = {title = rfsuite.i18n.get("app.modules.esc_tools.mfg.flrtr.basic"), script = "esc_basic.lua", image = "basic.png"}
 PageFiles[#PageFiles + 1] = {title = rfsuite.i18n.get("app.modules.esc_tools.mfg.flrtr.advanced"), script = "esc_advanced.lua", image = "advanced.png"}
 PageFiles[#PageFiles + 1] = {title = rfsuite.i18n.get("app.modules.esc_tools.mfg.flrtr.governor"), script = "esc_governor.lua", image = "governor.png"}
-PageFiles[#PageFiles + 1] = {title = rfsuite.i18n.get("app.modules.esc_tools.mfg.flrtr.other"), script = "esc_other.lua", image = "other.png", disablebutton = function(param) return disablebutton(#PageFiles,param) end}
+PageFiles[#PageFiles + 1] = {title = rfsuite.i18n.get("app.modules.esc_tools.mfg.flrtr.other"), script = "esc_other.lua", image = "other.png", disablebutton = function(param) return disablebutton(#PageFiles,param) end, mspversion = 12.08}
 
 return PageFiles

--- a/scripts/rfsuite/app/modules/esc_tools/mfg/flrtr/pages/esc_other.lua
+++ b/scripts/rfsuite/app/modules/esc_tools/mfg/flrtr/pages/esc_other.lua
@@ -15,12 +15,12 @@ local mspapi = {
         labels = {
         },
         fields = {
-            { t = rfsuite.i18n.get("app.modules.esc_tools.mfg.flrtr.throttle_protocol"),  mspapi = 1, apikey = "throttle_protocol",  type = 1,        mspapigt = 12.08 },
-            { t = rfsuite.i18n.get("app.modules.esc_tools.mfg.flrtr.telemetry_protocol"), mspapi = 1, apikey = "telemetry_protocol", type = 1,        mspapigt = 12.08 },
-            { t = rfsuite.i18n.get("app.modules.esc_tools.mfg.flrtr.led_color"),          mspapi = 1, apikey = "led_color_index",    type = 1,        mspapigt = 12.08 },
-            { t = rfsuite.i18n.get("app.modules.esc_tools.mfg.flrtr.motor_temp_sensor"),  mspapi = 1, apikey = "motor_temp_sensor",  type = 1,        mspapigt = 12.08 },
-            { t = rfsuite.i18n.get("app.modules.esc_tools.mfg.flrtr.motor_temp"),         mspapi = 1, apikey = "motor_temp",         mspapigt = 12.08 },
-            { t = rfsuite.i18n.get("app.modules.esc_tools.mfg.flrtr.battery_capacity"),   mspapi = 1, apikey = "battery_capacity",   mspapigt = 12.08 },
+            { t = rfsuite.i18n.get("app.modules.esc_tools.mfg.flrtr.throttle_protocol"),  mspapi = 1, apikey = "throttle_protocol",  type = 1,        apiversiongte = 12.08 },
+            { t = rfsuite.i18n.get("app.modules.esc_tools.mfg.flrtr.telemetry_protocol"), mspapi = 1, apikey = "telemetry_protocol", type = 1,        apiversiongte = 12.08 },
+            { t = rfsuite.i18n.get("app.modules.esc_tools.mfg.flrtr.led_color"),          mspapi = 1, apikey = "led_color_index",    type = 1,        apiversiongte = 12.08 },
+            { t = rfsuite.i18n.get("app.modules.esc_tools.mfg.flrtr.motor_temp_sensor"),  mspapi = 1, apikey = "motor_temp_sensor",  type = 1,        apiversiongte = 12.08 },
+            { t = rfsuite.i18n.get("app.modules.esc_tools.mfg.flrtr.motor_temp"),         mspapi = 1, apikey = "motor_temp",         apiversiongte = 12.08 },
+            { t = rfsuite.i18n.get("app.modules.esc_tools.mfg.flrtr.battery_capacity"),   mspapi = 1, apikey = "battery_capacity",   apiversiongte = 12.08 },
         }
     }
 }


### PR DESCRIPTION
Some general check to disable sections not meant to be visible if msp for rf2.1