### PR TITLE
Fuel sensor

### DIFF
--- a/bin/sensors/gui/sensors.xml
+++ b/bin/sensors/gui/sensors.xml
@@ -22,7 +22,7 @@
         <Sensor name="voltage" label="Main Voltage" type="range" min="0" max="25.2" rand="5" multiplier="100" unit="V" default="24.2" />
         <Sensor name="bec_voltage" label="BEC Voltage" type="range" rand="5" min="4.0" max="8.0" multiplier="100" unit="V" default="8.0" />
         <Sensor name="current" label="Current" type="range" rand="5" min="0" max="200" multiplier="1" unit="A" />
-        <Sensor name="fuel" label="Fuel" round="true" type="range" default="85" min="0" max="100" rand="1" multiplier="1" unit="%" />
+        <Sensor name="consumption" label="Consumption" round="true" type="range" default="0" min="0" max="5000" rand="0" multiplier="1" unit="mAh" />
     </Group>
 
     <Group name="Flight Profiles">

--- a/scripts/rfsuite/main.lua
+++ b/scripts/rfsuite/main.lua
@@ -230,6 +230,7 @@ rfsuite.session.batteryConfig = nil
     -- vbatwarningcellvoltage = nil
     -- vbatmincellvoltage = nil
     -- vbatmaxcellvoltage = nil
+    -- vbatfullcellvoltage = nil
     -- lvcPercentage = nil
     -- consumptionWarningPercentage = nil
 rfsuite.session.modelPreferences = nil -- this is used to store the model preferences

--- a/scripts/rfsuite/sim/sensors/consumption.lua
+++ b/scripts/rfsuite/sim/sensors/consumption.lua
@@ -1,1 +1,1 @@
-return 2000
+return 0

