### PR TITLE
Optimised arc.lua

### DIFF
--- a/scripts/rfsuite/widgets/dashboard/objects/gauge/arc.lua
+++ b/scripts/rfsuite/widgets/dashboard/objects/gauge/arc.lua
@@ -101,11 +101,79 @@ local function drawArc(cx, cy, radius, thickness, startAngle, endAngle, color)
     end
 end
 
+-- Precompile the value transform
+local function compileTransform(t, decimals)
+    local pow = decimals and (10 ^ decimals) or nil
+    local function round(v)
+        return pow and (math.floor(v * pow + 0.5) / pow) or v
+    end
+
+    if type(t) == "number" then
+        local mul = t
+        return function(v) return round(v * mul) end
+    elseif t == "floor" then
+        return function(v) return math.floor(v) end
+    elseif t == "ceil" then
+        return function(v) return math.ceil(v) end
+    elseif t == "round" or t == nil then
+        return function(v) return round(v) end
+    elseif type(t) == "function" then
+        return t
+    else
+        return function(v) return v end
+    end
+end
+
 function render.wakeup(box)
     local telemetry = rfsuite.tasks.telemetry
 
+    -- Reuse cache table
+    local c = box._cache or {}
+    box._cache = c
+
+    -- Build static config once
+    local cfg = box._cfg
+    if not cfg then
+        cfg = {}
+        cfg.title              = getParam(box, "title")
+        cfg.titlepos           = getParam(box, "titlepos") or (cfg.title and "top" or nil)
+        cfg.titlealign         = getParam(box, "titlealign")
+        cfg.titlefont          = getParam(box, "titlefont")
+        cfg.titlespacing       = getParam(box, "titlespacing") or 0
+        cfg.titlepadding       = getParam(box, "titlepadding")
+        cfg.titlepaddingleft   = getParam(box, "titlepaddingleft")
+        cfg.titlepaddingright  = getParam(box, "titlepaddingright")
+        cfg.titlepaddingtop    = getParam(box, "titlepaddingtop")
+        cfg.titlepaddingbottom = getParam(box, "titlepaddingbottom")
+        cfg.font               = getParam(box, "font") or "FONT_M"
+        cfg.maxfont            = getParam(box, "maxfont") or "FONT_S"
+        cfg.decimals           = getParam(box, "decimals")
+        cfg.valuealign         = getParam(box, "valuealign")
+        cfg.valuepadding       = getParam(box, "valuepadding")
+        cfg.valuepaddingleft   = getParam(box, "valuepaddingleft")
+        cfg.valuepaddingright  = getParam(box, "valuepaddingright")
+        cfg.valuepaddingtop    = getParam(box, "valuepaddingtop") or 18
+        cfg.valuepaddingbottom = getParam(box, "valuepaddingbottom")
+        cfg.thickness          = getParam(box, "thickness")
+        cfg.maxprefix          = getParam(box, "maxprefix") or "+"
+        cfg.maxpadding         = getParam(box, "maxpadding") or 0
+        cfg.maxpaddingleft     = getParam(box, "maxpaddingleft") or 0
+        cfg.maxpaddingtop      = getParam(box, "maxpaddingtop") or 0
+        cfg.gaugepadding       = getParam(box, "gaugepadding") or 0
+        cfg.gaugepaddingbottom = getParam(box, "gaugepaddingbottom") or 0
+        cfg.fillbgcolor        = resolveThemeColor("fillbgcolor", getParam(box, "fillbgcolor"))
+        cfg.bgcolor            = resolveThemeColor("bgcolor",     getParam(box, "bgcolor"))
+        cfg.titlecolor         = resolveThemeColor("titlecolor",  getParam(box, "titlecolor"))
+        cfg.manualUnit         = getParam(box, "unit")
+        cfg.source             = getParam(box, "source")
+        cfg.transform          = getParam(box, "transform")
+        cfg.transformFn        = compileTransform(cfg.transform, cfg.decimals)
+
+        box._cfg = cfg
+    end
+
     -- Value extraction
-    local source = getParam(box, "source")
+    local source = cfg.source
     local minCfg = getParam(box, "min")
     local maxCfg = getParam(box, "max")
     local thresholdsCfg = getParam(box, "thresholds")
@@ -119,15 +187,15 @@ function render.wakeup(box)
     -- Optionally cache and calculate max value for max arc
     local arcmax = getParam(box, "arcmax") == true
     local maxval = nil
-    if arcmax and source then
+    if arcmax and source and telemetry then
         local stats = telemetry.getSensorStats(source)
         local currentMax = stats and stats.max or nil
-        local prevMax = box._cache and box._cache.maxval or nil
+        local prevMax = c.maxval or nil
         maxval = currentMax or prevMax
     end
 
     -- Dynamic unit logic (User can force a unit or omit unit using "" to hide)
