### PR TITLE
Adjust all sensors to use a 5s guaranteed wakeup

### DIFF
--- a/scripts/rfsuite/tasks/sensors/elrs.lua
+++ b/scripts/rfsuite/tasks/sensors/elrs.lua
@@ -59,7 +59,7 @@ elrs.telemetryFrameSkip  = 0
 elrs.telemetryFrameCount = 0
 
 -- refresh stale sensors older than this many milliseconds
-local REFRESH_INTERVAL_MS = 500 -- 0.5s
+local REFRESH_INTERVAL_MS = 5000 -- 5s
 
 ---------------------------------------------------------------------
 -- Utilities

--- a/scripts/rfsuite/tasks/sensors/msp.lua
+++ b/scripts/rfsuite/tasks/sensors/msp.lua
@@ -152,7 +152,7 @@ local lastValue = {}          -- appId -> last value pushed
 local lastPush = {}           -- appId -> last os.clock() push time
 local lastModule = nil        -- detect telemetry module changes
 local VALUE_EPSILON = 0.0     -- push on any change (use >0 to throttle)
-local FORCE_REFRESH_INTERVAL = 0.25  -- seconds; heartbeat pushes to avoid TX warnings
+local FORCE_REFRESH_INTERVAL = 5  -- seconds; heartbeat pushes to avoid TX warnings
 
 local function getCurrentTime()
     return os.time()

--- a/scripts/rfsuite/tasks/sensors/sensors.lua
+++ b/scripts/rfsuite/tasks/sensors/sensors.lua
@@ -102,19 +102,16 @@ function sensors.wakeup()
 
     loadSensorModule()
     if loadedSensorModule and loadedSensorModule.module.wakeup then
+        
         loadedSensorModule.module.wakeup()
 
         if rfsuite.session and rfsuite.session.isConnected then
             -- run msp sensors
-            if msp and msp.wakeup then
-                msp.wakeup()
-            end
+            if msp and msp.wakeup then msp.wakeup() end
 
             -- run smart sensors
-            if smart and smart.wakeup then
-                smart.wakeup()
-            end        
-
+            if smart and smart.wakeup then smart.wakeup() end
+ 
         end
 
     end
@@ -123,16 +120,11 @@ end
 
 function sensors.reset()
 
-    if loadedSensorModule and loadedSensorModule.module and loadedSensorModule.module.reset then
-        loadedSensorModule.module.reset()
-    end
-
-    if smart and smart.reset then
-        smart.reset()
-    end
-
+    if loadedSensorModule and loadedSensorModule.module and loadedSensorModule.module.reset then loadedSensorModule.module.reset() end
+    if smart and smart.reset then smart.reset() end
+    if msp and msp.reset then msp.reset() end
     loadedSensorModule = nil  -- Clear loaded sensor module
-    msp.reset()
+
 end
 
 return sensors

--- a/scripts/rfsuite/tasks/sensors/smart.lua
+++ b/scripts/rfsuite/tasks/sensors/smart.lua
@@ -75,7 +75,7 @@ local lastValue = {}          -- appId -> last numeric value pushed to TX
 local lastPush = {}           -- appId -> last os.clock() time we pushed any value
 local lastModule = nil        -- detect module changes to rebind DIY sensors
 local VALUE_EPSILON = 0.0     -- push on any change; keep 0 to avoid stale warnings
-local FORCE_REFRESH_INTERVAL = 0.5  -- seconds; force a heartbeat write this often even if unchanged
+local FORCE_REFRESH_INTERVAL = 5  -- seconds; force a heartbeat write this often even if unchanged
 
 local function calculateFuel()
     -- work out what type of sensor we are running and use 


### PR DESCRIPTION
Use 5s as polling of custom sensors - ethos expects a wakeup on a sensor within 10s before complaining.