### PR TITLE
Updated consumption warning %

### DIFF
--- a/scripts/rfsuite/app/modules/battery/battery.lua
+++ b/scripts/rfsuite/app/modules/battery/battery.lua
@@ -1,3 +1,5 @@
+local i18n = rfsuite.i18n.get
+
 local apidata = {
     api = {
         [1] = 'BATTERY_CONFIG',
@@ -7,22 +9,38 @@ local apidata = {
         labels = {
         },
         fields = {
-            {t = rfsuite.i18n.get("app.modules.battery.max_cell_voltage"), mspapi = 1, apikey="vbatmaxcellvoltage"},
-            {t = rfsuite.i18n.get("app.modules.battery.full_cell_voltage"), mspapi = 1,  apikey="vbatfullcellvoltage"},
-            {t = rfsuite.i18n.get("app.modules.battery.warn_cell_voltage"), mspapi = 1,  apikey="vbatwarningcellvoltage"},
-            {t = rfsuite.i18n.get("app.modules.battery.min_cell_voltage"), mspapi = 1,  apikey="vbatmincellvoltage"},
-            {t = rfsuite.i18n.get("app.modules.battery.battery_capacity"), mspapi = 1,  apikey="batteryCapacity"},
-            {t = rfsuite.i18n.get("app.modules.battery.cell_count"), mspapi = 1,  apikey="batteryCellCount"},
-            {t = rfsuite.i18n.get("app.modules.battery.consumption_warning_percentage"), mspapi = 1,  apikey="consumptionWarningPercentage"},
-            {t = rfsuite.i18n.get("app.modules.battery.timer"), mspapi = 2,  apikey="model_param1_value"},
-
+            {t = i18n("app.modules.battery.max_cell_voltage"), mspapi = 1, apikey = "vbatmaxcellvoltage"},
+            {t = i18n("app.modules.battery.full_cell_voltage"), mspapi = 1, apikey = "vbatfullcellvoltage"},
+            {t = i18n("app.modules.battery.warn_cell_voltage"), mspapi = 1, apikey = "vbatwarningcellvoltage"},
+            {t = i18n("app.modules.battery.min_cell_voltage"), mspapi = 1, apikey = "vbatmincellvoltage"},
+            {t = i18n("app.modules.battery.battery_capacity"), mspapi = 1, apikey = "batteryCapacity"},
+            {t = i18n("app.modules.battery.cell_count"), mspapi = 1, apikey = "batteryCellCount"},
+            {t = i18n("app.modules.battery.consumption_warning_percentage"), min = 15, max = 60, mspapi = 1, apikey = "consumptionWarningPercentage"},
+            {t = i18n("app.modules.battery.timer"), mspapi = 2, apikey = "model_param1_value"},
         }
     }                 
 }
+
+local function postLoad(self)
+    for _, f in ipairs(self.fields or (self.apidata and self.apidata.formdata.fields) or {}) do
+        if f.apikey == "consumptionWarningPercentage" then
+            local v = tonumber(f.value)
+            if v then
+                if v < 15 then
+                    f.value = 35
+                elseif v > 60 then
+                    f.value = 35
+                end
+            end
+        end
+    end
+    rfsuite.app.triggers.closeProgressLoader = true
+end
 
 return {
     apidata = apidata,
     eepromWrite = true,
     reboot = false,
     API = {},
+    postLoad = postLoad,
 }

--- a/scripts/rfsuite/tasks/sensors/lib/smartfuel.lua
+++ b/scripts/rfsuite/tasks/sensors/lib/smartfuel.lua
@@ -154,7 +154,12 @@ local function smartFuelCalc()
         bc.batteryCellCount, bc.batteryCapacity, bc.consumptionWarningPercentage,
         bc.vbatmaxcellvoltage, bc.vbatmincellvoltage, bc.vbatfullcellvoltage
 
-    if reserve > 80 or reserve < 0 then reserve = 20 end
+    -- Clamp reserve to allowed range for safety
+    if reserve > 60 then
+        reserve = 35
+    elseif reserve < 15 then
+        reserve = 35
+    end
 
     if packCapacity < 10 or cellCount == 0 or maxCellV <= minCellV or fullCellV <= 0 then
         fuelStartingPercent = nil


### PR DESCRIPTION
Now defaults to 35%, if the value in RF is outside of 15 <-> 60 smartfuel will set a reserve of 35% and the battery configurator page will set the value to 35%.