### PR TITLE
Header support for @AERC theme

### DIFF
--- a/scripts/rfsuite/widgets/dashboard/lib/utils.lua
+++ b/scripts/rfsuite/widgets/dashboard/lib/utils.lua
@@ -146,6 +146,78 @@ function utils.getFontListsForResolution()
 
 end
 
+--- Returns a table of recommended header layout options for the current radio’s screen resolution.
+-- This function detects the radio’s LCD width, then returns a set of standard header options
+-- (such as height and padding values) appropriate for known device resolutions.
+-- These values ensure consistent header spacing, sizing, and alignment for the three supported full-screen
+-- layouts (X20, X18, X14).
+--
+-- The returned table can be used directly as a `header_layout` for dashboard themes, or individual fields
+
+function utils.getHeaderOptions()
+    local W, H = lcd.getWindowSize()
+
+    -- X20/X20RS: 800x480 or 784x294
+    if W == 800 or W == 784 then
+        return {
+            height = 36,
+            font = "FONT_L",
+            batterysegmentpaddingtop = 4,
+            batterysegmentpaddingbottom = 4,
+            batterysegmentpaddingleft = 4,
+            batterysegmentpaddingright = 4,
+            gaugepaddingleft = 25,
+            gaugepaddingright = 26,
+            gaugepaddingbottom = 2,
+            gaugepaddingtop = 2,
+            barpaddingleft = 25,
+            barpaddingright = 26,
+            barpaddingbottom = 2,
+            barpaddingtop = 4,
+            valuepaddingleft = 20,
+            valuepaddingbottom = 20,
+        }
+
+    -- X18/TWXLITE: 480x320 or 472x191
+    elseif W == 480 or W == 472 then
+        return {
+            height = 30,
+            font = "FONT_L",
+            batterysegmentpaddingtop = 4,
+            batterysegmentpaddingbottom = 4,
+            batterysegmentpaddingleft = 4,
+            batterysegmentpaddingright = 4,
+            gaugepaddingleft = 8,
+            gaugepaddingright = 9,
+            gaugepaddingbottom = 2,
+            gaugepaddingtop = 2,
+            barpaddingleft = 15,
+            barpaddingright = 16,
+            barpaddingbottom = 2,
+            barpaddingtop = 2,
+            valuepaddingbottom = 20,
+        }
+    -- X14/X14S: 640x360 or 630x236
+    elseif W == 640 or W == 630 then
+        return {
+            height = 30,
+            font = "FONT_L",
+            batterysegmentpaddingtop = 4,
+            batterysegmentpaddingbottom = 4,
+            batterysegmentpaddingleft = 4,
+            batterysegmentpaddingright = 4,
+            gaugepaddingleft = 20,
+            gaugepaddingright = 20,
+            gaugepaddingbottom = 2,
+            gaugepaddingtop = 2,
+            barpaddingleft = 19,
+            barpaddingright = 19,
+            barpaddingbottom = 2,
+            barpaddingtop = 2,
+            valuepaddingbottom = 20,
+        }
+    end
+end
 
 --- Resets the image cache by removing all entries from the `imageCache` table.
 -- This function iterates over all keys in the `imageCache` table and sets their values to nil,

--- a/scripts/rfsuite/widgets/dashboard/themes/@aerc/inflight.lua
+++ b/scripts/rfsuite/widgets/dashboard/themes/@aerc/inflight.lua
@@ -16,52 +16,41 @@
 ]]--
 
 local i18n = rfsuite.i18n.get
+local utils = rfsuite.widgets.dashboard.utils
+local boxes_cache = nil
+local themeconfig = nil
+local lastScreenW = nil
 
 local darkMode = {
-    textcolor   = "white",
-    titlecolor  = "white",
-    bgcolor     = "black",
-    fillcolor   = "green",
-    fillbgcolor = "grey",
-    accentcolor = "white",
-    rssifillcolor = "darkwhite",
-    txaccentcolor = "grey",
+    textcolor       = "white",
+    titlecolor      = "white",
+    bgcolor         = "black",
+    fillcolor       = "green",
+    fillbgcolor     = "darkgrey",
+    accentcolor     = "white",
+    rssifillcolor   = "green",
+    rssifillbgcolor = "darkgrey",
+    txaccentcolor   = "grey",
+    txfillcolor     = "green",
+    txbgfillcolor   = "darkgrey"
 }
 
 local lightMode = {
-    textcolor   = "black",
-    titlecolor  = "black",
-    bgcolor     = "white",
-    fillcolor   = "green",
-    fillbgcolor = "grey",
-    accentcolor = "black",
-    rssifillcolor = "darkwhite",
-    txaccentcolor = "grey",
+    textcolor       = "black",
+    titlecolor      = "black",
+    bgcolor         = "white",
+    fillcolor       = "green",
+    fillbgcolor     = "lightgrey",
+    accentcolor     = "darkgrey",
+    rssifillcolor   = "green",
+    rssifillbgcolor = "grey",
+    txaccentcolor   = "darkgrey",
+    txfillcolor     = "green",
+    txbgfillcolor   = "grey"
 }
 
 -- alias current mode
 local colorMode = lcd.darkMode() and darkMode or lightMode
-
--- Determine layout and screensize in use
-local function getScreenSize(w, h)
-
-    -- Large screens - (X20 / X20RS / X18RS etc) Full/Standard
-    if (w == 800 and (h == 458 or h == 480)) then return "ls_full" end
-    if (w == 784 and (h == 294 or h == 316)) then return "ls_std" end
-
-    -- Medium screens (X18 / X18S / TWXLITE) - Full/Standard
-    if (w == 480 and (h == 301 or h == 320)) then return "ms_full" end
-    if (w == 472 and (h == 191 or h == 210)) then return "ms_std" end
-
-    -- Small screens - (X14 / X14S) Full/Standard
-    if (w == 640 and (h == 338 or h == 360)) then return "ss_full" end
-    if (w == 630 and (h == 236 or h == 258)) then return "ss_std" end
-
-    return "unknown"
-end
-
-local W, H = lcd.getWindowSize()
-local screenGroup = getScreenSize(W, H)
 
 -- Theme config support
 local theme_section = "system/@aerc"
@@ -78,41 +67,95 @@ local THEME_DEFAULTS = {
     tx_max       = 8.4
 }
 
+-- Theme Options based on screen width
+local function getThemeOptionKey(W)
+    if     W == 800 then return "ls_full"
+    elseif W == 784 then return "ls_std"
+    elseif W == 640 then return "ss_full"
+    elseif W == 630 then return "ss_std"
+    elseif W == 480 then return "ms_full"
+    elseif W == 472 then return "ms_std"
+    end
+end
+
 -- Theme Options based on screen size
 local themeOptions = {
 
     -- Large screens - (X20 / X20RS / X18RS etc) Full/Standard
-    ls_full = { cols = 6, rows = 12, font = "FONT_XXL", advfont = "FONT_L", thickness = 28, gaugepadding = 10, gaugepaddingbottom = 40, 
-                maxpaddingtop = 60, maxpaddingleft = 20, valuepaddingbottom = 25, maxfont = "FONT_L", 
-                txgaugepaddingtop = 5, txgaugepaddingbottom = 5, txgaugepaddingleft = 36, txgaugepaddingright = 34, 
-                rssivaluepaddingleft = 22, barpadding = 5, barpaddingleft = 25, barpaddingright = 25},
+    ls_full = { 
+        font = "FONT_XXL", 
+        advfont = "FONT_L", 
+        thickness = 28, 
+        gaugepadding = 10, 
+        gaugepaddingbottom = 40, 
+        maxpaddingtop = 60, 
+        maxpaddingleft = 20, 
+        valuepaddingbottom = 25, 
+        maxfont = "FONT_L"
+    },
 
-    ls_std  = { cols = 6, rows = 11, font = "FONT_XL", advfont = "FONT_M", thickness = 20, gaugepadding = 0, gaugepaddingbottom = 0, 
-                maxpaddingtop = 30, maxpaddingleft = 10, valuepaddingbottom = 0, maxfont = "FONT_S"},
+    ls_std  = { 
+        font = "FONT_XL", 
+        advfont = "FONT_M", 
+        thickness = 22, 
+        gaugepadding = 0, 
+        gaugepaddingbottom = 0, 
+        maxpaddingtop = 30, 
+        maxpaddingleft = 10, 
+        valuepaddingbottom = 0, 
+        maxfont = "FONT_S"
+    },
 
     -- Medium screens (X18 / X18S / TWXLITE) - Full/Standard
-    ms_full = { cols = 6, rows = 12, font = "FONT_XL", advfont = "FONT_M", thickness = 17, gaugepadding = 5, gaugepaddingbottom = 20, 
-                maxpaddingtop = 30, maxpaddingleft = 10, valuepaddingbottom = 15, maxfont = "FONT_S", 
-                txgaugepaddingtop = 2, txgaugepaddingbottom = 2, txgaugepaddingleft = 18, txgaugepaddingright = 17, 
-                rssivaluepaddingleft = 10, barpadding = 2, barpaddingleft = 5, barpaddingright = 5},
+    ms_full = { 
+        font = "FONT_XL", 
+        advfont = "FONT_M", 
+        thickness = 17, 
+        gaugepadding = 5, 
+        gaugepaddingbottom = 20, 
+        maxpaddingtop = 30, 
+        maxpaddingleft = 10, 
+        valuepaddingbottom = 15, 
+        maxfont = "FONT_S"
+    },
 
-    ms_std  = { cols = 6, rows = 11, font = "FONT_XL", advfont = "FONT_M", thickness = 14, gaugepadding = 0, gaugepaddingbottom = 0, 
-                maxpaddingtop = 20, maxpaddingleft = 10, valuepaddingbottom = 0, maxfont = "FONT_S"},
+    ms_std  = {
+        font = "FONT_XL", 
+        advfont = "FONT_M", 
+        thickness = 14, 
+        gaugepadding = 0, 
+        gaugepaddingbottom = 0, 
+        maxpaddingtop = 20, 
+        maxpaddingleft = 10, 
+        valuepaddingbottom = 0, 
+        maxfont = "FONT_S"
+    },
 
     -- Small screens - (X14 / X14S) Full/Standard
-    ss_full = { cols = 6, rows = 12, font = "FONT_XXL", advfont = "FONT_M", thickness = 19, gaugepadding = 5, gaugepaddingbottom = 20, 
-                maxpaddingtop = 30, maxpaddingleft = 10, valuepaddingbottom = 15, maxfont = "FONT_S", 
-                txgaugepaddingtop = 2, txgaugepaddingbottom = 2, txgaugepaddingleft = 22, txgaugepaddingright = 21, 
-                rssivaluepaddingleft = 9, barpadding = 2, barpaddingleft = 13, barpaddingright = 13},
+    ss_full = { 
+        font = "FONT_XXL", 
+        advfont = "FONT_M", 
+        thickness = 19, 
+        gaugepadding = 5, 
+        gaugepaddingbottom = 20, 
+        maxpaddingtop = 30, 
+        maxpaddingleft = 10, 
+        valuepaddingbottom = 15, 
+        maxfont = "FONT_S"
+    },
 
-    ss_std  = { cols = 6, rows = 11, font = "FONT_XL", advfont = "FONT_M", thickness = 14, gaugepadding = 0, gaugepaddingbottom = 0, 
-                maxpaddingtop = 20, maxpaddingleft = 10, valuepaddingbottom = 0, maxfont = "FONT_S"},
-
-    -- Fallbacks
-    unknown = { cols = 6, rows = 11, font = "FONT_XL", advfont = "FONT_M", thickness = 20, gaugepadding = 0, gaugepaddingbottom = 0, 
-                maxpaddingtop = 30, maxpaddingleft = 10, valuepaddingbottom = 0, maxfont = "FONT_S"},
+    ss_std  = {
+        font = "FONT_XL", 
+        advfont = "FONT_M", 
+        thickness = 14, 
+        gaugepadding = 0, 
+        gaugepaddingbottom = 0, 
+        maxpaddingtop = 20, 
+        maxpaddingleft = 10, 
+        valuepaddingbottom = 0, 
+        maxfont = "FONT_S"
+    },
 }
