### PR TITLE
Audio callout fixes

### DIFF
--- a/scripts/rfsuite/app/modules/settings/tools/audio_events.lua
+++ b/scripts/rfsuite/app/modules/settings/tools/audio_events.lua
@@ -185,7 +185,13 @@ local function openPage(pageIdx, title, script)
             setFieldEnabled(rfsuite.app.formFields[fuelFields.haptic], val)
         end
     )
-    local calloutChoices = {{"Off",0},{"10%",10},{"20%",20},{"25%",25},{"50%",50}}
+    local calloutChoices = {
+        {"Default (Only at 10%)", 0},
+        {"Every 10%", 10},
+        {"Every 20%", 20},
+        {"Every 25%", 25},
+        {"Every 50%", 50},
+    }
     local fuelThresh = fuelPanel:addLine(i18n("Callout %"))
     formFieldCount = formFieldCount + 1
     rfsuite.app.formLineCnt = rfsuite.app.formLineCnt + 1


### PR DESCRIPTION
Resolved issue with multiple callouts in a scenario where a partially discharged pack is connected. Updated callouts so initial fuel % value is played once voltage is stabilised. Updated callout options form field so it makes more sense to users.