### PR TITLE
Progress Dialog - noMspQueueShortCircut

### DIFF
--- a/scripts/rfsuite/app/app.lua
+++ b/scripts/rfsuite/app/app.lua
@@ -73,6 +73,7 @@ triggers.closeSaveFake         = false
 triggers.badMspVersion         = false
 triggers.badMspVersionDisplay  = false
 triggers.closeProgressLoader   = false
+triggers.closeProgressLoaderNoisProcessed = false
 triggers.mspBusy               = false
 triggers.disableRssiTimeout    = false
 triggers.timeIsSet             = false

--- a/scripts/rfsuite/app/lib/ui.lua
+++ b/scripts/rfsuite/app/lib/ui.lua
@@ -44,13 +44,22 @@ function ui.progressDisplay(title, message)
 
             if not app.triggers.closeProgressLoader then
                 app.dialogs.progressCounter = app.dialogs.progressCounter + 2
-            elseif app.triggers.closeProgressLoader and rfsuite.tasks.msp.mspQueue:isProcessed() then
+            elseif app.triggers.closeProgressLoader and rfsuite.tasks.msp.mspQueue:isProcessed() then   -- this is the one we normally catch
                 app.dialogs.progressCounter = app.dialogs.progressCounter + 15
                 if app.dialogs.progressCounter >= 100 then
                     app.dialogs.progress:close()
                     app.dialogs.progressDisplay = false
                     app.dialogs.progressCounter = 0
                     app.triggers.closeProgressLoader = false
+                end
+            elseif app.triggers.closeProgressLoader and  app.triggers.closeProgressLoaderNoisProcessed then   -- an oddball for things where we dont want to check against isProcessed
+                app.dialogs.progressCounter = app.dialogs.progressCounter + 15
+                if app.dialogs.progressCounter >= 100 then
+                    app.dialogs.progress:close()
+                    app.dialogs.progressDisplay = false
+                    app.dialogs.progressCounter = 0
+                    app.triggers.closeProgressLoader = false
+                    app.triggers.closeProgressLoaderNoisProcessed= false
                 end
             end
 

--- a/scripts/rfsuite/app/modules/sbusout/sbusout.lua
+++ b/scripts/rfsuite/app/modules/sbusout/sbusout.lua
@@ -116,6 +116,7 @@ local function openPage(pidx, title, script)
     end
 
     rfsuite.app.triggers.closeProgressLoader = true
+    rfsuite.app.triggers.closeProgressLoaderNoisProcessed = true
 
     enableWakeup = true
     collectgarbage()
@@ -169,6 +170,7 @@ local function wakeup()
             rfsuite.app.formFields[pidx]:enable(true)
             if rfsuite.preferences.menulastselected["sbuschannel"] == rfsuite.currentSbusServoIndex then rfsuite.app.formFields[rfsuite.currentSbusServoIndex]:focus() end
         end
+        -- close the progressDisplay
     end
 
 end


### PR DESCRIPTION
Added in a shortcircuit to prevent getting an msp timeout for modules that require it.