-
 
 local function getThemeValue(key)
     if rfsuite and rfsuite.session and rfsuite.session.modelPreferences and rfsuite.session.modelPreferences[theme_section] then
@@ -124,170 +167,276 @@ local function getThemeValue(key)
 end
 
 -- Caching for boxes
+local lastScreenW = nil
 local boxes_cache = nil
 local themeconfig = nil
-local lastWindowWidth = nil
-local lastWindowHeight = nil
+local headeropts = utils.getHeaderOptions()
 
 -- Theme Layout
-local function getLayout()
-    local opts = themeOptions[screenGroup] or themeOptions.unknown
-    return { cols = opts.cols, rows = opts.rows }
-end
+local layout = {
+    cols    = 3,
+    rows    = 10,
+}
+
+local header_layout = {
+    height  = headeropts.height,
+    cols    = 7,
+    rows    = 1,
+}
 
 -- Boxes
-local function buildBoxes()
-    local opts = themeOptions[screenGroup] or themeOptions.unknown
+local function buildBoxes(W)
 
-    local boxes = {
-        
-        -- Craftname
-        {col = 1, row = 1, colspan = 2, type = "text", subtype = "craftname", font = "FONT_L", valuepaddingleft = 10, bgcolor = colorMode.bgcolor, titlecolor = colorMode.titlecolor, textcolor = colorMode.textcolor},
+    -- Object based options determined by screensize
+    local opts = themeOptions[getThemeOptionKey(W)] or themeOptions.unknown
 
-        -- RF Logo
-        {col = 3, row = 1, colspan = 2, type = "image", subtype = "image", bgcolor = colorMode.bgcolor},
-
-        -- TX Battery
-        {col = 5, row = 1,
-        type = "gauge", subtype = "bar", source = "txbatt",
-        font = "FONT_S", battery = true, batteryframe = true, hidevalue = true,
-        batteryframethickness = 2, decimals = 1, unit = "v", valuepaddingleft = 35, valuepaddingbottom = 10, valuealign = "left",
-        gaugepaddingtop = opts.txgaugepaddingtop, gaugepaddingbottom = opts.txgaugepaddingbottom, gaugepaddingleft = opts.txgaugepaddingleft, gaugepaddingright = opts.txgaugepaddingright,
-        batterysegments = 4, batterysegmentpaddingtop = 4, batterysegmentpaddingbottom = 4, batterysegmentpaddingleft = 4, batterysegmentpaddingright = 3, batteryspacing = 1,
-        fillcolor = colorMode.fillcolor, bgcolor = colorMode.bgcolor, accentcolor = colorMode.txaccentcolor, textcolor = colorMode.textcolor,
-        min = getThemeValue("tx_min"), max = getThemeValue("tx_max"), 
-        thresholds = {
-            { value = getThemeValue("tx_warn"), fillcolor = "orange"   },
-            { value = getThemeValue("tx_max"), fillcolor = "darkwhite"  }
-            }                        
-        },
-
-        -- RSSI
-        {col = 6, row = 1,
-        type = "gauge", subtype = "step", source = "rssi",            
-        font = "FONT_XS", barpadding = opts.barpadding, stepgap = 3, stepcount = 5, decimals = 0,
-        valuealign = "left", valuepaddingbottom = 20, valuepaddingleft = opts.rssivaluepaddingleft,
-        barpaddingleft = opts.barpaddingleft, barpaddingright = opts.barpaddingright,
-        bgcolor = colorMode.bgcolor, textcolor = colorMode.textcolor, fillcolor = colorMode.rssifillcolor,
-        },
-
+    return {
         -- Timer
-        {col = 1, colspan = 2, row = 1, rowspan = 3, 
-        type = "time", subtype = "flight", 
-        font = opts.font,
-        title = i18n("widgets.dashboard.flight_time"):upper(),
-        titlepos = "bottom",
-        bgcolor = colorMode.bgcolor,
-        titlecolor = colorMode.titlecolor,
-        textcolor = colorMode.textcolor,
+        {
+            col = 1, 
+            row = 1, 
+            rowspan = 2, 
+            type = "time", 
+            subtype = "flight", 
+            font = opts.font,
+            title = i18n("widgets.dashboard.flight_time"):upper(),
+            titlepos = "bottom",
+            bgcolor = colorMode.bgcolor,
+            titlecolor = colorMode.titlecolor,
+            textcolor = colorMode.textcolor,
         },
 
         -- Battery Bar
-        {col = 3, row = 1, colspan = 4, rowspan = 3,
-        type = "gauge", source = "smartfuel", battadv = true,
-        fillcolor = "green",
-        valuealign = "left", valuepaddingleft = 85, valuepaddingbottom = 10,
-        battadvfont = "FONT_M", font = opts.font,
-        battadvpaddingright = 5, battadvvaluealign = "right",
-        transform = "floor",
-        titlecolor = colorMode.titlecolor, textcolor = colorMode.textcolor,
-        thresholds = {
-            { value = 10,  fillcolor = "red"    },
-            { value = 30,  fillcolor = "orange" }
-        }
+        {
+            col = 2, 
+            row = 1,
+            colspan = 2, 
+            rowspan = 2,
+            type = "gauge", 
+            source = "smartfuel", 
+            battadv = true,
+            fillcolor = "green",
+            valuealign = "left", 
+            valuepaddingleft = 85, 
+            valuepaddingbottom = 10,
+            battadvfont = "FONT_M", 
+            font = opts.font,
+            battadvpaddingright = 5, 
+            battadvvaluealign = "right",
+            transform = "floor",
+            titlecolor = colorMode.titlecolor, 
+            textcolor = colorMode.textcolor,
+            thresholds = {
+                { value = 10,  fillcolor = "red"    },
+                { value = 30,  fillcolor = "orange" }
+            }
         },
 
         -- Throttle
-        {col = 1, colspan = 2, row = 4, rowspan = 8,
-        type = "gauge", subtype = "arc", source = "throttle_percent", arcmax = true,
-        title = i18n("widgets.dashboard.throttle"):upper(), titlepos = "bottom", 
-        thickness = opts.thickness, font = opts.font, maxfont = opts.maxfont,
-        maxprefix = "Max: ", maxpaddingtop = opts.maxpaddingtop,
-        gaugepadding = opts.gaugepadding, gaugepaddingbottom = opts.gaugepaddingbottom, valuepaddingbottom = opts.valuepaddingbottom,
-        bgcolor = colorMode.bgcolor, titlecolor = colorMode.titlecolor, textcolor = colorMode.textcolor, maxtextcolor = "orange",
-        transform = "floor",
-        thresholds = {
-            { value = 89,  fillcolor = "blue"       },
-            { value = 100, fillcolor = "darkblue"   }
-        }
+        {
+            col = 1, 
+            row = 3, 
+            rowspan = 8,
+            type = "gauge", 
+            subtype = "arc", 
+            source = "throttle_percent", 
+            arcmax = true,
+            title = i18n("widgets.dashboard.throttle"):upper(), 
+            titlepos = "bottom", 
+            thickness = opts.thickness, 
+            font = opts.font, 
+            maxfont = opts.maxfont,
+            maxprefix = "Max: ", 
+            maxpaddingtop = opts.maxpaddingtop,
+            gaugepadding = opts.gaugepadding, 
+            gaugepaddingbottom = opts.gaugepaddingbottom, 
+            valuepaddingbottom = opts.valuepaddingbottom,
+            bgcolor = colorMode.bgcolor,
+            fillbgcolor = colorMode.fillbgcolor,
+            titlecolor = colorMode.titlecolor, 
+            textcolor = colorMode.textcolor, 
+            maxtextcolor = "orange",
+            transform = "floor",
+            thresholds = {
+                { value = 89,  fillcolor = "blue"       },
+                { value = 100, fillcolor = "darkblue"   }
+            }
         },
 
         -- Headspeed
-        {col = 3, colspan = 2, row = 4, rowspan = 8,
-        type = "gauge", subtype = "arc", source = "rpm", arcmax = true,
-        title = i18n("widgets.dashboard.headspeed"):upper(), titlepos = "bottom", 
-        min = 0, max = getThemeValue("rpm_max"),
-        thickness = opts.thickness,
-        unit = "",
-        maxprefix = "Max: ", font = opts.font, maxpaddingtop = opts.maxpaddingtop, maxfont = opts.maxfont,
-        gaugepadding = opts.gaugepadding, gaugepaddingbottom = opts.gaugepaddingbottom, valuepaddingbottom = opts.valuepaddingbottom,
-        bgcolor = colorMode.bgcolor, titlecolor = colorMode.titlecolor, textcolor = colorMode.textcolor, maxtextcolor = "orange",
-        transform = "floor",
-        thresholds = {
-            { value = getThemeValue("rpm_min"),   fillcolor = "lightpurple"   },
-            { value = getThemeValue("rpm_max"),   fillcolor = "purple"        },
-            { value = 10000,                      fillcolor = "darkpurple"    }
-        }
+        {
+            col = 2, 
+            row = 3, 
+            rowspan = 8,
+            type = "gauge", 
+            subtype = "arc", 
+            source = "rpm", 
+            arcmax = true,
+            title = i18n("widgets.dashboard.headspeed"):upper(), 
+            titlepos = "bottom", 
+            min = 0, 
+            max = getThemeValue("rpm_max"),
+            thickness = opts.thickness,
+            unit = "",
+            maxprefix = "Max: ", 
+            font = opts.font, 
+            maxpaddingtop = opts.maxpaddingtop, 
+            maxfont = opts.maxfont,
+            gaugepadding = opts.gaugepadding, 
+            gaugepaddingbottom = opts.gaugepaddingbottom, 
+            valuepaddingbottom = opts.valuepaddingbottom,
+            bgcolor = colorMode.bgcolor,
+            fillbgcolor = colorMode.fillbgcolor,
+            titlecolor = colorMode.titlecolor, 
+            textcolor = colorMode.textcolor, 
+            maxtextcolor = "orange",
+            transform = "floor",
+            thresholds = {
+                { value = getThemeValue("rpm_min"),   fillcolor = "lightpurple"   },
+                { value = getThemeValue("rpm_max"),   fillcolor = "purple"        },
+                { value = 10000,                      fillcolor = "darkpurple"    }
+            }
         },
 
         -- ESC Temp
-        {col = 5, colspan = 2, row = 4, rowspan = 8,
-        type = "gauge", subtype = "arc", source = "temp_esc", arcmax = true,
-        title = i18n("widgets.dashboard.esc_temp"):upper(), titlepos = "bottom", 
-        min = 0, max = getThemeValue("esctemp_max"), 
-        thickness = opts.thickness,
-        valuepaddingleft = 10, valuepaddingbottom = opts.valuepaddingbottom, maxpaddingleft = opts.maxpaddingleft, maxpaddingtop = opts.maxpaddingtop,
-        maxprefix = "Max: ",maxfont = opts.maxfont, font = opts.font,
-        gaugepadding = opts.gaugepadding, gaugepaddingbottom = opts.gaugepaddingbottom,
-        bgcolor = colorMode.bgcolor, titlecolor = colorMode.titlecolor, textcolor = colorMode.textcolor, maxtextcolor = "orange",
-        transform = "floor", 
-        thresholds = {
-            { value = getThemeValue("esctemp_warn"), fillcolor = "green"  },
-            { value = getThemeValue("esctemp_max"),  fillcolor = "orange" },
-            { value = 200,                           fillcolor = "red"    }
-        }
+        {
+            col = 3, 
+            row = 3, 
+            rowspan = 8,
+            type = "gauge", 
+            subtype = "arc", 
+            source = "temp_esc", 
+            arcmax = true,
+            title = i18n("widgets.dashboard.esc_temp"):upper(), 
+            titlepos = "bottom", 
+            min = 0, max = getThemeValue("esctemp_max"), 
+            thickness = opts.thickness,
+            valuepaddingleft = 10, 
+            valuepaddingbottom = opts.valuepaddingbottom, 
+            maxpaddingleft = opts.maxpaddingleft, 
+            maxpaddingtop = opts.maxpaddingtop,
+            maxprefix = "Max: ",
+            maxfont = opts.maxfont, 
+            font = opts.font,
+            gaugepadding = opts.gaugepadding, 
+            gaugepaddingbottom = opts.gaugepaddingbottom,
+            bgcolor = colorMode.bgcolor,
+            fillbgcolor = colorMode.fillbgcolor, 
+            titlecolor = colorMode.titlecolor, 
+            textcolor = colorMode.textcolor, 
+            maxtextcolor = "orange",
+            transform = "floor", 
+            thresholds = {
+                { value = getThemeValue("esctemp_warn"), fillcolor = "green"  },
+                { value = getThemeValue("esctemp_max"),  fillcolor = "orange" },
+                { value = 200,                           fillcolor = "red"    }
+            }
         },
     }
-
-    if screenGroup and screenGroup:find("_full") then
-        for _, box in ipairs(boxes) do
-            -- Do not shift these four specific boxes
-            local isTopRow =
-                (box.type == "text"  and box.subtype == "craftname") or
-                (box.type == "image" and box.subtype == "image") or
-                (box.type == "gauge" and box.subtype == "bar" and box.source == "txbatt") or
-                (box.type == "gauge" and box.subtype == "step" and box.source == "rssi")
-            if not isTopRow then
-                box.row = (box.row or 1) + 1
-            end
-        end
-    end
-    
-    return boxes
 end
 
+local header_boxes = {
+-- Craftname
+    { 
+        col = 1, 
+        row = 1, 
+        colspan = 2, 
+        type = "text", 
+        subtype = "craftname",
+        font = headeropts.font, 
+        valuealign = "left", 
+        valuepaddingleft = 5,
+        bgcolor = colorMode.bgcolor, 
+        titlecolor = colorMode.titlecolor, 
+        textcolor = colorMode.textcolor 
+    },
+
+    -- RF Logo
+    { 
+        col = 3, 
+        row = 1, 
+        colspan = 3, 
+        type = "image", 
+        subtype = "image",
+        bgcolor = colorMode.bgcolor 
+    },
+
+    -- TX Battery
+    { 
+        col = 6, 
+        row = 1,
+        type = "gauge", 
+        subtype = "bar", 
+        source = "txbatt",
+        font = headeropts.font,
+        battery = true, 
+        batteryframe = true, 
+        hidevalue = true,
+        valuealign = "left", 
+        batterysegments = 4, 
+        batteryspacing = 1, 
+        batteryframethickness  = 2,
+        batterysegmentpaddingtop = headeropts.batterysegmentpaddingtop,
+        batterysegmentpaddingbottom = headeropts.batterysegmentpaddingbottom,
+        batterysegmentpaddingleft = headeropts.batterysegmentpaddingleft,
+        batterysegmentpaddingright = headeropts.batterysegmentpaddingright,
+        gaugepaddingright = headeropts.gaugepaddingright,
+        gaugepaddingleft = headeropts.gaugepaddingleft,
+        gaugepaddingbottom = headeropts.gaugepaddingbottom,
+        gaugepaddingtop = headeropts.gaugepaddingtop,
+        fillbgcolor = colorMode.txbgfillcolor, 
+        bgcolor = colorMode.bgcolor,
+        accentcolor = colorMode.txaccentcolor, 
+        textcolor = colorMode.textcolor,
+        min = getThemeValue("tx_min"), 
+        max = getThemeValue("tx_max"), 
+        thresholds = {
+            { value = getThemeValue("tx_warn"), fillcolor = "orange" },
+            { value = getThemeValue("tx_max"), fillcolor = colorMode.txfillcolor }
+        }
+    },
+
+    -- RSSI
+    { 
+        col = 7, 
+        row = 1,
+        type = "gauge", 
+        subtype = "step", 
+        source = "rssi",
+        font = "FONT_XS", 
+        stepgap = 2, 
+        stepcount = 5, 
+        decimals = 0,
+        valuealign = "left",
+        barpaddingleft = headeropts.barpaddingleft,
+        barpaddingright = headeropts.barpaddingright,
+        barpaddingbottom = headeropts.barpaddingbottom,
+        barpaddingtop = headeropts.barpaddingtop,
+        valuepaddingleft = headeropts.valuepaddingleft,
+        valuepaddingbottom = headeropts.valuepaddingbottom,
+        bgcolor = colorMode.bgcolor, 
+        textcolor = colorMode.textcolor, 
+        fillcolor = colorMode.rssifillcolor,
+        fillbgcolor = colorMode.rssifillbgcolor,
+    },
+}
+
 local function boxes()
-    local config =
-        rfsuite and rfsuite.session and rfsuite.session.modelPreferences and rfsuite.session.modelPreferences[theme_section]
-    local W, H = lcd.getWindowSize()
-    -- Detect layout size change
-    if boxes_cache == nil
-        or themeconfig ~= config
-        or lastWindowWidth ~= W
-        or lastWindowHeight ~= H then
-        -- Re-evaluate screen group and options
-        screenGroup = getScreenSize(W, H)
-        boxes_cache = buildBoxes()
+    local config = rfsuite and rfsuite.session and rfsuite.session.modelPreferences and rfsuite.session.modelPreferences[theme_section]
+    local W = lcd.getWindowSize()
+    if boxes_cache == nil or themeconfig ~= config or lastScreenW ~= W then
+        boxes_cache = buildBoxes(W)
         themeconfig = config
-        lastWindowWidth = W
-        lastWindowHeight = H
+        lastScreenW = W
     end
     return boxes_cache
 end
 
 return {
-    layout = getLayout,
+    layout = layout,
     boxes = boxes,
+    header_boxes = header_boxes,
+    header_layout = header_layout,
     scheduler = {
         spread_scheduling = true,         -- (optional: spread scheduling over the interval to avoid spikes in CPU usage) 
         spread_scheduling_paint = false,  -- optional: spread scheduling for paint (if true, paint will be spread over the interval) 

--- a/scripts/rfsuite/widgets/dashboard/themes/@aerc/postflight.lua
+++ b/scripts/rfsuite/widgets/dashboard/themes/@aerc/postflight.lua
@@ -16,6 +16,9 @@
 ]]--
 
 local i18n = rfsuite.i18n.get
+local utils = rfsuite.widgets.dashboard.utils
+local boxes_cache = nil
+local lastScreenW = nil
 
 local function maxVoltageToCellVoltage(value)
     local cfg = rfsuite.session.batteryConfig
@@ -30,49 +33,35 @@ local function maxVoltageToCellVoltage(value)
 end
 
 local darkMode = {
-    textcolor   = "white",
-    titlecolor  = "white",
-    bgcolor     = "black",
-    fillcolor   = "green",
-    fillbgcolor = "grey",
-    accentcolor = "white",
-    rssifillcolor = "darkwhite",
-    txaccentcolor = "grey",
+    textcolor       = "white",
+    titlecolor      = "white",
+    bgcolor         = "black",
+    fillcolor       = "green",
+    fillbgcolor     = "darkgrey",
+    accentcolor     = "white",
+    rssifillcolor   = "green",
+    rssifillbgcolor = "darkgrey",
+    txaccentcolor   = "grey",
+    txfillcolor     = "green",
+    txbgfillcolor   = "darkgrey"
 }
 
 local lightMode = {
-    textcolor   = "black",
-    titlecolor  = "black",
-    bgcolor     = "white",
-    fillcolor   = "green",
-    fillbgcolor = "grey",
-    accentcolor = "black",
-    rssifillcolor = "darkwhite",
-    txaccentcolor = "grey",
+    textcolor       = "black",
+    titlecolor      = "black",
+    bgcolor         = "white",
+    fillcolor       = "green",
+    fillbgcolor     = "lightgrey",
+    accentcolor     = "darkgrey",
+    rssifillcolor   = "green",
+    rssifillbgcolor = "grey",
+    txaccentcolor   = "darkgrey",
+    txfillcolor     = "green",
+    txbgfillcolor   = "grey"
 }
-
 
 -- alias current mode
 local colorMode = lcd.darkMode() and darkMode or lightMode
-
-local function getScreenSize(w, h)
-    -- Large screens - (X20 / X20RS / X18RS etc) Full/Standard
-    if (w == 800 and (h == 458 or h == 480)) then return "ls_full" end
-    if (w == 784 and (h == 294 or h == 316)) then return "ls_std" end
-
-    -- Medium screens (X18 / X18S / TWXLITE) - Full/Standard
-    if (w == 480 and (h == 301 or h == 320)) then return "ms_full" end
-    if (w == 472 and (h == 191 or h == 210)) then return "ms_std" end
-
-    -- Small screens - (X14 / X14S) Full/Standard
-    if (w == 640 and (h == 338 or h == 360)) then return "ss_full" end
-    if (w == 630 and (h == 236 or h == 258)) then return "ss_std" end
-
-    return "unknown"
-end
-
-local W, H = lcd.getWindowSize()
-local screenGroup = getScreenSize(W, H)
 
 -- Theme config support
 local theme_section = "system/@aerc"
@@ -89,32 +78,63 @@ local THEME_DEFAULTS = {
     tx_max       = 8.4
 }
 
+-- Theme Options based on screen width
+local function getThemeOptionKey(W)
+    if     W == 800 then return "ls_full"
+    elseif W == 784 then return "ls_std"
+    elseif W == 640 then return "ss_full"
+    elseif W == 630 then return "ss_std"
+    elseif W == 480 then return "ms_full"
+    elseif W == 472 then return "ms_std"
+    end
+end
+
 -- Theme Options based on screen size
 local themeOptions = {
 
     -- Large screens - (X20 / X20RS / X18RS etc) Full/Standard
-    ls_full = { cols = 6, rows = 13, font = "FONT_XXL", titlefont = "FONT_S", valuepaddingbottom = 20, titlepaddingtop = 15, 
-                txgaugepaddingtop = 5, txgaugepaddingbottom = 5, txgaugepaddingleft = 36, txgaugepaddingright = 34, 
-                rssivaluepaddingleft = 22, barpadding = 5, barpaddingleft = 25, barpaddingright = 25},
+    ls_full = {
+        font = "FONT_XXL", 
+        titlefont = "FONT_S", 
+        valuepaddingbottom = 20, 
+        titlepaddingtop = 15
+    },
 
-    ls_std  = { cols = 6, rows = 12, font = "FONT_XL", titlefont = "FONT_XS", valuepaddingbottom = 25, titlepaddingtop = 0},
+    ls_std  = {
+        font = "FONT_XL", 
+        titlefont = "FONT_XS", 
+        valuepaddingbottom = 25, 
+        titlepaddingtop = 0},
 
     -- Medium screens (X18 / X18S / TWXLITE) - Full/Standard
-    ms_full = { cols = 6, rows = 13, font = "FONT_XL", titlefont = "FONT_XS", valuepaddingbottom = 15, titlepaddingtop = 5, 
-                txgaugepaddingtop = 2, txgaugepaddingbottom = 0, txgaugepaddingleft = 18, txgaugepaddingright = 17, 
-                rssivaluepaddingleft = 10, barpadding = 2, barpaddingleft = 5, barpaddingright = 5},
+    ms_full = {
+        font = "FONT_XL", 
+        titlefont = "FONT_XS", 
+        valuepaddingbottom = 15, 
+        titlepaddingtop = 5
+    },
 
-    ms_std  = { cols = 6, rows = 12, font = "FONT_XL", titlefont = "FONT_XXS", valuepaddingbottom = 0, titlepaddingtop = 0},
+    ms_std  = {
+        font = "FONT_XL", 
+        titlefont = "FONT_XXS", 
+        valuepaddingbottom = 0, 
+        titlepaddingtop = 0
+    },
 
     -- Small screens - (X14 / X14S) Full/Standard
-    ss_full = { cols = 6, rows = 13, font = "FONT_XL", titlefont = "FONT_XS", valuepaddingbottom = 15, titlepaddingtop = 5, 
-                txgaugepaddingtop = 2, txgaugepaddingbottom = 2, txgaugepaddingleft = 22, txgaugepaddingright = 21, 
-                rssivaluepaddingleft = 9, barpadding = 2, barpaddingleft = 13, barpaddingright = 13},
+    ss_full = {
+        font = "FONT_XL", 
+        titlefont = "FONT_XS", 
+        valuepaddingbottom = 15, 
+        titlepaddingtop = 5
+    },
 
-    ss_std  = { cols = 6, rows = 12, font = "FONT_XL", titlefont = "FONT_XXS", valuepaddingbottom = 0, titlepaddingtop = 0},
-
-    -- Fallbacks
-    unknown = { cols = 6, rows = 12, font = "FONT_XL", titlefont = "FONT_XS", valuepaddingbottom = 25, titlepaddingtop = 0},
+    ss_std  = {
+        font = "FONT_XL", 
+        titlefont = "FONT_XXS", 
+        valuepaddingbottom = 0, 
+        titlepaddingtop = 0
+    },
 }
 
 local function getThemeValue(key)
@@ -127,135 +147,174 @@ local function getThemeValue(key)
 end
 
 -- Caching for boxes
+local lastScreenW = nil
 local boxes_cache = nil
 local themeconfig = nil
-local lastWindowWidth = nil
-local lastWindowHeight = nil
+local headeropts = utils.getHeaderOptions()
 
 -- Theme Layout
-local function getLayout()
-    local opts = themeOptions[screenGroup] or themeOptions.unknown
-    return { cols = opts.cols, rows = opts.rows }
-end
+local layout = {
+    cols    = 3,
+    rows    = 8,
+}
+
+local header_layout = {
+    height  = headeropts.height,
+    cols    = 7,
+    rows    = 1,
+}
 
 -- Boxes
-local function buildBoxes()
-    local opts = themeOptions[screenGroup] or themeOptions.unknown
-    
-    local boxes = {
-    
-        -- Craftname
-        { col = 1, row = 1, colspan = 2, type = "text", subtype = "craftname", font = "FONT_L", valuepaddingleft = 10, bgcolor = colorMode.bgcolor, titlecolor = colorMode.titlecolor, textcolor = colorMode.textcolor},
+local function buildBoxes(W)
 
-        -- RF Logo
-        {col = 3, row = 1, colspan = 2, type = "image", subtype = "image", bgcolor = colorMode.bgcolor},
+    -- Object based options determined by screensize
+    local opts = themeOptions[getThemeOptionKey(W)] or themeOptions.unknown
 
-        -- TX Battery
-        {col = 5, row = 1,
-        type = "gauge", subtype = "bar", source = "txbatt",
-        font = "FONT_S", battery = true, batteryframe = true, hidevalue = true,
-        batteryframethickness = 2, decimals = 1, unit = "v", valuepaddingleft = 35, valuepaddingbottom = 10, valuealign = "left",
-        gaugepaddingtop = opts.txgaugepaddingtop, gaugepaddingbottom = opts.txgaugepaddingbottom, gaugepaddingleft = opts.txgaugepaddingleft, gaugepaddingright = opts.txgaugepaddingright,
-        batterysegments = 4, batterysegmentpaddingtop = 4, batterysegmentpaddingbottom = 4, batterysegmentpaddingleft = 4, batterysegmentpaddingright = 3, batteryspacing = 1,
-        fillcolor = colorMode.fillcolor, bgcolor = colorMode.bgcolor, accentcolor = colorMode.txaccentcolor, textcolor = colorMode.textcolor,
-        min = getThemeValue("tx_min"), max = getThemeValue("tx_max"), 
-        thresholds = {
-            { value = getThemeValue("tx_warn"), fillcolor = "orange"   },
-            { value = getThemeValue("tx_max"), fillcolor = "darkwhite"  }
-            }                        
-        },
-
-        -- RSSI
-        {col = 6, row = 1,
-        type = "gauge", subtype = "step", source = "rssi",            
-        font = "FONT_XS", barpadding = opts.barpadding, stepgap = 3, stepcount = 5, decimals = 0,
-        valuealign = "left", valuepaddingbottom = 20, valuepaddingleft = opts.rssivaluepaddingleft,
-        barpaddingleft = opts.barpaddingleft, barpaddingright = opts.barpaddingright,
-        bgcolor = colorMode.bgcolor, textcolor = colorMode.textcolor, fillcolor = colorMode.rssifillcolor, 
-        },
-
+    return {    
         -- Flight info and RPM info
-        {col = 1, row = 1, colspan = 2, rowspan = 3, type = "time", subtype = "flight", title = i18n("widgets.dashboard.flight_duration"), titlepos = "top", titlepaddingtop = opts.titlepaddingtop,
+        {col = 1, row = 1, rowspan = 2, type = "time", subtype = "flight", title = i18n("widgets.dashboard.flight_duration"), titlepos = "top", titlepaddingtop = opts.titlepaddingtop,
         font = opts.font, titlefont = opts.titlefont, bgcolor = colorMode.bgcolor, titlecolor = colorMode.titlecolor, textcolor = "orange"},
 
-        {col = 1, row = 4, colspan = 2, rowspan = 3, type = "time", subtype = "total", title = i18n("widgets.dashboard.total_flight_duration"), titlepos = "top", titlepaddingtop = opts.titlepaddingtop, 
+        {col = 1, row = 3, rowspan = 2, type = "time", subtype = "total", title = i18n("widgets.dashboard.total_flight_duration"), titlepos = "top", titlepaddingtop = opts.titlepaddingtop, 
         font = opts.font, titlefont = opts.titlefont, bgcolor = colorMode.bgcolor, titlecolor = colorMode.titlecolor, textcolor = "orange"},
 
-        {col = 1, row = 7, colspan = 2, rowspan = 3, type = "time", subtype = "count", title = i18n("widgets.dashboard.flights"), titlepos = "top", titlepaddingtop = opts.titlepaddingtop, 
+        {col = 1, row = 5, rowspan = 2, type = "time", subtype = "count", title = i18n("widgets.dashboard.flights"), titlepos = "top", titlepaddingtop = opts.titlepaddingtop, 
         font = opts.font, titlefont = opts.titlefont, bgcolor = colorMode.bgcolor, titlecolor = colorMode.titlecolor, textcolor = "orange", transform = "floor"},
 
-        {col = 1, row = 10, colspan = 2, rowspan = 3, type = "text", subtype = "stats", source = "rpm", title = i18n("widgets.dashboard.rpm_max"), unit = " rpm", titlepos = "top", titlepaddingtop = opts.titlepaddingtop, 
+        {col = 1, row = 7, rowspan = 2, type = "text", subtype = "stats", source = "rpm", title = i18n("widgets.dashboard.rpm_max"), unit = " rpm", titlepos = "top", titlepaddingtop = opts.titlepaddingtop, 
         font = opts.font, titlefont = opts.titlefont, bgcolor = colorMode.bgcolor, titlecolor = colorMode.titlecolor, textcolor = "orange", transform = "floor"},
 
         -- Flight max/min stats 1
-        {col = 3, row = 1, colspan = 2, rowspan = 3, type = "text", subtype = "watts", source = "max", title = i18n("widgets.dashboard.watts_max"), unit = "W", titlepos = "top", titlepaddingtop = opts.titlepaddingtop, 
+        {col = 2, row = 1, rowspan = 2, type = "text", subtype = "watts", source = "max", title = i18n("widgets.dashboard.watts_max"), unit = "W", titlepos = "top", titlepaddingtop = opts.titlepaddingtop, 
         font = opts.font, titlefont = opts.titlefont, bgcolor = colorMode.bgcolor, transform = "floor", textcolor = "orange", titlecolor = colorMode.titlecolor},
 
-        {col = 3, row = 4, colspan = 2, rowspan = 3, type = "text", subtype = "stats", source = "current", title = i18n("widgets.dashboard.current_max"), titlepos = "top", titlepaddingtop = opts.titlepaddingtop, 
+        {col = 2, row = 3, rowspan = 2, type = "text", subtype = "stats", source = "current", title = i18n("widgets.dashboard.current_max"), titlepos = "top", titlepaddingtop = opts.titlepaddingtop, 
         font = opts.font, titlefont = opts.titlefont, bgcolor = colorMode.bgcolor, titlecolor = colorMode.titlecolor, textcolor = "orange", transform = "floor"},
 
-        {col = 3, row = 7, colspan = 2, rowspan = 3, type = "text", subtype = "stats", source = "temp_esc", title = i18n("widgets.dashboard.esc_max_temp"), titlepos = "top", titlepaddingtop = opts.titlepaddingtop, 
+        {col = 2, row = 5, rowspan = 2, type = "text", subtype = "stats", source = "temp_esc", title = i18n("widgets.dashboard.esc_max_temp"), titlepos = "top", titlepaddingtop = opts.titlepaddingtop, 
         font = opts.font, titlefont = opts.titlefont, bgcolor = colorMode.bgcolor, titlecolor = colorMode.titlecolor, textcolor = "orange", transform = "floor"},
 
-        {col = 3, row = 10, colspan = 2, rowspan = 3, type = "text", subtype = "stats", source = "altitude", title = i18n("widgets.dashboard.altitude_max"), titlepos = "top", titlepaddingtop = opts.titlepaddingtop, 
+        {col = 2, row = 7, rowspan = 2, type = "text", subtype = "stats", source = "altitude", title = i18n("widgets.dashboard.altitude_max"), titlepos = "top", titlepaddingtop = opts.titlepaddingtop, 
         font = opts.font, titlefont = opts.titlefont, bgcolor = colorMode.bgcolor, titlecolor = colorMode.titlecolor, textcolor = "orange", transform = "floor"},
 
         -- Flight max/min stats 2
-        {col = 5, row = 1, colspan = 2, rowspan = 3, type = "text", subtype = "stats", stattype = "max", source = "consumption", title = i18n("widgets.dashboard.consumed_mah"), titlepos = "top", titlepaddingtop = opts.titlepaddingtop, 
+        {col = 3, row = 1, rowspan = 2, type = "text", subtype = "stats", stattype = "max", source = "consumption", title = i18n("widgets.dashboard.consumed_mah"), titlepos = "top", titlepaddingtop = opts.titlepaddingtop, 
         font = opts.font, titlefont = opts.titlefont, bgcolor = colorMode.bgcolor, titlecolor = colorMode.titlecolor, textcolor = "orange", transform = "floor"},
 
-        {col = 5, row = 4, colspan = 2, rowspan = 3, type = "text", subtype = "stats", stattype = "min", source = "smartfuel", title = i18n("widgets.dashboard.fuel_remaining"), titlepos = "top", titlepaddingtop = opts.titlepaddingtop,
+        {col = 3, row = 3, rowspan = 2, type = "text", subtype = "stats", stattype = "min", source = "smartfuel", title = i18n("widgets.dashboard.fuel_remaining"), titlepos = "top", titlepaddingtop = opts.titlepaddingtop,
         font = opts.font, titlefont = opts.titlefont, bgcolor = colorMode.bgcolor, titlecolor = colorMode.titlecolor, textcolor = "orange", transform = "floor"},
 
-        {col = 5, row = 7, colspan = 2, rowspan = 3, type = "text", subtype = "telemetry", source = "voltage", title = i18n("widgets.dashboard.volts_per_cell"), titlepos = "top", titlepaddingtop = opts.titlepaddingtop, 
+        {col = 3, row = 5, rowspan = 2, type = "text", subtype = "telemetry", source = "voltage", title = i18n("widgets.dashboard.volts_per_cell"), titlepos = "top", titlepaddingtop = opts.titlepaddingtop, 
         font = opts.font, titlefont = opts.titlefont, bgcolor = colorMode.bgcolor, titlecolor = colorMode.titlecolor, textcolor = "orange", unit = "V", transform = function(v) return maxVoltageToCellVoltage(v) end},
 
-        {col = 5, row = 10, colspan = 2, rowspan = 3, type = "text", subtype = "stats", stattype = "min", source = "rssi", title = i18n("widgets.dashboard.link_min"), titlepos = "top", titlepaddingtop = opts.titlepaddingtop,
+        {col = 3, row = 7, rowspan = 2, type = "text", subtype = "stats", stattype = "min", source = "rssi", title = i18n("widgets.dashboard.link_min"), titlepos = "top", titlepaddingtop = opts.titlepaddingtop,
         font = opts.font, titlefont = opts.titlefont, bgcolor = colorMode.bgcolor, titlecolor = colorMode.titlecolor, textcolor = "orange", transform = "floor"},
     }
-
-    if screenGroup and screenGroup:find("_full") then
-        for _, box in ipairs(boxes) do
-            -- Do not shift these four specific boxes
-            local isTopRow =
-                (box.type == "text"  and box.subtype == "craftname") or
-                (box.type == "image" and box.subtype == "image") or
-                (box.type == "gauge" and box.subtype == "bar" and box.source == "txbatt") or
-                (box.type == "gauge" and box.subtype == "step" and box.source == "rssi")
-            if not isTopRow then
-                box.row = (box.row or 1) + 1
-            end
-        end
-    end
-    
-    return boxes
 end
 
+local header_boxes = {
+-- Craftname
+    { 
+        col = 1, 
+        row = 1, 
+        colspan = 2, 
+        type = "text", 
+        subtype = "craftname",
+        font = headeropts.font, 
+        valuealign = "left", 
+        valuepaddingleft = 5,
+        bgcolor = colorMode.bgcolor, 
+        titlecolor = colorMode.titlecolor, 
+        textcolor = colorMode.textcolor 
+    },
+
+    -- RF Logo
+    { 
+        col = 3, 
+        row = 1, 
+        colspan = 3, 
+        type = "image", 
+        subtype = "image",
+        bgcolor = colorMode.bgcolor 
+    },
+
+    -- TX Battery
+    { 
+        col = 6, 
+        row = 1,
+        type = "gauge", 
+        subtype = "bar", 
+        source = "txbatt",
+        font = headeropts.font,
+        battery = true, 
+        batteryframe = true, 
+        hidevalue = true,
+        valuealign = "left", 
+        batterysegments = 4, 
+        batteryspacing = 1, 
+        batteryframethickness  = 2,
+        batterysegmentpaddingtop = headeropts.batterysegmentpaddingtop,
+        batterysegmentpaddingbottom = headeropts.batterysegmentpaddingbottom,
+        batterysegmentpaddingleft = headeropts.batterysegmentpaddingleft,
+        batterysegmentpaddingright = headeropts.batterysegmentpaddingright,
+        gaugepaddingright = headeropts.gaugepaddingright,
+        gaugepaddingleft = headeropts.gaugepaddingleft,
+        gaugepaddingbottom = headeropts.gaugepaddingbottom,
+        gaugepaddingtop = headeropts.gaugepaddingtop,
+        fillbgcolor = colorMode.txbgfillcolor, 
+        bgcolor = colorMode.bgcolor,
+        accentcolor = colorMode.txaccentcolor, 
+        textcolor = colorMode.textcolor,
+        min = getThemeValue("tx_min"), 
+        max = getThemeValue("tx_max"), 
+        thresholds = {
+            { value = getThemeValue("tx_warn"), fillcolor = "orange" },
+            { value = getThemeValue("tx_max"), fillcolor = colorMode.txfillcolor }
+        }
+    },
+
+    -- RSSI
+    { 
+        col = 7, 
+        row = 1,
+        type = "gauge", 
+        subtype = "step", 
+        source = "rssi",
+        font = "FONT_XS", 
+        stepgap = 2, 
+        stepcount = 5, 
+        decimals = 0,
+        valuealign = "left",
+        barpaddingleft = headeropts.barpaddingleft,
+        barpaddingright = headeropts.barpaddingright,
+        barpaddingbottom = headeropts.barpaddingbottom,
+        barpaddingtop = headeropts.barpaddingtop,
+        valuepaddingleft = headeropts.valuepaddingleft,
+        valuepaddingbottom = headeropts.valuepaddingbottom,
+        bgcolor = colorMode.bgcolor, 
+        textcolor = colorMode.textcolor, 
+        fillcolor = colorMode.rssifillcolor,
+        fillbgcolor = colorMode.rssifillbgcolor,
+    },
+}
+
 local function boxes()
-    local config =
-        rfsuite and rfsuite.session and rfsuite.session.modelPreferences and rfsuite.session.modelPreferences[theme_section]
-    local W, H = lcd.getWindowSize()
-    -- Detect layout size change
-    if boxes_cache == nil
-        or themeconfig ~= config
-        or lastWindowWidth ~= W
-        or lastWindowHeight ~= H then
-        -- Re-evaluate screen group and options
-        screenGroup = getScreenSize(W, H)
-        boxes_cache = buildBoxes()
-        themeconfig = config
-        lastWindowWidth = W
-        lastWindowHeight = H
+    local W = lcd.getWindowSize()
+    if boxes_cache == nil or lastScreenW ~= W then
+        boxes_cache = buildBoxes(W)
+        lastScreenW = W
     end
     return boxes_cache
 end
 
 return {
-    layout = getLayout,
+    layout = layout,
     boxes = boxes,
+    header_boxes = header_boxes,
+    header_layout = header_layout,
     scheduler = {
         spread_scheduling = true,         -- (optional: spread scheduling over the interval to avoid spikes in CPU usage) 
         spread_scheduling_paint = false,  -- optional: spread scheduling for paint (if true, paint will be spread over the interval) 
-        spread_ratio = 0.5                -- optional: manually override default ratio logic (applies if spread_scheduling is true)     
-    } 
+        spread_ratio = 0.5                -- optional: manually override default ratio logic (applies if spread_scheduling is true)
+    }
 }

--- a/scripts/rfsuite/widgets/dashboard/themes/@aerc/preflight.lua
+++ b/scripts/rfsuite/widgets/dashboard/themes/@aerc/preflight.lua
@@ -16,52 +16,41 @@
 ]]--
 
 local i18n = rfsuite.i18n.get
+local utils = rfsuite.widgets.dashboard.utils
+local boxes_cache = nil
+local themeconfig = nil
+local lastScreenW = nil
 
 local darkMode = {
-    textcolor   = "white",
-    titlecolor  = "white",
-    bgcolor     = "black",
-    fillcolor   = "green",
-    fillbgcolor = "grey",
-    accentcolor = "white",
-    rssifillcolor = "darkwhite",
-    txaccentcolor = "grey",
+    textcolor       = "white",
+    titlecolor      = "white",
+    bgcolor         = "black",
+    fillcolor       = "green",
+    fillbgcolor     = "darkgrey",
+    accentcolor     = "white",
+    rssifillcolor   = "green",
+    rssifillbgcolor = "darkgrey",
+    txaccentcolor   = "grey",
+    txfillcolor     = "green",
+    txbgfillcolor   = "darkgrey"
 }
 
 local lightMode = {
-    textcolor   = "black",
-    titlecolor  = "black",
-    bgcolor     = "white",
-    fillcolor   = "green",
-    fillbgcolor = "grey",
-    accentcolor = "black",
-    rssifillcolor = "darkwhite",
-    txaccentcolor = "grey",
+    textcolor       = "black",
+    titlecolor      = "black",
+    bgcolor         = "white",
+    fillcolor       = "green",
+    fillbgcolor     = "lightgrey",
+    accentcolor     = "darkgrey",
+    rssifillcolor   = "green",
+    rssifillbgcolor = "grey",
+    txaccentcolor   = "darkgrey",
+    txfillcolor     = "green",
+    txbgfillcolor   = "grey"
 }
 
 -- alias current mode
 local colorMode = lcd.darkMode() and darkMode or lightMode
-
--- Determine layout and screensize in use
-local function getScreenSize(w, h)
-
-    -- Large screens - (X20 / X20RS / X18RS etc) Full/Standard
-    if (w == 800 and (h == 458 or h == 480)) then return "ls_full" end
-    if (w == 784 and (h == 294 or h == 316)) then return "ls_std" end
-
-    -- Medium screens (X18 / X18S / TWXLITE) - Full/Standard
-    if (w == 480 and (h == 301 or h == 320)) then return "ms_full" end
-    if (w == 472 and (h == 191 or h == 210)) then return "ms_std" end
-
-    -- Small screens - (X14 / X14S) Full/Standard
-    if (w == 640 and (h == 338 or h == 360)) then return "ss_full" end
-    if (w == 630 and (h == 236 or h == 258)) then return "ss_std" end
-
-    return "unknown"
-end
-
-local W, H = lcd.getWindowSize()
-local screenGroup = getScreenSize(W, H)
 
 -- Theme based configuration settings
 local theme_section = "system/@aerc"
@@ -78,39 +67,105 @@ local THEME_DEFAULTS = {
     tx_max       = 8.4
 }
 
--- Theme Options based on screen size
+-- Theme Options based on screen width
+local function getThemeOptionKey(W)
+    if     W == 800 then return "ls_full"
+    elseif W == 784 then return "ls_std"
+    elseif W == 640 then return "ss_full"
+    elseif W == 630 then return "ss_std"
+    elseif W == 480 then return "ms_full"
+    elseif W == 472 then return "ms_std"
+    end
+end
+
+-- Theme Options based on screen width
 local themeOptions = {
-
     -- Large screens - (X20 / X20RS / X18RS etc) Full/Standard
-    ls_full = { cols = 7, rows = 12, thickness = 30, font = "FONT_XXL", advfont = "FONT_M", batteryframethickness = 4, 
-                titlepaddingbottom = 15, valuepaddingleft = 25, valuepaddingtop = 20, valuepaddingbottom = 25, 
-                gaugepaddingtop = 20, battadvpaddingtop = 20, txgaugepaddingtop = 5, txgaugepaddingbottom = 5, txgaugepaddingleft = 26, txgaugepaddingright = 25, 
-                rssivaluepaddingleft = 12, barpadding = 5, barpaddingleft = 15, barpaddingright = 15},
+    ls_full = { 
+        font = "FONT_XXL", 
+        advfont = "FONT_M", 
+        thickness = 25, 
+        batteryframethickness = 4, 
+        titlepaddingbottom = 15, 
+        valuepaddingleft = 25, 
+        valuepaddingtop = 20, 
+        valuepaddingbottom = 25, 
+        gaugepaddingtop = 20, 
+        battadvpaddingtop = 20, 
+        brvaluepaddingtop = 25
+    },
 
-    ls_std  = { cols = 7, rows = 11, thickness = 11, font = "FONT_XL", advfont = "FONT_M", batteryframethickness = 4, 
-                titlepaddingbottom = 0, valuepaddingleft = 75, valuepaddingtop = 5, valuepaddingbottom = 25, gaugepaddingtop = 5, battadvpaddingtop = 5},
+    ls_std  = { 
+        font = "FONT_XL", 
+        advfont = "FONT_M", 
+        thickness = 15, 
+        batteryframethickness = 4, 
+        titlepaddingbottom = 0, 
+        valuepaddingleft = 75, 
+        valuepaddingtop = 5, 
+        valuepaddingbottom = 25, 
+        gaugepaddingtop = 5, 
+        battadvpaddingtop = 5, 
+        brvaluepaddingtop = 10
+    },
 
     -- Medium screens (X18 / X18S / TWXLITE) - Full/Standard
-    ms_full = { cols = 7, rows = 12, thickness = 20, font = "FONT_XL", advfont = "FONT_M", batteryframethickness = 4, 
-                titlepaddingbottom = 0, valuepaddingleft = 20, valuepaddingtop = 5, valuepaddingbottom = 15, gaugepaddingtop = 5, battadvpaddingtop = 5, 
-                txgaugepaddingtop = 2, txgaugepaddingbottom = 2, txgaugepaddingleft = 10, txgaugepaddingright = 9, 
-                rssivaluepaddingleft = 7, barpadding = 2, barpaddingleft = 5, barpaddingright = 5},
+    ms_full = { 
+        font = "FONT_XXL", 
+        advfont = "FONT_M", 
+        thickness = 17, 
+        batteryframethickness = 4, 
+        titlepaddingbottom = 0, 
+        valuepaddingleft = 20, 
+        valuepaddingtop = 5, 
+        valuepaddingbottom = 15, 
+        gaugepaddingtop = 5, 
+        battadvpaddingtop = 5, 
+        brvaluepaddingtop = 20
+    },
 
-    ms_std  = { cols = 7, rows = 11, thickness = 12, font = "FONT_L", advfont = "FONT_S", batteryframethickness = 2, 
-                titlepaddingbottom = 0, valuepaddingleft = 20, valuepaddingtop = 10, valuepaddingbottom = 25, gaugepaddingtop = 5, battadvpaddingtop = 0},
+    ms_std  = { 
+        font = "FONT_XL", 
+        advfont = "FONT_S", 
+        thickness = 10, 
+        batteryframethickness = 2, 
+        titlepaddingbottom = 0, 
+        valuepaddingleft = 20, 
+        valuepaddingtop = 10, 
+        valuepaddingbottom = 25, 
+        gaugepaddingtop = 5, 
+        battadvpaddingtop = 0, 
+        brvaluepaddingtop = 10
+    },
 
     -- Small screens - (X14 / X14S) Full/Standard
-    ss_full = { cols = 7, rows = 12, thickness = 20, font = "FONT_XL", advfont = "FONT_M", batteryframethickness = 4, 
-                titlepaddingbottom = 0, valuepaddingleft = 20, valuepaddingtop = 5, valuepaddingbottom = 15, 
-                gaugepaddingtop = 5, battadvpaddingtop = 5, txgaugepaddingtop = 2, txgaugepaddingbottom = 2, txgaugepaddingleft = 12, txgaugepaddingright = 12, 
-                rssivaluepaddingleft = 9, barpadding = 2, barpaddingleft = 13, barpaddingright = 13},
+    ss_full = { 
+        font = "FONT_XL", 
+        advfont = "FONT_M", 
+        thickness = 20,  
+        batteryframethickness = 4, 
+        titlepaddingbottom = 0, 
+        valuepaddingleft = 20, 
+        valuepaddingtop = 5, 
+        valuepaddingbottom = 15, 
+        gaugepaddingtop = 5, 
+        battadvpaddingtop = 5, 
+        brvaluepaddingtop = 10
+    },
 
-    ss_std  = { cols = 7, rows = 11, thickness = 12, font = "FONT_L", advfont = "FONT_S", batteryframethickness = 2, 
-                titlepaddingbottom = 0, valuepaddingleft = 20, valuepaddingtop = 10, valuepaddingbottom = 25, gaugepaddingtop = 5, battadvpaddingtop = 0},
-
-    -- Fallbacks
-    unknown = { cols = 7, rows = 11, thickness = 11, font = "FONT_XL", advfont = "FONT_M", batteryframethickness = 4, 
-                titlepaddingbottom = 0, valuepaddingleft = 75, valuepaddingtop = 5, valuepaddingbottom = 25, gaugepaddingtop = 5, battadvpaddingtop = 5},
+    ss_std  = { 
+        font = "FONT_XL", 
+        advfont = "FONT_S", 
+        thickness = 12,  
+        batteryframethickness = 2, 
+        titlepaddingbottom = 0, 
+        valuepaddingleft = 20, 
+        valuepaddingtop = 10, 
+        valuepaddingbottom = 25, 
+        gaugepaddingtop = 5, 
+        battadvpaddingtop = 0, 
+        brvaluepaddingtop = 10
+    },
 }
 
 local function getThemeValue(key)
@@ -123,233 +178,347 @@ local function getThemeValue(key)
 end
 
 -- Caching for boxes
+local lastScreenW = nil
 local boxes_cache = nil
 local themeconfig = nil
-local lastWindowWidth = nil
-local lastWindowHeight = nil
+local headeropts = utils.getHeaderOptions()
 
 -- Theme Layout
-local function getLayout()
-    local opts = themeOptions[screenGroup] or themeOptions.unknown
-    return { cols = opts.cols, rows = opts.rows }
-end
+local layout = {
+    cols    = 7,
+    rows    = 12,
+}
+
+local header_layout = {
+    height  = headeropts.height,
+    cols    = 7,
+    rows    = 1,
+}
 
 -- Boxes
-local function buildBoxes()
-    local opts = themeOptions[screenGroup] or themeOptions.unknown
+local function buildBoxes(W)
+    
+    -- Object based options determined by screensize
+    local opts = themeOptions[getThemeOptionKey(W)] or themeOptions.unknown
 
-    local boxes = {
-
-        -- Craftname
-        { col = 1, row = 1, colspan = 2, type = "text", subtype = "craftname", font = "FONT_L", valuepaddingleft = 100, bgcolor = colorMode.bgcolor, titlecolor = colorMode.titlecolor, textcolor = colorMode.textcolor},
-        
-        -- RF Logo
-        {col = 3, row = 1, colspan = 3, type = "image", subtype = "image", bgcolor = colorMode.bgcolor},
-
-        -- TX Battery
-        {col = 5, row = 1,
-        type = "gauge", subtype = "bar", source = "txbatt",
-        font = "FONT_S", battery = true, batteryframe = true, hidevalue = true,
-        batteryframethickness = 2, decimals = 1, unit = "v", valuepaddingleft = 35, valuepaddingbottom = 10, valuealign = "left",
-        gaugepaddingtop = opts.txgaugepaddingtop, gaugepaddingbottom = opts.txgaugepaddingbottom, gaugepaddingleft = opts.txgaugepaddingleft, gaugepaddingright = opts.txgaugepaddingright,
-        batterysegments = 4, batterysegmentpaddingtop = 4, batterysegmentpaddingbottom = 4, batterysegmentpaddingleft = 4, batterysegmentpaddingright = 3, batteryspacing = 1,
-        fillcolor = colorMode.fillcolor, bgcolor = colorMode.bgcolor, accentcolor = colorMode.txaccentcolor, textcolor = colorMode.textcolor,
-        min = getThemeValue("tx_min"), max = getThemeValue("tx_max"), 
-        thresholds = {
-            { value = getThemeValue("tx_warn"), fillcolor = "orange"   },
-            { value = getThemeValue("tx_max"), fillcolor = "darkwhite"  }
-        }                        
-        },
-
-        -- RSSI
-        {col = 7, row = 1,
-        type = "gauge", subtype = "step", source = "rssi",            
-        font = "FONT_XS", barpadding = opts.barpadding, stepgap = 3, stepcount = 5, decimals = 0,
-        valuealign = "left", valuepaddingbottom = 20, valuepaddingleft = opts.rssivaluepaddingleft,
-        barpaddingleft = opts.barpaddingleft, barpaddingright = opts.barpaddingright,
-        bgcolor = colorMode.bgcolor, textcolor = colorMode.textcolor, fillcolor = colorMode.rssifillcolor, 
-        },
-
+    return {
         -- Model Image
-        {col = 1, row = 1, colspan = 3, rowspan = 8, type = "image", subtype = "model", bgcolor = colorMode.bgcolor},
+        {
+            col = 1, 
+            row = 1, 
+            colspan = 3, 
+            rowspan = 9, 
+            type = "image", 
+            subtype = "model", 
+            bgcolor = colorMode.bgcolor
+        },
         
         -- Rates
-        {col = 1, row = 9, rowspan = 3,
-        type = "text", subtype = "telemetry", source = "rate_profile",
-        title = i18n("widgets.dashboard.rates"):upper(), titlepos = "bottom",
-        font = "FONT_XL",
-        bgcolor = colorMode.bgcolor, titlecolor = colorMode.titlecolor,
-        transform = "floor",
-        thresholds = {
-            { value = 1.5, textcolor = "blue" },
-            { value = 2.5, textcolor = "orange" },
-            { value = 6,   textcolor = "green" }
-        }
+        {
+            col = 1, 
+            row = 10, 
+            rowspan = 3,
+            type = "text", 
+            subtype = "telemetry", 
+            source = "rate_profile",
+            title = i18n("widgets.dashboard.rates"):upper(), 
+            titlepos = "bottom",
+            font = "FONT_XL",
+            valuepaddingtop = opts.brvaluepaddingtop,
+            bgcolor = colorMode.bgcolor, 
+            titlecolor = colorMode.titlecolor,
+            transform = "floor",
+            thresholds = {
+                { value = 1.5, textcolor = "blue" },
+                { value = 2.5, textcolor = "orange" },
+                { value = 6,   textcolor = "green" }
+            }
         },
 
         -- PID
-        {col = 2, row = 9, rowspan = 3,
-        type = "text", subtype = "telemetry", source = "pid_profile",
-        title = i18n("widgets.dashboard.profile"):upper(), titlepos = "bottom",
-        font = "FONT_XL",
-        bgcolor = colorMode.bgcolor, titlecolor = colorMode.titlecolor,
-        transform = "floor",
-        thresholds = {
-            { value = 1.5, textcolor = "blue" },
-            { value = 2.5, textcolor = "orange" },
-            { value = 6,   textcolor = "green" }
-        }
+        {
+            col = 2, 
+            row = 10, 
+            rowspan = 3,
+            type = "text", 
+            subtype = "telemetry", 
+            source = "pid_profile",
+            title = i18n("widgets.dashboard.profile"):upper(), 
+            titlepos = "bottom",
+            font = "FONT_XL",
+            valuepaddingtop = opts.brvaluepaddingtop,
+            bgcolor = colorMode.bgcolor, 
+            titlecolor = colorMode.titlecolor,
+            transform = "floor",
+            thresholds = {
+                { value = 1.5, textcolor = "blue" },
+                { value = 2.5, textcolor = "orange" },
+                { value = 6,   textcolor = "green" }
+            }
         },
         
         -- Flights
-        {col = 3, row = 9, rowspan = 3,
-        type = "time", subtype = "count",
-        title = i18n("widgets.dashboard.flights"):upper(), titlepos = "bottom",
-        font = "FONT_XL",
-        bgcolor = colorMode.bgcolor, titlecolor = colorMode.titlecolor, textcolor = colorMode.textcolor,
+        {
+            col = 3, 
+            row = 10, 
+            rowspan = 3,
+            type = "time", 
+            subtype = "count",
+            title = i18n("widgets.dashboard.flights"):upper(), 
+            titlepos = "bottom",
+            font = "FONT_XL",
+            valuepaddingtop = opts.brvaluepaddingtop,
+            bgcolor = colorMode.bgcolor, 
+            titlecolor = colorMode.titlecolor, 
+            textcolor = colorMode.textcolor,
         },
 
         -- Fuel Bar
-        {col = 4, row = 1, colspan = 4, rowspan = 3,
-        type = "gauge", source = "smartfuel", 
-        batteryframe = true, battadv = true, batteryframethickness = opts.batteryframethickness,
-        font = opts.font,
-        valuealign = "left", valuepaddingleft = opts.valuepaddingleft, valuepaddingtop = opts.valuepaddingtop,
-        gaugepaddingleft = 5, gaugepaddingright = 5, gaugepaddingtop = opts.gaugepaddingtop, gaugepaddingbottom = 3,
-        battadvfont = opts.advfont, battadvpaddingright = 25, battadvpaddingtop = opts.battadvpaddingtop, battadvvaluealign = "right",
-        fillcolor = "green", bgcolor = colorMode.bgcolor, titlecolor = colorMode.titlecolor, textcolor = colorMode.textcolor, accentcolor = colorMode.accentcolor,
-        transform = "floor",
-        thresholds = {
-            { value = 10, fillcolor = "red" },
-            { value = 30, fillcolor = "orange" }
-        }
+        {
+            col = 4, 
+            row = 1, 
+            colspan = 4, 
+            rowspan = 3,
+            type = "gauge", 
+            source = "smartfuel", 
+            batteryframe = true, 
+            battadv = true,
+            battadvvaluealign = "right",
+            battadvpaddingright = 25,
+            gaugepaddingbottom = 3,
+            gaugepaddingleft = 5, 
+            gaugepaddingright = 5,
+            valuealign = "left", 
+            batteryframethickness = opts.batteryframethickness,
+            font = opts.font,
+            valuepaddingleft = opts.valuepaddingleft, 
+            valuepaddingtop = opts.valuepaddingtop,
+            gaugepaddingtop = opts.gaugepaddingtop, 
+            battadvfont = opts.advfont, 
+            battadvpaddingtop = opts.battadvpaddingtop, 
+            fillcolor = "green",
+            bgcolor = colorMode.bgcolor, 
+            titlecolor = colorMode.titlecolor, 
+            textcolor = colorMode.textcolor, 
+            accentcolor = colorMode.accentcolor,
+            transform = "floor",
+            thresholds = {
+                { value = 10, fillcolor = "red" },
+                { value = 30, fillcolor = "orange" }
+            }
         },
 
         -- BEC Voltage
-        {col = 4, colspan = 2, row = 4, rowspan = 5,
-        type = "gauge", subtype = "arc", source = "bec_voltage",
-        title = i18n("widgets.dashboard.bec_voltage"):upper(), titlepos = "bottom", titlepaddingbottom = opts.titlepaddingbottom,
-        font = opts.font,
-        min = getThemeValue("bec_min"), max = getThemeValue("bec_max"),
-        decimals = 1, thickness = opts.thickness,
-        bgcolor = colorMode.bgcolor, titlecolor = colorMode.titlecolor, textcolor = colorMode.textcolor, 
-        thresholds = {
-            { value = getThemeValue("bec_min"), fillcolor = "red" },
-            { value = getThemeValue("bec_max"), fillcolor = "green" }
-        }
+        {
+            col = 4, 
+            colspan = 2, 
+            row = 4, 
+            rowspan = 6,
+            type = "gauge", 
+            subtype = "arc", 
+            source = "bec_voltage",
+            title = i18n("widgets.dashboard.bec_voltage"):upper(), 
+            titlepos = "bottom",
+            decimals = 1,         
+            titlepaddingbottom = opts.titlepaddingbottom,
+            font = opts.font,
+            min = getThemeValue("bec_min"), 
+            max = getThemeValue("bec_max"),
+            thickness = opts.thickness,
+            bgcolor = colorMode.bgcolor,
+            fillbgcolor = colorMode.fillbgcolor,
+            titlecolor = colorMode.titlecolor, 
+            textcolor = colorMode.textcolor, 
+            thresholds = {
+                { value = getThemeValue("bec_min"), fillcolor = "red" },
+                { value = getThemeValue("bec_max"), fillcolor = "green" }
+            }
         },
 
         -- Blackbox
-        {col = 4, row = 9, colspan = 2, rowspan = 3,
-        type = "text", subtype = "blackbox",
-        title = i18n("widgets.dashboard.blackbox"):upper(), titlepos = "bottom",
-        font = "FONT_XL", decimals = 0,
-        bgcolor = colorMode.bgcolor, titlecolor = colorMode.titlecolor,
-        transform = "floor", 
-        thresholds = {
-            { value = 80, textcolor = colorMode.textcolor },
-            { value = 90, textcolor = "orange" },
-            { value = 100, textcolor = "red" }
-        }
+        {
+            col = 4, 
+            row = 10, 
+            colspan = 2, 
+            rowspan = 3,
+            type = "text", 
+            subtype = "blackbox",
+            title = i18n("widgets.dashboard.blackbox"):upper(), 
+            titlepos = "bottom",
+            font = "FONT_XL", 
+            decimals = 0,
+            bgcolor = colorMode.bgcolor, 
+            titlecolor = colorMode.titlecolor,
+            valuepaddingtop = opts.brvaluepaddingtop,
+            transform = "floor", 
+            thresholds = {
+                { value = 80, textcolor = colorMode.textcolor },
+                { value = 90, textcolor = "orange" },
+                { value = 100, textcolor = "red" }
+            }
         },
 
         -- ESC Temp
-        {col = 6, colspan = 2, row = 4, rowspan = 5,
-        type = "gauge", subtype = "arc", source = "temp_esc",
-        title = i18n("widgets.dashboard.esc_temp"):upper(), titlepos = "bottom",
-        font = opts.font,
-        min = 0, max = getThemeValue("esctemp_max"), thickness = opts.thickness,
-        valuepaddingleft = 10, 
-        bgcolor = colorMode.bgcolor, titlecolor = colorMode.titlecolor, textcolor = colorMode.textcolor,
-        titlepaddingbottom = opts.titlepaddingbottom,
-        transform = "floor",
-        thresholds = {
-            { value = getThemeValue("esctemp_warn"), fillcolor = "green" },
-            { value = getThemeValue("esctemp_max"), fillcolor = "orange" },
-            { value = 200, fillcolor = "red" }
-        }
+        {
+            col = 6, 
+            colspan = 2, 
+            row = 4, 
+            rowspan = 6,
+            type = "gauge", 
+            subtype = "arc", 
+            source = "temp_esc",
+            title = i18n("widgets.dashboard.esc_temp"):upper(), 
+            titlepos = "bottom",
+            font = opts.font,
+            min = 0, 
+            max = getThemeValue("esctemp_max"), 
+            thickness = opts.thickness,
+            valuepaddingleft = 10, 
+            bgcolor = colorMode.bgcolor,
+            fillbgcolor = colorMode.fillbgcolor, 
+            titlecolor = colorMode.titlecolor, 
+            textcolor = colorMode.textcolor,
+            titlepaddingbottom = opts.titlepaddingbottom,
+            transform = "floor",
+            thresholds = {
+                { value = getThemeValue("esctemp_warn"), fillcolor = "green" },
+                { value = getThemeValue("esctemp_max"), fillcolor = "orange" },
+                { value = 200, fillcolor = "red" }
+            }
         },
 
         -- Governor
-        {col = 6, row = 9, colspan = 2, rowspan = 3,
-        type = "text", subtype = "governor",
-        title = i18n("widgets.dashboard.governor"):upper(), titlepos = "bottom",
-        font = "FONT_XL",
-        bgcolor = colorMode.bgcolor, titlecolor = colorMode.titlecolor,
-        thresholds = {
-            { value = i18n("widgets.governor.DISARMED"), textcolor = "red" },
-            { value = i18n("widgets.governor.OFF"), textcolor = "red" },
-            { value = i18n("widgets.governor.IDLE"), textcolor = "blue" },
-            { value = i18n("widgets.governor.SPOOLUP"), textcolor = "blue" },
-            { value = i18n("widgets.governor.RECOVERY"), textcolor = "orange" },
-            { value = i18n("widgets.governor.ACTIVE"), textcolor = "green" },
-            { value = i18n("widgets.governor.THR-OFF"), textcolor = "red" }
-        }
+        {
+            col = 6, 
+            row = 10, 
+            colspan = 2, 
+            rowspan = 3,
+            type = "text", 
+            subtype = "governor",
+            title = i18n("widgets.dashboard.governor"):upper(), 
+            titlepos = "bottom",
+            font = "FONT_XL",
+            valuepaddingtop = opts.brvaluepaddingtop,
+            bgcolor = colorMode.bgcolor, 
+            titlecolor = colorMode.titlecolor,
+            thresholds = {
+                { value = i18n("widgets.governor.DISARMED"), textcolor = "red" },
+                { value = i18n("widgets.governor.OFF"), textcolor = "red" },
+                { value = i18n("widgets.governor.IDLE"), textcolor = "blue" },
+                { value = i18n("widgets.governor.SPOOLUP"), textcolor = "blue" },
+                { value = i18n("widgets.governor.RECOVERY"), textcolor = "orange" },
+                { value = i18n("widgets.governor.ACTIVE"), textcolor = "green" },
+                { value = i18n("widgets.governor.THR-OFF"), textcolor = "red" }
+            }
         }
     }
-
-    if screenGroup and screenGroup:find("_full") then
-        for _, box in ipairs(boxes) do
-            -- Top row (logo, craftname, txbatt, rssi)
-            if box.type == "text" and box.subtype == "craftname" then
-                box.col = 1; box.row = 1; box.colspan = 2
-            elseif box.type == "image" and box.subtype == "image" then
-                box.col = 3; box.row = 1; box.colspan = 3
-            elseif box.type == "gauge" and box.subtype == "bar" and box.source == "txbatt" then
-                box.col = 6; box.row = 1
-            elseif box.type == "gauge" and box.subtype == "step" and box.source == "rssi" then
-                box.col = 7; box.row = 1
-
-            -- Model Image, Throttle, BEC Voltage, ESC Temp: shift down by 1, increase rowspan
-            elseif (box.type == "image" and box.subtype == "model")
-                or (box.type == "text" and box.subtype == "telemetry" and box.source == "throttle_percent")
-                or (box.type == "gauge" and box.subtype == "arc" and (box.source == "bec_voltage" or box.source == "temp_esc"))
-            then
-                box.row = (box.row or 1) + 1
-                box.rowspan = (box.rowspan or 1) + 1
-
-            -- Tally group: shift down by 2, reduce rowspan
-            elseif (box.type == "text" and box.subtype == "blackbox") or
-                (box.type == "text" and box.subtype == "governor") or
-                (box.type == "text" and box.subtype == "telemetry" and (box.source == "rate_profile" or box.source == "pid_profile")) or
-                (box.type == "time" and box.subtype == "count") then
-                box.row = (box.row or 1) + 2
-                box.rowspan = math.max(1, (box.rowspan or 1) - 1)
-            -- Everything else: shift down by 1
-            else
-                box.row = (box.row or 1) + 1
-            end
-        end
-    end
-
-    return boxes
 end
 
+local header_boxes = {
+-- Craftname
+    { 
+        col = 1, 
+        row = 1, 
+        colspan = 2, 
+        type = "text", 
+        subtype = "craftname",
+        font = headeropts.font, 
+        valuealign = "left", 
+        valuepaddingleft = 5,
+        bgcolor = colorMode.bgcolor, 
+        titlecolor = colorMode.titlecolor, 
+        textcolor = colorMode.textcolor 
+    },
+
+    -- RF Logo
+    { 
+        col = 3, 
+        row = 1, 
+        colspan = 3, 
+        type = "image", 
+        subtype = "image",
+        bgcolor = colorMode.bgcolor 
+    },
+
+    -- TX Battery
+    { 
+        col = 6, 
+        row = 1,
+        type = "gauge", 
+        subtype = "bar", 
+        source = "txbatt",
+        font = headeropts.font,
+        battery = true, 
+        batteryframe = true, 
+        hidevalue = true,
+        valuealign = "left", 
+        batterysegments = 4, 
+        batteryspacing = 1, 
+        batteryframethickness  = 2,
+        batterysegmentpaddingtop = headeropts.batterysegmentpaddingtop,
+        batterysegmentpaddingbottom = headeropts.batterysegmentpaddingbottom,
+        batterysegmentpaddingleft = headeropts.batterysegmentpaddingleft,
+        batterysegmentpaddingright = headeropts.batterysegmentpaddingright,
+        gaugepaddingright = headeropts.gaugepaddingright,
+        gaugepaddingleft = headeropts.gaugepaddingleft,
+        gaugepaddingbottom = headeropts.gaugepaddingbottom,
+        gaugepaddingtop = headeropts.gaugepaddingtop,
+        fillbgcolor = colorMode.txbgfillcolor, 
+        bgcolor = colorMode.bgcolor,
+        accentcolor = colorMode.txaccentcolor, 
+        textcolor = colorMode.textcolor,
+        min = getThemeValue("tx_min"), 
+        max = getThemeValue("tx_max"), 
+        thresholds = {
+            { value = getThemeValue("tx_warn"), fillcolor = "orange" },
+            { value = getThemeValue("tx_max"), fillcolor = colorMode.txfillcolor }
+        }
+    },
+
+    -- RSSI
+    { 
+        col = 7, 
+        row = 1,
+        type = "gauge", 
+        subtype = "step", 
+        source = "rssi",
+        font = "FONT_XS", 
+        stepgap = 2, 
+        stepcount = 5, 
+        decimals = 0,
+        valuealign = "left",
+        barpaddingleft = headeropts.barpaddingleft,
+        barpaddingright = headeropts.barpaddingright,
+        barpaddingbottom = headeropts.barpaddingbottom,
+        barpaddingtop = headeropts.barpaddingtop,
+        valuepaddingleft = headeropts.valuepaddingleft,
+        valuepaddingbottom = headeropts.valuepaddingbottom,
+        bgcolor = colorMode.bgcolor, 
+        textcolor = colorMode.textcolor, 
+        fillcolor = colorMode.rssifillcolor,
+        fillbgcolor = colorMode.rssifillbgcolor,
+    },
+}
+
 local function boxes()
-    local config =
-        rfsuite and rfsuite.session and rfsuite.session.modelPreferences and rfsuite.session.modelPreferences[theme_section]
-    local W, H = lcd.getWindowSize()
-    -- Detect layout size change
-    if boxes_cache == nil
-        or themeconfig ~= config
-        or lastWindowWidth ~= W
-        or lastWindowHeight ~= H then
-        -- Re-evaluate screen group and options
-        screenGroup = getScreenSize(W, H)
-        boxes_cache = buildBoxes()
+    local config = rfsuite and rfsuite.session and rfsuite.session.modelPreferences and rfsuite.session.modelPreferences[theme_section]
+    local W = lcd.getWindowSize()
+    if boxes_cache == nil or themeconfig ~= config or lastScreenW ~= W then
+        boxes_cache = buildBoxes(W)
         themeconfig = config
-        lastWindowWidth = W
-        lastWindowHeight = H
+        lastScreenW = W
     end
     return boxes_cache
 end
 
 return {
-    layout = getLayout,
-    boxes = boxes,
-    scheduler = {
+  layout = layout,
+  boxes = boxes,
+  header_boxes = header_boxes,
+  header_layout = header_layout,
+  scheduler = {
         spread_scheduling = true,         -- (optional: spread scheduling over the interval to avoid spikes in CPU usage) 
         spread_scheduling_paint = false,  -- optional: spread scheduling for paint (if true, paint will be spread over the interval) 
-        spread_ratio = 0.5                -- optional: manually override default ratio logic (applies if spread_scheduling is true)      
-    }    
+        spread_ratio = 0.5                -- optional: manually override default ratio logic (applies if spread_scheduling is true)
+  }    
 }


### PR DESCRIPTION
Added utilities wrapper for header, will be able to re-use this for all themes and base them on this standard header layout. AERC Theme now works and looks crisp in darkmode, lightmode and full screen to standard widget layout.