--- a/scripts/rfsuite/tasks/events/init.lua
+++ b/scripts/rfsuite/tasks/events/init.lua
@@ -17,7 +17,7 @@
  * 
 ]] --
 local init = {
-    interval        = 0.25,          -- run every 0.5 seconds
+    interval        = 0.1,          -- run every 0.1 seconds
     script          = "events.lua", -- run this script
     linkrequired    = true,         -- run this script only if link is established
     spreadschedule  = true,         -- run on every loop

--- a/scripts/rfsuite/tasks/events/tasks/flightmode.lua
+++ b/scripts/rfsuite/tasks/events/tasks/flightmode.lua
@@ -22,19 +22,20 @@ local flightmode = {}
 local lastFlightMode = nil
 local hasBeenInFlight = false
 
-local throttleStartTime = nil -- Time when throttle first exceeded 0
-local throttleDelaySeconds = 10 -- Delay before trusting throttle > 0
-
+local throttleStartTime = nil
+local throttleDelaySeconds = 10
 
 --- Determines if the aircraft is considered "in flight" based on telemetry and session data.
--- 
--- The function checks the following conditions in order of priority:
--- 1. If telemetry is inactive or the session is not armed, returns false.
--- 2. If a "governor" sensor is available and its value is between 4 and 8 (inclusive), returns true.
--- 3. If the throttle value is greater than 0 for a specified delay period (`throttleDelaySeconds`), returns true.
--- 4. Otherwise, returns false.
---
--- @return boolean True if the aircraft is considered in flight, false otherwise.
+local function isGovernorActive(value)
+    return type(value) == "number" and value >= 4 and value <= 8
+end
+
+--- Determines if the flight mode is considered "in flight".
+-- This function checks two main conditions to decide if the model is in flight:
+-- 1. If the governor sensor is active (highest priority).
+-- 2. If the throttle has been above zero for a sustained period.
+-- The function also ensures telemetry is active and the session is armed before proceeding.
+-- @return boolean True if the model is considered in flight, false otherwise.
 function flightmode.inFlight()
     local telemetry = rfsuite.tasks.telemetry
 
@@ -43,72 +44,66 @@ function flightmode.inFlight()
         return false
     end
 
-    -- Priority 1: Governor
+    -- Priority 1: Governor sensor range
     local governor = telemetry.getSensor("governor")
-    if governor then
-        local g = governor
-        if g ~= nil then
-            return g == 4 or g == 5 or g == 6 or g == 7 or g == 8
-        end
+    if isGovernorActive(governor) then
+        return true
     end
 
-    -- Priority 2: Throttle fallback with delay
+    -- Priority 2: Throttle above 0 for sustained time
     local now = rfsuite.clock
-    local throttle = rfsuite.session.rx and rfsuite.session.rx.values and rfsuite.session.rx.values.throttle
+    local rx = rfsuite.session.rx
+    local throttle = rx and rx.values and rx.values.throttle
 
     if throttle and throttle > 0 then
         if not throttleStartTime then
-            throttleStartTime = now -- start timer
+            throttleStartTime = now
         elseif (now - throttleStartTime) >= throttleDelaySeconds then
-            return true -- throttle has been above 0 long enough
+            return true
         end
     else
-        throttleStartTime = nil -- reset timer if throttle drops
+        throttleStartTime = nil
     end
 
     return false
 end
 
-
---------------------------------------------------------------------------------
--- Resets flight mode tracking and timers:
---   • Clears lastFlightMode and hasBeenInFlight flags
---------------------------------------------------------------------------------
+--- Resets the flight mode state.
+-- This function clears the last flight mode, resets the flight status,
+-- and clears the throttle start time. It is typically used to reinitialize
+-- the flight mode tracking variables to their default states.
 function flightmode.reset()
     lastFlightMode = nil
     hasBeenInFlight = false
     throttleStartTime = nil
 end
 
---------------------------------------------------------------------------------
--- Handles the wakeup logic for flight mode state transitions:
---   • Determines "preflight", "inflight", or "postflight"
---   • Logs mode transitions and updates model preferences as needed
---------------------------------------------------------------------------------
-function flightmode.wakeup()
-
-    local mode
+--- Determines the current flight mode based on session state and flight status.
+-- This function checks the current session's flight mode and connection status,
+-- as well as the result of `flightmode.inFlight()`, to decide whether the mode
+-- should be "preflight", "inflight", or "postflight".
+-- It also manages the `hasBeenInFlight` flag to track if the system has ever been in flight.
+-- @return string The determined flight mode: "preflight", "inflight", or "postflight".
+local function determineMode()
+    if rfsuite.session.flightMode == "inflight" and not rfsuite.session.isConnected then
+        hasBeenInFlight = false
+        return "postflight"
+    end
 
     if flightmode.inFlight() then
-        mode = "inflight"
-
         hasBeenInFlight = true
-
-    else
-        if hasBeenInFlight then
-            mode = "postflight"
-        else
-            mode = "preflight"
-        end
+        return "inflight"
     end
 
-    -- catch a hard power-off senario
-    if rfsuite.session.flightMode == "inflight" and not rfsuite.session.isConnected  then
-        mode = "postflight"
-        hasBeenInFlight = false
-    end
+    return hasBeenInFlight and "postflight" or "preflight"
+end
 
-    -- Log and update flight mode on transition
+--- Wakes up the flight mode task and updates the current flight mode if it has changed.
+-- Determines the current flight mode using `determineMode()`. If the mode has changed since the last check,
+-- logs the new flight mode, updates the session's flight mode, and stores the new mode as the last known mode.
+function flightmode.wakeup()
+    local mode = determineMode()
+
     if lastFlightMode ~= mode then
         rfsuite.utils.log("Flight mode: " .. mode, "info")
         rfsuite.session.flightMode = mode

--- a/scripts/rfsuite/tasks/events/tasks/stats.lua
+++ b/scripts/rfsuite/tasks/events/tasks/stats.lua
@@ -15,104 +15,92 @@
  * Note: Some icons have been sourced from https://www.flaticon.com/
 ]]--
 
+-- Optimized stats.lua
+
 local arg = { ... }
 local config = arg[1]
 
 local stats = {}
 
--- Full sensorTable reference (rfsuite.tasks.telemetry.sensorTable)
 local fullSensorTable = nil
--- After one pass, this holds only the sensors we’ll actually track
--- Format: { [sensorKey] = sensorDef, ... }
 local filteredSensors = nil
