### PR TITLE
Timer audio event

### DIFF
--- a/scripts/rfsuite/tasks/events/events.lua
+++ b/scripts/rfsuite/tasks/events/events.lua
@@ -23,7 +23,7 @@ local wakeupStep = 0
 local wakeupHandlers = {}
 
 -- List of task module names (must match the .lua filenames)
-local taskNames = { "telemetry", "switches", "flightmode", "stats", "rxmap" }
+local taskNames = { "telemetry", "switches", "flightmode", "stats", "rxmap", "timer" }
 local taskExecutionPercent = 50 -- 50% of tasks will run each cycle
 
 -- Dynamically load task modules and populate wakeupHandlers

--- a/scripts/rfsuite/tasks/events/tasks/timer.lua
+++ b/scripts/rfsuite/tasks/events/tasks/timer.lua
@@ -1,0 +1,67 @@
+--[[
+ * Copyright (C) Rotorflight Project
+ *
+ * License GPLv3: https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * Note: Some icons have been sourced from https://www.flaticon.com/
+]]--
+
+local arg = { ... }
+local config = arg[1]
+local timer = {}
+
+local triggered = false
+local lastBeepTime = nil
+
+function timer.wakeup()
+    local session = rfsuite.session
+    local modelFlightTime = session and session.modelFlightTime
+    local batteryConfig = session and session.batteryConfig
+    local targetSeconds = batteryConfig and batteryConfig.modelFlightTime or 0
+
+    -- Only trigger if the feature is configured and flight time is available
+    if not targetSeconds or targetSeconds == 0 or not modelFlightTime or modelFlightTime == 0 then
+        triggered = false
+        lastBeepTime = nil
+        return
+    end
+
+    -- Only trigger if we are armed / inflight
+    if rfsuite.flightmode.current ~= "inflight" then
+        triggered = false
+        lastBeepTime = nil
+        return
+    end
+
+    -- If flight time exceeds or equals the target, handle beeping
+    if modelFlightTime >= targetSeconds then
+        local now = rfsuite.clock
+        if not triggered then
+            rfsuite.utils.playFileCommon("beep.wav")
+            triggered = true
+            lastBeepTime = now
+        elseif lastBeepTime and (now - lastBeepTime) >= 10 then
+            rfsuite.utils.playFileCommon("beep.wav")
+            lastBeepTime = now
+        end
+    else
+        triggered = false
+        lastBeepTime = nil
+    end
+end
+
+function timer.reset()
+    triggered = false
+    lastBeepTime = nil
+end
+
+return timer


### PR DESCRIPTION
Created new audio event for the pilot_config timer functionality recently added. Will extend the configurable options for this later. Current config will beep every 10 seconds when in-flight and rfsuite.session.modelFlightTime has been exceeded. Will not trigger if value isnt configured.