### PR TITLE
Fuel Sensor Updates

### DIFF
--- a/bin/sensors/gui/sensors.xml
+++ b/bin/sensors/gui/sensors.xml
@@ -22,7 +22,7 @@
         <Sensor name="voltage" label="Main Voltage" type="range" min="0" max="25.2" rand="5" multiplier="100" unit="V" default="24.2" />
         <Sensor name="bec_voltage" label="BEC Voltage" type="range" rand="5" min="4.0" max="8.0" multiplier="100" unit="V" default="8.0" />
         <Sensor name="current" label="Current" type="range" rand="5" min="0" max="200" multiplier="1" unit="A" />
-        <Sensor name="fuel" label="Fuel" round="true" type="range" default="85" min="0" max="100" rand="1" multiplier="1" unit="%" />
+        <Sensor name="consumption" label="Consumption" round="true" type="range" default="0" min="0" max="5000" rand="0" multiplier="1" unit="mAh" />
     </Group>
 
     <Group name="Flight Profiles">

--- a/scripts/rfsuite/main.lua
+++ b/scripts/rfsuite/main.lua
@@ -230,6 +230,7 @@ rfsuite.session.batteryConfig = nil
     -- vbatwarningcellvoltage = nil
     -- vbatmincellvoltage = nil
     -- vbatmaxcellvoltage = nil
+    -- vbatfullcellvoltage = nil
     -- lvcPercentage = nil
     -- consumptionWarningPercentage = nil
 rfsuite.session.modelPreferences = nil -- this is used to store the model preferences

--- a/scripts/rfsuite/sim/sensors/consumption.lua
+++ b/scripts/rfsuite/sim/sensors/consumption.lua
@@ -1,1 +1,1 @@
-return 2000
+return 0

--- a/scripts/rfsuite/tasks/onconnect/tasks/medium/battery.lua
+++ b/scripts/rfsuite/tasks/onconnect/tasks/medium/battery.lua
@@ -32,6 +32,7 @@ function battery.wakeup()
             local vbatwarningcellvoltage = API.readValue("vbatwarningcellvoltage")/100
             local vbatmincellvoltage = API.readValue("vbatmincellvoltage")/100
             local vbatmaxcellvoltage = API.readValue("vbatmaxcellvoltage")/100
+            local vbatfullcellvoltage = API.readValue("vbatfullcellvoltage")/100
             local lvcPercentage = API.readValue("lvcPercentage")
             local consumptionWarningPercentage = API.readValue("consumptionWarningPercentage")
 
@@ -41,6 +42,7 @@ function battery.wakeup()
             rfsuite.session.batteryConfig.vbatwarningcellvoltage = vbatwarningcellvoltage
             rfsuite.session.batteryConfig.vbatmincellvoltage = vbatmincellvoltage
             rfsuite.session.batteryConfig.vbatmaxcellvoltage = vbatmaxcellvoltage
+            rfsuite.session.batteryConfig.vbatfullcellvoltage = vbatfullcellvoltage
             rfsuite.session.batteryConfig.lvcPercentage = lvcPercentage
             rfsuite.session.batteryConfig.consumptionWarningPercentage = consumptionWarningPercentage
 
@@ -49,6 +51,7 @@ function battery.wakeup()
             rfsuite.utils.log("Warning Voltage: " .. vbatwarningcellvoltage .. "V","info")
             rfsuite.utils.log("Min Voltage: " .. vbatmincellvoltage .. "V","info")
             rfsuite.utils.log("Max Voltage: " .. vbatmaxcellvoltage .. "V","info")
+            rfsuite.utils.log("Full Cell Voltage: " .. vbatfullcellvoltage .. "V", "info")
             rfsuite.utils.log("LVC Percentage: " .. lvcPercentage .. "%","info")
             rfsuite.utils.log("Consumption Warning Percentage: " .. consumptionWarningPercentage .. "%","info")
             rfsuite.utils.log("Battery Config Complete","info")

--- a/scripts/rfsuite/tasks/telemetry/telemetry.lua
+++ b/scripts/rfsuite/tasks/telemetry/telemetry.lua
@@ -365,6 +365,34 @@ local sensorTable = {
             },
             crsfLegacy = { "Rx Batt%" },
         },