-    local manualUnit = getParam(box, "unit")
+    local manualUnit = cfg.manualUnit
     local unit
     if manualUnit ~= nil then
         unit = manualUnit  -- use user value, even if ""
@@ -159,23 +227,23 @@ function render.wakeup(box)
     -- Transform and decimals (if required)
     local displayValue
     if value ~= nil then
-        displayValue = utils.transformValue(value, box)
+        displayValue = cfg.transformFn(value)
     end
 
     -- Transform and decimals (if required - for arcmax)
     local displayMaxValue = nil
     if arcmax and maxval ~= nil then
-        displayMaxValue = utils.transformValue(maxval, box)
+        displayMaxValue = cfg.transformFn(maxval)
     end
 
     -- ... style loading indicator
     if value == nil then
         local maxDots = 3
-        if box._dotCount == nil then
-            box._dotCount = 0
+        if c._dotCount == nil then
+            c._dotCount = 0
         end
-        box._dotCount = (box._dotCount + 1) % (maxDots + 1)
-        displayValue = string.rep(".", box._dotCount)
+        c._dotCount = (c._dotCount + 1) % (maxDots + 1)
+        displayValue = string.rep(".", c._dotCount)
         if displayValue == "" then
             displayValue = "."
         end
@@ -190,51 +258,49 @@ function render.wakeup(box)
     -- Set box.value so dashboard/dirty can track change for redraws
     box._currentDisplayValue = value
 
-    box._cache = {
-        value              = value,
-        maxval             = maxval,
-        displayValue       = displayValue,
-        displayMaxValue    = displayMaxValue,
-        arcmax             = arcmax,
-        min                = min,
-        max                = max,
-        percent            = percent,
-        maxPercent         = maxPercent,
-        unit               = unit,
-        textcolor          = resolveThresholdColor(value,   box, "textcolor",   "textcolor",   thresholds),
-        maxtextcolor       = resolveThresholdColor(maxval,  box, "maxtextcolor","textcolor",   thresholds),
-        fillcolor          = resolveThresholdColor(value,   box, "fillcolor",   "fillcolor",   thresholds),
-        maxfillcolor       = resolveThresholdColor(maxval,  box, "fillcolor",   "fillcolor",   thresholds),
-        fillbgcolor        = resolveThemeColor("fillbgcolor", getParam(box, "fillbgcolor")),
-        bgcolor            = resolveThemeColor("bgcolor", getParam(box, "bgcolor")),
-        titlecolor         = resolveThemeColor("titlecolor", getParam(box, "titlecolor")),
-        title              = getParam(box, "title"),
-        titlepos           = getParam(box, "titlepos") or (getParam(box, "title") and "top"),
-        titlealign         = getParam(box, "titlealign"),
-        titlefont          = getParam(box, "titlefont"),
-        titlespacing       = getParam(box, "titlespacing") or 0,
-        titlepadding       = getParam(box, "titlepadding"),
-        titlepaddingleft   = getParam(box, "titlepaddingleft"),
-        titlepaddingright  = getParam(box, "titlepaddingright"),
-        titlepaddingtop    = getParam(box, "titlepaddingtop"),
-        titlepaddingbottom = getParam(box, "titlepaddingbottom"),
-        font               = getParam(box, "font") or "FONT_M",
-        maxfont            = getParam(box, "maxfont") or "FONT_S",
-        decimals           = getParam(box, "decimals"),
-        valuealign         = getParam(box, "valuealign"),
-        valuepadding       = getParam(box, "valuepadding"),
-        valuepaddingleft   = getParam(box, "valuepaddingleft"),
-        valuepaddingright  = getParam(box, "valuepaddingright"),
-        valuepaddingtop    = getParam(box, "valuepaddingtop") or 18,
-        valuepaddingbottom = getParam(box, "valuepaddingbottom"),
-        thickness          = getParam(box, "thickness"),
-        maxprefix          = getParam(box, "maxprefix") or "+",
-        maxpadding         = getParam(box, "maxpadding") or 0,
-        maxpaddingleft     = getParam(box, "maxpaddingleft") or 0,
-        maxpaddingtop      = getParam(box, "maxpaddingtop") or 0,
-        gaugepadding       = getParam(box, "gaugepadding") or 0,
-        gaugepaddingbottom = getParam(box, "gaugepaddingbottom") or 0,
-    }
+    -- Mutate cache
+    c.value              = value
+    c.maxval             = maxval
+    c.displayValue       = displayValue
+    c.displayMaxValue    = displayMaxValue
+    c.arcmax             = arcmax
+    c.min                = min
+    c.max                = max
+    c.percent            = percent
+    c.maxPercent         = maxPercent
+    c.unit               = unit
+    c.textcolor          = resolveThresholdColor(value,   box, "textcolor",   "textcolor",   thresholds)
+    c.maxtextcolor       = resolveThresholdColor(maxval,  box, "maxtextcolor","textcolor",   thresholds)
+    c.fillcolor          = resolveThresholdColor(value,   box, "fillcolor",   "fillcolor",   thresholds)
+    c.maxfillcolor       = resolveThresholdColor(maxval,  box, "fillcolor",   "fillcolor",   thresholds)
+    c.fillbgcolor        = cfg.fillbgcolor
+    c.bgcolor            = cfg.bgcolor
+    c.titlecolor         = cfg.titlecolor
+    c.title              = cfg.title
+    c.titlepos           = cfg.titlepos
+    c.titlealign         = cfg.titlealign
+    c.titlefont          = cfg.titlefont
+    c.titlespacing       = cfg.titlespacing
+    c.titlepadding       = cfg.titlepadding
+    c.titlepaddingleft   = cfg.titlepaddingleft
+    c.titlepaddingright  = cfg.titlepaddingright
+    c.titlepaddingtop    = cfg.titlepaddingtop
+    c.titlepaddingbottom = cfg.titlepaddingbottom
+    c.font               = cfg.font
+    c.maxfont            = cfg.maxfont
+    c.valuealign         = cfg.valuealign
+    c.valuepadding       = cfg.valuepadding
+    c.valuepaddingleft   = cfg.valuepaddingleft
+    c.valuepaddingright  = cfg.valuepaddingright
+    c.valuepaddingtop    = cfg.valuepaddingtop
+    c.valuepaddingbottom = cfg.valuepaddingbottom
+    c.thickness          = cfg.thickness
+    c.maxprefix          = cfg.maxprefix
+    c.maxpadding         = cfg.maxpadding
+    c.maxpaddingleft     = cfg.maxpaddingleft
+    c.maxpaddingtop      = cfg.maxpaddingtop
+    c.gaugepadding       = cfg.gaugepadding
+    c.gaugepaddingbottom = cfg.gaugepaddingbottom
 end
 
 function render.paint(x, y, w, h, box)
