### PR TITLE
Fixed issue with totalflighttime

### DIFF
--- a/scripts/rfsuite/tasks/timer/timer.lua
+++ b/scripts/rfsuite/tasks/timer/timer.lua
@@ -88,6 +88,10 @@ local function finalizeFlightSegment(now)
     timerSession.baseLifetime = timerSession.baseLifetime + segment
     timerSession.lifetime = timerSession.baseLifetime
 
+    -- Only update INI for totalflighttime at the end of flight
+    if prefs then
+        rfsuite.ini.setvalue(prefs, "general", "totalflighttime", timerSession.baseLifetime)
+    end
     timer.save()
 end
 
@@ -130,10 +134,6 @@ function timer.wakeup()
 
         local computedLifetime = (timerSession.baseLifetime or 0) + currentSegment
         timerSession.lifetime = computedLifetime
-
-        if prefs then
-            rfsuite.ini.setvalue(prefs, "general", "totalflighttime", computedLifetime)
-        end
 
         if timerSession.live >= 25 and not rfsuite.session.flightCounted then
             rfsuite.session.flightCounted = true


### PR DESCRIPTION
Previous logic with recording totalflightcount was overwriting values and not incrementing it each flight, moved it out of wakeup and into finalize function.