### PR TITLE
ESC Consumptions factors should not go lower than 99%

### DIFF
--- a/scripts/rfsuite/tasks/msp/api/ESC_SENSOR_CONFIG.lua
+++ b/scripts/rfsuite/tasks/msp/api/ESC_SENSOR_CONFIG.lua
@@ -34,9 +34,9 @@ local MSP_API_STRUCTURE_READ_DATA = {
     {field = "hw4_current_gain",                                type = "U8",  apiVersion = 12.06, simResponse = {0},     min = 0, max = 250, default = 0},
     {field = "hw4_voltage_gain",                                type = "U8",  apiVersion = 12.06, simResponse = {30},    min = 0, max = 250,  default = 30},
     {field = "pin_swap",                                        type = "U8",  apiVersion = 12.07, simResponse = {0},     table = onOff, tableIdxInc = -1},
-    {field = "voltage_correction",           mandatory = false, type = "S8",  apiVersion = 12.08, simResponse = {0},     unit = "%", default = 1, min = -100, max = 125},
-    {field = "current_correction",           mandatory = false, type = "S8",  apiVersion = 12.08, simResponse = {0},     unit = "%", default = 1, min = -100, max = 125},
-    {field = "consumption_correction",       mandatory = false, type = "S8",  apiVersion = 12.08, simResponse = {0},     unit = "%", default = 1, min = -100, max = 125},
+    {field = "voltage_correction",           mandatory = false, type = "S8",  apiVersion = 12.08, simResponse = {0},     unit = "%", default = 1, min = -99, max = 125},
+    {field = "current_correction",           mandatory = false, type = "S8",  apiVersion = 12.08, simResponse = {0},     unit = "%", default = 1, min = -99, max = 125},
+    {field = "consumption_correction",       mandatory = false, type = "S8",  apiVersion = 12.08, simResponse = {0},     unit = "%", default = 1, min = -99, max = 125},
 }
 
 -- Process structure in one pass


### PR DESCRIPTION
Running consumption factor at -100% results in no changes.

(consumption * (100 + escSensorConfig()->consumption_correction)) / 100;

Its a maths thing!

Adjust to -99% max to avoid issue.