@@ -242,35 +308,67 @@ function render.paint(x, y, w, h, box)
     local c = box._cache or {}
 
     -- Title/Arc layout calculation
-    local titleHeight = 0
-    if c.title then
-        lcd.font(_G[c.titlefont] or FONT_XS)
-        local _, th = lcd.getTextSize(c.title)
-        titleHeight = (th or 0) + (c.titlespacing or 0) + (c.titlepaddingtop or 0) + (c.titlepaddingbottom or 0)
+    -- Geometry cache
+    local g = box._geom
+    local needGeo =
+        (not g) or g.w ~= w or g.h ~= h or
+        g.title ~= c.title or g.titlefont ~= c.titlefont or
+        g.titlespacing ~= (c.titlespacing or 0) or
+        g.titlepaddingtop ~= (c.titlepaddingtop or 0) or
+        g.titlepaddingbottom ~= (c.titlepaddingbottom or 0) or
+        g.titlepos ~= c.titlepos or
+        g.thickness ~= (c.thickness or 0) or
+        g.gaugepadding ~= (c.gaugepadding or 0) or
+        g.gaugepaddingbottom ~= (c.gaugepaddingbottom or 0)
+
+    if needGeo then
+        g = g or {}
+        g.w, g.h = w, h
+        g.title, g.titlefont = c.title, c.titlefont
+        g.titlespacing = c.titlespacing or 0
+        g.titlepaddingtop = c.titlepaddingtop or 0
+        g.titlepaddingbottom = c.titlepaddingbottom or 0
+        g.titlepos = c.titlepos
+        g.thickness = c.thickness or math.max(6, math.min(w, h) * 0.07)
+        g.gaugepadding = c.gaugepadding or 0
+        g.gaugepaddingbottom = c.gaugepaddingbottom or 0
+
+        local titleHeight = 0
+        if c.title then
+            lcd.font(_G[c.titlefont] or FONT_XS)
+            local _, th = lcd.getTextSize(c.title)
+            titleHeight = (th or 0) + g.titlespacing + g.titlepaddingtop + g.titlepaddingbottom
+        end
+
+        local arcRegionY, arcRegionH, cy
+        if c.titlepos == "top" then
+            arcRegionY = y + titleHeight
+            arcRegionH = h - titleHeight - g.gaugepaddingbottom
+            cy = arcRegionY + arcRegionH * 0.5
+        elseif c.titlepos == "bottom" then
+            arcRegionY = y
+            arcRegionH = h - titleHeight - g.gaugepaddingbottom
+            cy = arcRegionY + arcRegionH * 0.6
+        else
+            arcRegionY = y
+            arcRegionH = h - g.gaugepaddingbottom
+            cy = arcRegionY + arcRegionH * 0.55
+        end
+
+        local thickness = g.thickness
+        local maxRadius = (arcRegionH / 2) - (thickness / 2)
+        local radius    = math.min((w / 2) - g.gaugepadding, maxRadius + 8)
+
+        g.cx = x + w / 2
+        g.cy = cy
+        g.radius = radius
+
+        local startAngle = 225
+        g.startAngle = startAngle
+        g.endAngleFull = (startAngle + 270) % 360
+
+        box._geom = g
     end