+        source = function()
+            return {
+                value = function()
+                    local bc = rfsuite and rfsuite.session and rfsuite.session.batteryConfig
+                    local consumption = telemetry and telemetry.getSensor and telemetry.getSensor("consumption") or nil
+                    local packCapacity = bc and bc.batteryCapacity or 0
+                    local reserve = bc and bc.consumptionWarningPercentage or 0
+                    if reserve > 80 or reserve < 0 then reserve = 20 end
+
+                    if not consumption or not packCapacity or packCapacity < 10 then
+                        return nil
+                    end
+
+                    -- Always start at 100%
+                    if not fuelStartingPercent then
+                        fuelStartingPercent = 100
+                        fuelStartingConsumption = consumption or 0
+                    end
+
+                    local used = consumption - fuelStartingConsumption
+                    local usableCapacity = packCapacity * (1 - reserve / 100)
+                    if usableCapacity < 10 then usableCapacity = packCapacity end
+                    local percentUsed = used / usableCapacity * 100
+                    local remaining = math.max(0, fuelStartingPercent - percentUsed)
+                    return math.floor(math.min(100, remaining) + 0.5)
+                end
+            }
+        end,
     },
 
     consumption = {
@@ -951,31 +979,53 @@ function telemetry.getSensorSource(name)
 end
 
 --- Retrieves the value of a telemetry sensor by its key.
--- Looks up the sensor source using the provided sensorKey.
--- If the sensor source is found, returns its raw value; otherwise, returns nil.
+-- This function now supports both physical sensors (linked to telemetry sources)
+-- and virtual/computed sensors (which define a `.source` function in sensorTable).
+--
+-- 1. If the sensorTable entry includes a `source` function (virtual/computed sensor),
+--    this function is called and its `.value()` result is returned.
+-- 2. Otherwise, attempts to resolve the sensor as a physical/real telemetry source.
+--    If found, returns its value; otherwise, returns nil.
+-- 3. If a `localizations` function is defined for the sensor, it is applied to
+--    transform the raw value and resolve units as needed.
+--
 -- @param sensorKey The key identifying the telemetry sensor.
--- @return The raw value of the sensor if found, or nil if the sensor does not exist.
+-- @return The sensor value (possibly transformed), primary unit (major), and secondary unit (minor) if available.
 function telemetry.getSensor(sensorKey)
+    local entry = sensorTable[sensorKey]
+
+    if entry and type(entry.source) == "function" then
+        local src = entry.source()
+        if src and type(src.value) == "function" then
+            local value, major, minor = src.value()
+            major = major or entry.unit
+            -- Optionally apply localization, if needed:
+            if entry.localizations and type(entry.localizations) == "function" then
+                value, major, minor = entry.localizations(value)
+            end
+            return value, major, minor
+        end
+    end
+
+    -- Physical/real telemetry source
     local source = telemetry.getSensorSource(sensorKey)
     if not source then
         return nil
     end
 
     -- get initial defaults
-    local value = source:value()                        -- get the raw value from the source
-    local major = sensorTable[sensorKey].unit or nil    -- use the default unit if defined
-    local minor = nil                                   -- minor version is not possible without a localizations function which we do not have yet
-
+    local value = source:value()
+    local major = entry and entry.unit or nil
+    local minor = nil
 
     -- if the sensor has a transform function, apply it to the value:
-    if sensorTable[sensorKey] and sensorTable[sensorKey].localizations and type(sensorTable[sensorKey].localizations) == "function" then
-        value, major, minor = sensorTable[sensorKey].localizations(value)
+    if entry and entry.localizations and type(entry.localizations) == "function" then
+        value, major, minor = entry.localizations(value)
     end
 
-    -- Return the value
     return value, major, minor
-
 end
+
 
 --[[ 
     Function: telemetry.validateSensors


### PR DESCRIPTION
Updated telemetry.getSensor to support virtual/computed sensors by allowing any sensorTable entry to define a .source function. All existing logic remains as is, just added this support to it.
Extended the batteryConfig table to include vbatfullcellvoltage (must have been missed when it was originally coded).
New fuel sensor logic: fuel now supports user configurable reserve %