### PR TITLE
Reduce cpu churn - dashboard and io lookups

### DIFF
--- a/scripts/rfsuite/lib/utils.lua
+++ b/scripts/rfsuite/lib/utils.lua
@@ -304,21 +304,51 @@ function utils.createCacheFile(tbl, path, options)
     f:close()
 end
 
-function utils.dir_exists(base, name)
+-- Cache tables
+local directoryExistenceCache = {}
+local fileExistenceCache      = {}
+
+--- Check if a directory exists, with optional caching.
+-- @param base string: base path (defaults to "./")
+-- @param name string: directory name
+-- @param noCache boolean: bypass the cache if true
+-- @return boolean: true if exists, false otherwise
+function utils.dir_exists(base, name, noCache)
     base = base or "./"
     if not name then return false end
 
-    local tgt = base .. name
-    local exists = os.stat(tgt)
-    if exists then return true end
+    local targetPath = base .. name
+
+    if not noCache and directoryExistenceCache[targetPath] then return true end
+
+    local exists = os.stat(targetPath)
+    if exists then
+        if not noCache then
+            directoryExistenceCache[targetPath] = true
+        end
+        return true
+    end
+
     return false
 end
 
-function utils.file_exists(name)
-    local tgt = os.stat(name)
-    if tgt then
+--- Check if a file exists, with optional caching.
+-- @param path string: file path
+-- @param noCache boolean: bypass the cache if true
+-- @return boolean: true if exists, false otherwise
+function utils.file_exists(path, noCache)
+    if not path then return false end
+
+    if not noCache and fileExistenceCache[path] then return true end
+
+    local stat = os.stat(path)
+    if stat then
+        if not noCache then
+            fileExistenceCache[path] = true
+        end
         return true
     end
+
     return false
 end
 

--- a/scripts/rfsuite/widgets/dashboard/dashboard.lua
+++ b/scripts/rfsuite/widgets/dashboard/dashboard.lua
@@ -1412,19 +1412,13 @@ function dashboard.wakeup(widget)
     if admin or not visible then
         -- not visible or in admin 
         return     
-    elseif not rfsuite.session.isConnected then
-        -- if not connected, then poll every 1 second
-        if (now - lastWakeup) < 1 then return end
     elseif isSliding then
         -- check if sliding timeout expired
         if (now - isSlidingStart) > 1 then
             isSliding = false
         else
             return
-        end
-    else
-        -- default rate limit of 0.05s (50% of clock speed)
-        if (now - lastWakeup) < 0.05 then return end   
+        end 
     end
 
     objectProfiler = rfsuite.preferences and rfsuite.preferences.developer and rfsuite.preferences.developer.logobjprof


### PR DESCRIPTION
Added in a 'cache' to quick return on file/disk lookups - to reduce disk lookups

Removed a loop wasting cycles checking valid screen resolution (now checks only if resolution changes)

Moved some 'quick returns for dashboard higher in the wakeup - resulting in less 'churn' when you will return anyway!