-
-    -- Arc region: based on title position
-    local arcRegionY, arcRegionH, cy, radius
-    local thickness, maxRadius
-
-    if c.titlepos == "top" then
-        arcRegionY = y + titleHeight
-        arcRegionH = h - titleHeight - (c.gaugepaddingbottom or 0)
-        cy = arcRegionY + arcRegionH * 0.5
-    elseif c.titlepos == "bottom" then
-        arcRegionY = y
-        arcRegionH = h - titleHeight - (c.gaugepaddingbottom or 0)
-        cy = arcRegionY + arcRegionH * 0.6
-    else
-        arcRegionY = y
-        arcRegionH = h - (c.gaugepaddingbottom or 0)
-        cy = arcRegionY + arcRegionH * 0.55
-    end
-
-    thickness = c.thickness or math.max(6, math.min(w, arcRegionH) * 0.07)
-    local gaugepadding = c.gaugepadding or 0
-    maxRadius = (arcRegionH / 2) - (thickness / 2)
-    radius = math.min((w / 2) - gaugepadding, maxRadius + 8)
 
     -- Widget background
     if c.bgcolor then
@@ -279,25 +377,21 @@ function render.paint(x, y, w, h, box)
     end
 
     -- Arc layout
-    local cx = x + w / 2
-    local startAngle = 225
-    local endAngle = (startAngle + 270) % 360
-
     -- Draw background arc (full 270° from 225 to 135)
-    drawArc(cx, cy, radius, thickness, startAngle, endAngle, c.fillbgcolor)
+    drawArc(g.cx, g.cy, g.radius, c.thickness, g.startAngle, g.endAngleFull, c.fillbgcolor)
 
     -- Foreground arc based on percent fill
     if c.percent and c.percent > 0 then
-        local valueEndAngle = (startAngle + 270 * c.percent) % 360
-        drawArc(cx, cy, radius, thickness, startAngle, valueEndAngle, c.fillcolor)
+        local valueEndAngle = (g.startAngle + 270 * c.percent) % 360
+        drawArc(g.cx, g.cy, g.radius, c.thickness, g.startAngle, valueEndAngle, c.fillcolor)
     end
 
     -- Max value arc if enabled
     if c.arcmax and c.maxval and c.max ~= c.min and c.maxPercent > 0 then
-        local innerRadius = radius * 0.74
-        local innerThickness = thickness * 0.8
-        local maxEndAngle = (startAngle + 270 * c.maxPercent) % 360
-        drawArc(cx, cy, innerRadius, innerThickness, startAngle, maxEndAngle, c.maxfillcolor)
+        local innerRadius = g.radius * 0.74
+        local innerThickness = (c.thickness or g.thickness) * 0.8
+        local maxEndAngle = (g.startAngle + 270 * c.maxPercent) % 360
+        drawArc(g.cx, g.cy, innerRadius, innerThickness, g.startAngle, maxEndAngle, c.maxfillcolor)
     end
 
     -- Draw title and value
@@ -320,8 +414,8 @@ function render.paint(x, y, w, h, box)
         lcd.font(_G[c.maxfont] or FONT_S)
         local tw2, th2 = lcd.getTextSize(maxStr)
         lcd.drawText(
-            cx - tw2 / 2 + (c.maxpaddingleft or 0),
-            cy + radius * 0.25 + (c.maxpadding or 0) + (c.maxpaddingtop or 0),
+            g.cx - tw2 / 2 + (c.maxpaddingleft or 0),
+            g.cy + g.radius * 0.25 + (c.maxpadding or 0) + (c.maxpaddingtop or 0),
             maxStr
         )
     end


### PR DESCRIPTION
Reuse and mutate box._cache instead of rebuilding it each wakeup, cutting allocations and GC churn. Cache static params/theme resolves once in box._cfg and reuse them every frame to avoid repeated getParam/resolve calls. Cache arc/title geometry in box._geom and recompute only when size/layout inputs change, eliminating per-paint measurements. Precompile the value transform into cfg.transformFnand use it for values to skip per-frame branching/math.