### PR TITLE
Added reset handler for events tasks

### DIFF
--- a/scripts/rfsuite/tasks/events/events.lua
+++ b/scripts/rfsuite/tasks/events/events.lua
@@ -61,6 +61,12 @@ end
 
 function events.reset()
     telemetryStartTime = nil
+    for _, name in ipairs(taskNames) do
+        local subtask = events[name]
+        if subtask and type(subtask.reset) == "function" then
+            subtask.reset()
+        end
+    end
 end
 
 return events

--- a/scripts/rfsuite/tasks/events/tasks/stats.lua
+++ b/scripts/rfsuite/tasks/events/tasks/stats.lua
@@ -118,7 +118,9 @@ function stats.wakeup()
 end
 
 function stats.reset()
-    telemetry.sensorStats = {}
+    if telemetry then
+        telemetry.sensorStats = {}
+    end
     fullSensorTable  = nil
     filteredSensors  = nil
     lastTrackTime    = 0

--- a/scripts/rfsuite/tasks/events/tasks/telemetry.lua
+++ b/scripts/rfsuite/tasks/events/tasks/telemetry.lua
@@ -301,4 +301,16 @@ function telemetry.wakeup()
 end
 
 telemetry.eventTable = eventTable
+
+function telemetry.reset()
+    lastSmartfuelAnnounced = nil
+    lastLowFuelAnnounced = false
+    lastLowFuelRepeat = 0
+    lastLowFuelRepeatCount = 0
+    lastEventTimes = {}
+    lastValues     = {}
+    lastAlertState = {}
+    rollingSamples = {}
+end
+
 return telemetry


### PR DESCRIPTION
Previously the reset functions were not being executed. Added this functionality and then added caching to stats.lua and watts.lua objects so they continue to display the values following telemetry loss on postflight. Confirmed all audio events now correctly reset and function as expected now following telemetry loss and reconnection. Now all events are appropriately cleaned up.