-
--- Throttle tracking to once every 2 CPU‐seconds:
 local lastTrackTime = 0
 
--- Build filteredSensors exactly once:
+local telemetry
+
 local function buildFilteredList()
     filteredSensors = {}
 
     for sensorKey, sensorDef in pairs(fullSensorTable) do
         local mt = sensorDef.stats
 
-        -- Include if it's a literal true:
         if mt == true then
             filteredSensors[sensorKey] = sensorDef
 
-        -- Or if it's a function that returns true right now:
         elseif type(mt) == "function" then
-            -- Call it once. If it says “true”, include:
             local ok, result = pcall(mt)
             if ok and result then
                 filteredSensors[sensorKey] = sensorDef
             end
         end
-        -- Anything else (false, nil, or function returning false) is skipped
     end
 end
 
 function stats.wakeup()
 
-    -- we should only build stats when 'inflight'
-    if rfsuite.session.flightMode ~= "inflight" then
+    -- we start this in wakeup as telemetry may not be set when this tasks starts
+    if not telemetry then
+        telemetry = rfsuite.tasks.telemetry
         return
     end
 
-    -- Throttle: only run once every 0.25 CPU‐seconds
+    if rfsuite.session.flightMode ~= "inflight" then return end
+
     local now = rfsuite.clock
-    if now - lastTrackTime < 0.25 then
-        return
-    end
+    if now - lastTrackTime < 0.25 then return end
     lastTrackTime = now
 
-    -- On the very first wakeup, grab the full sensorTable and build the filtered list
     if not fullSensorTable then
-        fullSensorTable = rfsuite.tasks.telemetry.sensorTable
-        if not fullSensorTable then
-            -- Telemetry not ready yet
-            return
-        end
-
+        fullSensorTable = telemetry.sensorTable
+        if not fullSensorTable then return end
         buildFilteredList()
     end
 
-    -- Ensure telemetry module is available
-    if not telemetry then
-        telemetry = rfsuite.tasks.telemetry
+    if not telemetry.sensorStats then
+        telemetry.sensorStats = {}
     end
 
-    -- Initialize sensorStats if it doesn't exist
-    if not rfsuite.tasks.telemetry.sensorStats then
-        rfsuite.tasks.telemetry.sensorStats = {}
-    end
+    local statsTable = telemetry.sensorStats
 
-    local statsTable = rfsuite.tasks.telemetry.sensorStats
-
-    -- Now iterate only over filteredSensors—no more checks of stats
-    for sensorKey, sensorDef in pairs(filteredSensors) do
-        local source = telemetry.getSensor(sensorKey)
-        if source then
-            local val = source
-            if val then
-                local stats = statsTable[sensorKey] or { min = math.huge, max = -math.huge, sum = 0, count = 0, avg = 0 }
-                stats.min = math.min(stats.min, val)
-                stats.max = math.max(stats.max, val)
-                stats.sum = stats.sum + val
-                stats.count = stats.count + 1
-                stats.avg = stats.sum / stats.count
-                statsTable[sensorKey] = stats
+    for sensorKey, _ in pairs(filteredSensors) do
+        local val = telemetry.getSensor(sensorKey)
+        if val and type(val) == "number" then
+            if not statsTable[sensorKey] then
+                statsTable[sensorKey] = {
+                    min = math.huge,
+                    max = -math.huge,
+                    sum = 0,
+                    count = 0,
+                    avg = 0
+                }
             end
+
+            local entry = statsTable[sensorKey]
+            entry.min   = math.min(entry.min, val)
+            entry.max   = math.max(entry.max, val)
+            entry.sum   = entry.sum + val
+            entry.count = entry.count + 1
+            entry.avg   = entry.sum / entry.count
         end
     end
 end
 
 function stats.reset()
-    -- Clear all stored stats and force a full rebuild on next wakeup()
-    rfsuite.tasks.telemetry.sensorStats = {}
+    telemetry.sensorStats = {}
     fullSensorTable  = nil
     filteredSensors  = nil
     lastTrackTime    = 0
 end
 
 return stats
+

