### PR TITLE
[fix] Auto detect correct menu to return to 

### DIFF
--- a/src/rfsuite/app/lib/ui.lua
+++ b/src/rfsuite/app/lib/ui.lua
@@ -395,6 +395,8 @@ function ui.openMainMenuSub(activesection)
     if not utils.ethosVersionAtLeast(config.ethosVersion) then return end
 
     local MainMenu = app.MainMenu
+    
+    app.lastMenu = activesection
 
     preferences.general.iconsize = tonumber(preferences.general.iconsize) or 1
 


### PR DESCRIPTION
Adds in a variable that was accidently removed resulting in back button not going to correct level within the menu stack.