--- a/scripts/rfsuite/tasks/events/tasks/telemetry.lua
+++ b/scripts/rfsuite/tasks/events/tasks/telemetry.lua
@@ -82,9 +82,9 @@ local eventTable = {
     {
         sensor = "fuel",
         event = function(value)
-            local config = rfsuite.session.batteryConfig
-            local warningPct = config and config.consumptionWarningPercentage
-            if warningPct and value < warningPct then
+            print("Fuel event value:", value)
+            -- Play the alert every interval if fuel is 10% or below
+            if value and value <= 10 then
                 rfsuite.utils.playFile("events", "alerts/lowfuel.wav")
             end
         end,

--- a/scripts/rfsuite/tasks/events/tasks/telemetry.lua
+++ b/scripts/rfsuite/tasks/events/tasks/telemetry.lua
@@ -20,15 +20,13 @@ local config = arg[1]
 
 local telemetry = {}
 
--- Tracking tables for event timing and value changes
 local lastEventTimes = {}
 local lastValues     = {}
 local lastPlayTime   = {}
 
--- Shortcut to user preferences
 local userpref = rfsuite.preferences
+local enabledEvents = (userpref and userpref.events) or {}
 
--- Definition of telemetry-driven events
 local eventTable = {
     {
         sensor = "armflags",
@@ -43,49 +41,35 @@ local eventTable = {
             if filename then
                 rfsuite.utils.playFile("events", "alerts/" .. filename)
             end
-        end,
-        interval = nil,
-        debounce = nil,
+        end
     },
     {
         sensor = "voltage",
         event = function(value)
             local session = rfsuite.session
-            if not session.batteryConfig then
-                return
-            end
+            if not session.batteryConfig then return end
 
-            local cellCount    = session.batteryConfig.batteryCellCount
-            local warnVoltage  = session.batteryConfig.vbatwarningcellvoltage
-            local minVoltage   = session.batteryConfig.vbatmincellvoltage
+            local cellCount   = session.batteryConfig.batteryCellCount
+            local warnVoltage = session.batteryConfig.vbatwarningcellvoltage
+            local minVoltage  = session.batteryConfig.vbatmincellvoltage
 
             local collective = session.rx.values['collective'] or 0
-            local aileron = session.rx.values['aileron'] or 0
-            local elevator = session.rx.values['elevator'] or 0
-            local rudder = session.rx.values['rudder'] or 0
+            local aileron    = session.rx.values['aileron'] or 0
+            local elevator   = session.rx.values['elevator'] or 0
+            local rudder     = session.rx.values['rudder'] or 0
 
-            if not (cellCount and warnVoltage and minVoltage) then
-                return
-            end
+            if not (cellCount and warnVoltage and minVoltage) then return end
 
-            local cellVoltage      = value / cellCount
-            local suppressThreshold = minVoltage / 2
+            local cellVoltage = value / cellCount
+            if cellVoltage >= 0 and cellVoltage < (minVoltage / 2) then return end
 
-            -- Suppress if below suppression threshold but not zero
-            if cellVoltage >= 0 and cellVoltage < suppressThreshold then
-                return
-            end
+            local suppressionPercent = userpref.general.gimbalsupression or 0.85
+            local suppressionLimit = suppressionPercent * 1024
 
-            -- Define suppression percentage threshold (e.g., 0.8 for 80%)
-            local suppressionPercent = rfsuite.preferences.general.gimbalsupression or 0.85
-            local maxStickValue = 1024
-            local suppressionLimit = suppressionPercent * maxStickValue
-
-            -- Suppress if any stick input exceeds the suppression limit
             if math.abs(collective) > suppressionLimit or
-            math.abs(aileron) > suppressionLimit or
-            math.abs(elevator) > suppressionLimit or
-            math.abs(rudder) > suppressionLimit then
+               math.abs(aileron) > suppressionLimit or
+               math.abs(elevator) > suppressionLimit or
+               math.abs(rudder) > suppressionLimit then
                 return
             end
 
@@ -93,52 +77,35 @@ local eventTable = {
                 rfsuite.utils.playFile("events", "alerts/lowvoltage.wav")
             end
         end,
-        interval = 10,
-        debounce = nil,
+        interval = 10
     },
     {
         sensor = "fuel",
         event = function(value)
-            local session = rfsuite.session
-            if not (session.batteryConfig and session.batteryConfig.consumptionWarningPercentage) then
-                return
-            end
-
-            local warningPct = session.batteryConfig.consumptionWarningPercentage
-            if value < warningPct then
+            local config = rfsuite.session.batteryConfig
+            local warningPct = config and config.consumptionWarningPercentage
+            if warningPct and value < warningPct then
                 rfsuite.utils.playFile("events", "alerts/lowfuel.wav")
             end
         end,
-        interval = 10,
-        debounce = nil,
+        interval = 10
     },
     {
         sensor = "governor",
         event = function(value)
-            if not rfsuite.session.isArmed or rfsuite.session.governorMode == 0 then
-                return
-            end
+            if not rfsuite.session.isArmed or rfsuite.session.governorMode == 0 then return end
 
             local governorMap = {
-                [0]   = "off.wav",
-                [1]   = "idle.wav",
-                [2]   = "spoolup.wav",
-                [3]   = "recovery.wav",
-                [4]   = "active.wav",
-                [5]   = "thr-off.wav",
-                [6]   = "lost-hs.wav",
-                [7]   = "autorot.wav",
-                [8]   = "bailout.wav",
-                [100] = "disabled.wav",
-                [101] = "disarmed.wav",
+                [0] = "off.wav", [1] = "idle.wav", [2] = "spoolup.wav",
+                [3] = "recovery.wav", [4] = "active.wav", [5] = "thr-off.wav",
+                [6] = "lost-hs.wav", [7] = "autorot.wav", [8] = "bailout.wav",
+                [100] = "disabled.wav", [101] = "disarmed.wav"
             }
             local filename = governorMap[math.floor(value)]
             if filename then
                 rfsuite.utils.playFile("events", "gov/" .. filename)
             end
-        end,
-        interval = nil,
-        debounce = nil,
+        end
     },
     {
         sensor = "pid_profile",
@@ -146,8 +113,7 @@ local eventTable = {
             rfsuite.utils.playFile("events", "alerts/profile.wav")
             system.playNumber(math.floor(value))
         end,
-        interval = nil,
-        debounce = 0.25,
+        debounce = 0.25
     },
     {
         sensor = "rate_profile",
@@ -155,84 +121,41 @@ local eventTable = {
             rfsuite.utils.playFile("events", "alerts/rates.wav")
             system.playNumber(math.floor(value))
         end,
-        interval = nil,
-        debounce = 0.25,
-    },
-    {
-        sensor = "adj_f",
-        event = function(value)
-            -- Placeholder for future implementation
-        end,
-        interval = nil,
-        debounce = nil,
-    },
-    {
-        sensor = "adj_v",
-        event = function(value)
-            -- Placeholder for future implementation
-        end,
-        interval = nil,
-        debounce = nil,
-    },
+        debounce = 0.25
+    }
 }
 
---------------------------------------------------------------------------------
--- Handles telemetry wakeup events by processing each telemetry item in eventTable.
---
--- For each configured event:
---   • Retrieves the sensor source and its current value.
---   • Skips if the value hasn't changed since last event.
---   • Applies debounce and interval checks to avoid rapid/redundant firing.
---   • Checks user preferences to see if the event is enabled.
---   • If conditions are met, triggers the event callback and updates timing/value.
---------------------------------------------------------------------------------
 function telemetry.wakeup()
-    local currentTime = rfsuite.clock
+    local now = rfsuite.clock
 
     for _, item in ipairs(eventTable) do
-        local key      = item.sensor
-        local callback = item.event
-        local interval = item.interval or 0
-        local debounce = item.debounce or 0
+        local key = item.sensor
+        if not enabledEvents[key] then goto continue end
 
-        local sensor = rfsuite.tasks.telemetry.getSensorSource(key)
-        if not sensor then
-            goto continue
-        end
+        local source = rfsuite.tasks.telemetry.getSensorSource(key)
+        if not source then goto continue end
 
-        local value = sensor:value()
-        if value == nil then
-            goto continue
-        end
+        local value = source:value()
+        if not value then goto continue end
 
-        local lastValue = lastValues[key]
-        if lastValue ~= nil and value == lastValue then
-            goto continue
-        end
+        local lastVal = lastValues[key]
+        if lastVal and value == lastVal then goto continue end
 
         local lastTime = lastEventTimes[key] or 0
-        if debounce > 0 and (currentTime - lastTime) < debounce then
-            goto continue
-        end
+        local debounce = item.debounce or 0
+        local interval = item.interval or 0
 
-        if interval > 0 and (currentTime - lastTime) < interval then
-            goto continue
-        end
+        if debounce > 0 and (now - lastTime) < debounce then goto continue end
+        if interval > 0 and (now - lastTime) < interval then goto continue end
 
-        if not userpref or not userpref.events or userpref.events[key] ~= true then
-            goto continue
-        end
-
-        -- Trigger event and update trackers
-        callback(value)
-        lastEventTimes[key] = currentTime
-        lastValues[key]     = value
+        item.event(value)
+        lastValues[key] = value
+        lastEventTimes[key] = now
 
         ::continue::
     end
 end
 
--- Expose eventTable for other modules if needed
 telemetry.eventTable = eventTable
 
 return telemetry

--- a/scripts/rfsuite/tasks/logging/init.lua
+++ b/scripts/rfsuite/tasks/logging/init.lua
@@ -17,7 +17,7 @@
  * 
 ]] --
 local init = {
-    interval        = 5,               -- run every 5 seconds  
+    interval        = 2,               -- run every 5 seconds  
     script          = "logging.lua",   -- run this script
     linkrequired    = true,            -- run this script only if link is established        
     spreadschedule  = true,            -- run on every loop 

--- a/scripts/rfsuite/tasks/onconnect/tasks/medium/battery.lua
+++ b/scripts/rfsuite/tasks/onconnect/tasks/medium/battery.lua
@@ -32,6 +32,7 @@ function battery.wakeup()
             local vbatwarningcellvoltage = API.readValue("vbatwarningcellvoltage")/100
             local vbatmincellvoltage = API.readValue("vbatmincellvoltage")/100
             local vbatmaxcellvoltage = API.readValue("vbatmaxcellvoltage")/100
+            local vbatfullcellvoltage = API.readValue("vbatfullcellvoltage")/100
             local lvcPercentage = API.readValue("lvcPercentage")
             local consumptionWarningPercentage = API.readValue("consumptionWarningPercentage")
 
@@ -41,6 +42,7 @@ function battery.wakeup()
             rfsuite.session.batteryConfig.vbatwarningcellvoltage = vbatwarningcellvoltage
             rfsuite.session.batteryConfig.vbatmincellvoltage = vbatmincellvoltage
             rfsuite.session.batteryConfig.vbatmaxcellvoltage = vbatmaxcellvoltage
+            rfsuite.session.batteryConfig.vbatfullcellvoltage = vbatfullcellvoltage
             rfsuite.session.batteryConfig.lvcPercentage = lvcPercentage
             rfsuite.session.batteryConfig.consumptionWarningPercentage = consumptionWarningPercentage
 
@@ -49,6 +51,7 @@ function battery.wakeup()
             rfsuite.utils.log("Warning Voltage: " .. vbatwarningcellvoltage .. "V","info")
             rfsuite.utils.log("Min Voltage: " .. vbatmincellvoltage .. "V","info")
             rfsuite.utils.log("Max Voltage: " .. vbatmaxcellvoltage .. "V","info")
+            rfsuite.utils.log("Full Cell Voltage: " .. vbatfullcellvoltage .. "V", "info")
             rfsuite.utils.log("LVC Percentage: " .. lvcPercentage .. "%","info")
             rfsuite.utils.log("Consumption Warning Percentage: " .. consumptionWarningPercentage .. "%","info")
             rfsuite.utils.log("Battery Config Complete","info")

--- a/scripts/rfsuite/widgets/dashboard/dashboard.lua
+++ b/scripts/rfsuite/widgets/dashboard/dashboard.lua
@@ -133,6 +133,10 @@ dashboard._moduleCache = dashboard._moduleCache or {}
 dashboard._hg_cycles_required = math.ceil(0.5 / (loadedThemeIntervals.paint_interval or 0.5))
 dashboard._hg_cycles = 0
 
+-- how long the loader must stay visible (in seconds)
+dashboard._loader_min_duration = 1.5
+dashboard._loader_start_time = nil
+
 -- Utility methods loaded from external utils.lua (drawing, color helpers, etc.)
 dashboard.utils = assert(
     compile("SCRIPTS:/" .. baseDir .. "/widgets/dashboard/lib/utils.lua")
@@ -437,7 +441,9 @@ function dashboard.renderLayout(widget, config)
     ----------------------------------------------------------------
     -- PHASE 2: Spinner Until First Wakeup Pass Completes
     ----------------------------------------------------------------
-    if objectsThreadedWakeupCount < 1 then
+    dashboard._loader_start_time = dashboard._loader_start_time or rfsuite.clock
+    local loaderElapsed = rfsuite.clock - dashboard._loader_start_time
+    if objectsThreadedWakeupCount < 1 or loaderElapsed < dashboard._loader_min_duration then
         dashboard.loader(0, 0, W, H)
         lcd.invalidate()
         return

--- a/scripts/rfsuite/widgets/dashboard/lib/loaders.lua
+++ b/scripts/rfsuite/widgets/dashboard/lib/loaders.lua
@@ -102,9 +102,9 @@ function loaders.staticLoader(dashboard, x, y, w, h)
 
 -- Animated dots below the logo
   dashboard._dots_index = dashboard._dots_index or 1
-  dashboard._dots_time = dashboard._dots_time or rfsuite.clock
-  if rfsuite.clock - dashboard._dots_time > 0.5 then
-    dashboard._dots_time = rfsuite.clock
+  dashboard._dots_time = dashboard._dots_time or os.clock()
+  if os.clock() - dashboard._dots_time > 0.5 then
+    dashboard._dots_time = os.clock()
     dashboard._dots_index = (dashboard._dots_index % 3) + 1
   end
 
@@ -155,6 +155,28 @@ function loaders.staticOverlayMessage(dashboard, x, y, w, h, txt)
     lcd.drawFilledCircle(cx, cy, radius)
     lcd.color(lcd.darkMode() and lcd.RGB(0,0,0,1.0) or lcd.RGB(0,0,0,1.0))
     lcd.drawFilledCircle(cx, cy, radius - thickness)
+  end
+
+-- Animated dots below the logo
+  dashboard._dots_index = dashboard._dots_index or 1
+  dashboard._dots_time = dashboard._dots_time or os.clock()
+  if os.clock() - dashboard._dots_time > 0.5 then
+    dashboard._dots_time = os.clock()
+    dashboard._dots_index = (dashboard._dots_index % 3) + 1
+  end
+
+  local dotRadius = 4
+  local spacing = 3 * dotRadius
+  local startX = cx - spacing
+  local yPos = cy + (radius - thickness / 2) / 2  -- Midway between center and outer edge
+
+  for i = 1, 3 do
+    if i == dashboard._dots_index then
+      lcd.color(lcd.darkMode() and lcd.RGB(255,255,255) or lcd.RGB(0,0,0))
+    else
+      lcd.color(lcd.darkMode() and lcd.RGB(80,80,80) or lcd.RGB(180,180,180))
+    end
+    lcd.drawFilledCircle(startX + (i - 1) * spacing, yPos, dotRadius)
   end
 
   renderOverlayText(dashboard, cx, cy, innerR, fg)


### PR DESCRIPTION
Adjusted sim sensor for fuel to be consumption instead, modified audio alert for Charge Level to trigger when the value is 10% or below and not based on consmptionwarningpercentage anymore as this is the new value for setting a Reserve %. Will raise another PR for renaming consumptionwarningpercentage so it reflects the fact it is now actually reserve %. Applied same logic to sim and alerts trigger as expected when below 10% fuel with charge level audio alert turned on.