### PR TITLE
Add new headers for configuration and system, update translations, an…

### DIFF
--- a/src/rfsuite/app/lib/ui.lua
+++ b/src/rfsuite/app/lib/ui.lua
@@ -337,7 +337,7 @@ function ui.openMainMenu()
 
     local lc, bx, y = 0, 0, 0
 
-    local header = form.addLine("Configuration")
+    local header = form.addLine("@i18n(app.header_configuration)@")
 
     for pidx, pvalue in ipairs(Menu) do
         app.formFieldsOffline[pidx] = pvalue.offline or false
@@ -345,7 +345,7 @@ function ui.openMainMenu()
 
         if pvalue.newline then
             lc = 0
-            form.addLine("System")
+            form.addLine("@i18n(app.header_system)@")
         end
 
         if lc == 0 then y = form.height() + ((preferences.general.iconsize == 2) and app.radio.buttonPadding or app.radio.buttonPaddingSmall) end
@@ -442,7 +442,7 @@ function ui.openMainMenuSub(activesection)
 
             local x = windowWidth - 110
             app.formNavigationFields['menu'] = form.addButton(line, {x = x, y = app.radio.linePaddingTop, w = 100, h = app.radio.navbuttonHeight}, {
-                text = "MENU",
+                text = "@i18n(app.navigation_menu)@",
                 icon = nil,
                 options = FONT_S,
                 paint = function() end,

--- a/src/rfsuite/app/modules/diagnostics/diagnostics.lua
+++ b/src/rfsuite/app/modules/diagnostics/diagnostics.lua
@@ -45,7 +45,7 @@ local function openPage(pidx, title, script)
     local x = windowWidth - buttonW - 10
 
     app.formNavigationFields['menu'] = form.addButton(line, {x = x, y = app.radio.linePaddingTop, w = buttonW, h = app.radio.navbuttonHeight}, {
-        text = "MENU",
+        text = "@i18n(app.navigation_menu)@",
         icon = nil,
         options = FONT_S,
         paint = function() end,

--- a/src/rfsuite/app/modules/pids/help.lua
+++ b/src/rfsuite/app/modules/pids/help.lua
@@ -9,7 +9,7 @@ local data = {}
 
 data['help'] = {}
 
-data['help']['default'] = {"@i18n(app.modules.pids.help_p1)@", "@i18n(app.modules.pids.help_p2)@", "@i18n(app.modules.pids.help_p3)@", "@i18n(app.modules.pids.help_p4)@", "@i18n(app.modules.pids.help_p5)@"}
+data['help']['default'] = {"@i18n(app.modules.pids.help_p1)@", "@i18n(app.modules.pids.help_p2)@", "@i18n(app.modules.pids.help_p3)@", "@i18n(app.modules.pids.help_p4)@"}
 
 data['fields'] = {}
 

--- a/src/rfsuite/app/modules/settings/settings.lua
+++ b/src/rfsuite/app/modules/settings/settings.lua
@@ -45,7 +45,7 @@ local function openPage(pidx, title, script)
     local x = windowWidth - buttonW - 10
 
     rfsuite.app.formNavigationFields['menu'] = form.addButton(line, {x = x, y = rfsuite.app.radio.linePaddingTop, w = buttonW, h = rfsuite.app.radio.navbuttonHeight}, {
-        text = "MENU",
+        text = "@i18n(app.navigation_menu)@",
         icon = nil,
         options = FONT_S,
         paint = function() end,

--- a/src/rfsuite/i18n/de.json
+++ b/src/rfsuite/i18n/de.json
@@ -16,7 +16,7 @@
       "batteryCapacity": {
         "english": "The milliamp hour capacity of your battery.",
         "needs_translation": false,
-        "translation": "Die Kapazitaet Ihrer Batterie in Milliamperestunden."
+        "translation": "Die Kapazität Ihrer Batterie in Milliamperestunden."
       },
       "batteryCellCount": {
         "english": "The number of cells in your battery.",
@@ -25,38 +25,38 @@
       },
       "source_adc": {
         "english": "Battery ADC",
-        "needs_translation": true,
-        "translation": "Battery ADC"
+        "needs_translation": false,
+        "translation": "Batterie ADC"
       },
       "source_esc": {
         "english": "ESC Telemetry",
-        "needs_translation": true,
-        "translation": "ESC Telemetry"
+        "needs_translation": false,
+        "translation": "ESC Telemetrie"
       },
       "source_none": {
         "english": "None",
-        "needs_translation": true,
-        "translation": "None"
+        "needs_translation": false,
+        "translation": "Keine"
       },
       "vbatfullcellvoltage": {
         "english": "The nominal voltage of a fully charged cell.",
         "needs_translation": false,
-        "translation": "Die Nennspannung einer vollstaendig geladenen Zelle."
+        "translation": "Die Nennspannung einer vollständig geladenen Zelle."
       },
       "vbatmaxcellvoltage": {
         "english": "The maximum voltage per cell before the high voltage alarm is triggered.",
         "needs_translation": false,
-        "translation": "Die maximale Spannung pro Zelle, bevor der Hochspannungsalarm ausgeloest wird."
+        "translation": "Die maximale Spannung pro Zelle, bevor der Hochspannungsalarm ausgelöst wird."
       },
       "vbatmincellvoltage": {
         "english": "The minimum voltage per cell before the low voltage alarm is triggered.",
         "needs_translation": false,
-        "translation": "Die minimale Spannung pro Zelle, bevor der Niederspannungsalarm ausgeloest wird."
+        "translation": "Die minimale Spannung pro Zelle, bevor der Niederspannungsalarm ausgelöst wird."
       },
       "vbatwarningcellvoltage": {
         "english": "The voltage per cell at which the low voltage alarm will start to sound.",
         "needs_translation": false,
-        "translation": "Die Spannung pro Zelle, bei der der Niederspannungsalarm ausgeloest wird."
+        "translation": "Die Spannung pro Zelle, bei der der Niederspannungsalarm ausgelöst wird."
       }
     },
     "BATTERY_INI": {
@@ -73,7 +73,7 @@
       "alert_rxbatt": {
         "english": "RxBatt",
         "needs_translation": false,
-        "translation": "Empfaengerakku"
+        "translation": "Empfängerakku"
       },
       "calcfuel_local": {
         "english": "Calculate Fuel Using",
@@ -83,7 +83,7 @@
       "sag_multiplier": {
         "english": "Raise or lower to adjust for the amount of voltage sag you see in flight.",
         "needs_translation": false,
-        "translation": "Erhoehen oder verringern, um den Spannungseinbruch im Flug anzupassen."
+        "translation": "Erhöhen oder verringern, um den Spannungseinbruch im Flug anzupassen."
       },
       "tbl_off": {
         "english": "Current Sensor",
@@ -100,7 +100,7 @@
       "buzzer_volume": {
         "english": "Beeper volume",
         "needs_translation": false,
-        "translation": "Summerlautstaerke"
+        "translation": "Summerlautstärke"
       },
       "cell_count": {
         "english": "Number of cells in the battery",
@@ -110,7 +110,7 @@
       "current_gain": {
         "english": "Gain value for the current sensor",
         "needs_translation": false,
-        "translation": "Verstaerkungswert fuer den Stromsensor"
+        "translation": "Verstärkungswert für den Stromsensor"
       },
       "drive_freq": {
         "english": "PWM drive frequency",
@@ -120,17 +120,17 @@
       "electrical_angle": {
         "english": "Electrical angle for the motor",
         "needs_translation": false,
-        "translation": "Timing-Winkel fuer den Motor"
+        "translation": "Timing-Winkel für den Motor"
       },
       "gov_i": {
         "english": "Integral value for the governor",
         "needs_translation": false,
-        "translation": "Integralwert fuer den Governor"
+        "translation": "Integralwert für den Governor"
       },
       "gov_p": {
         "english": "Proportional value for the governor",
         "needs_translation": false,
-        "translation": "Proportionalwert fuer den Governor"
+        "translation": "Proportionalwert für den Governor"
       },
       "low_voltage_protection": {
         "english": "Voltage at which we cut power by 50%",
@@ -150,17 +150,17 @@
       "soft_start": {
         "english": "Soft start time",
         "needs_translation": false,
-        "translation": "Wert fuer sanftes Anlaufen"
+        "translation": "Wert für sanftes Anlaufen"
       },
       "starting_torque": {
         "english": "Starting power for the motor",
         "needs_translation": false,
-        "translation": "Anlaufmoment fuer den Motor"
+        "translation": "Anlaufmoment für den Motor"
       },
       "tbl_alwaysoff": {
         "english": "Always Off",
-        "needs_translation": true,
-        "translation": "Always Off"
+        "needs_translation": false,
+        "translation": "Immer aus"
       },
       "tbl_alwayson": {
         "english": "Always On",
@@ -257,7 +257,7 @@
       "tbl_fixedwing": {
         "english": "Fixed Wing",
         "needs_translation": false,
-        "translation": "Flaechenflugzeug"
+        "translation": "Flächenflugzeug"
       },
       "tbl_hardcutoff": {
         "english": "Hard Cutoff",
@@ -267,7 +267,7 @@
       "tbl_heliext": {
         "english": "Heli Ext Governor",
         "needs_translation": false,
-        "translation": "Heli Externer Governor"
+        "translation": "Heli externer Governor"
       },
       "tbl_heligov": {
         "english": "Heli Governor",
@@ -277,7 +277,7 @@
       "tbl_helistore": {
         "english": "Heli Governor Store",
         "needs_translation": false,
-        "translation": "Heli Governor Speicher"
+        "translation": "Heli Governor-Speicher"
       },
       "tbl_normal": {
         "english": "Normal",
@@ -344,7 +344,7 @@
       "tbl_fmfw": {
         "english": "Fixed Wing",
         "needs_translation": false,
-        "translation": "Flaechenflugzeug"
+        "translation": "Flächenflugzeug"
       },
       "tbl_fmheli": {
         "english": "Helicopter",
@@ -354,12 +354,12 @@
       "tbl_fwgov": {
         "english": "Fixed Wing",
         "needs_translation": false,
-        "translation": "Flaechenflugzeug-Governor"
+        "translation": "Flächenflugzeug-Governor"
       },
       "tbl_green": {
         "english": "GREEN",
         "needs_translation": false,
-        "translation": "Gruen"
+        "translation": "Grün"
       },
       "tbl_high": {
         "english": "High",
@@ -369,7 +369,7 @@
       "tbl_jadegreen": {
         "english": "JADE GREEN",
         "needs_translation": false,
-        "translation": "Jadegruen"
+        "translation": "Jadegrün"
       },
       "tbl_low": {
         "english": "Low",
@@ -434,7 +434,7 @@
       "tbl_white": {
         "english": "WHITE",
         "needs_translation": false,
-        "translation": "Weiss"
+        "translation": "Weiß"
       },
       "tbl_yellow": {
         "english": "YELLOW",
@@ -568,7 +568,7 @@
       "tbl_fmfw": {
         "english": "Fixed Wing",
         "needs_translation": false,
-        "translation": "Flaechenflugzeug"
+        "translation": "Flöchenflugzeug"
       },
       "tbl_fmheli": {
         "english": "Helicopter",
@@ -578,7 +578,7 @@
       "tbl_fwgov": {
         "english": "Fixed Wing",
         "needs_translation": false,
-        "translation": "Flaechenflugzeug-Governor"
+        "translation": "Flöchenflugzeug-Governor"
       },
       "tbl_green": {
         "english": "GREEN",
@@ -720,7 +720,7 @@
       "tbl_modeair": {
         "english": "Aero Motor",
         "needs_translation": false,
-        "translation": "Luftfahrtmotor"
+        "translation": "Flugmotor"
       },
       "tbl_modeext": {
         "english": "Heli Ext Governor",
@@ -745,7 +745,7 @@
       "tbl_modeheli": {
         "english": "Heli Governor",
         "needs_translation": false,
-        "translation": "Heli Governor"
+        "translation": "Heli-Governor"
       },
       "tbl_modestore": {
         "english": "Heli Governor Store",
@@ -790,7 +790,7 @@
       "tbl_unused": {
         "english": "*Unused*",
         "needs_translation": false,
-        "translation": "*Nicht verwendet*"
+        "translation": "*Ungenutzt*"
       }
     },
     "ESC_PARAMETERS_ZTW": {
@@ -939,7 +939,7 @@
       "consumption_correction": {
         "english": "Adjust the consumption correction",
         "needs_translation": false,
-        "translation": "Anpassen der Verbrauchskorrektur"
+        "translation": "Verbrauchskorrektur anpassen"
       },
       "current_correction": {
         "english": "Adjust current correction",
@@ -959,7 +959,7 @@
       "hw4_current_gain": {
         "english": "Hobbywing v4 current gain adjustment",
         "needs_translation": false,
-        "translation": "Hobbywing v4 Stromverstaerkung-Anpassung"
+        "translation": "Hobbywing v4 Stromverstörkung-Anpassung"
       },
       "hw4_current_offset": {
         "english": "Hobbywing v4 current offset adjustment",
@@ -969,12 +969,12 @@
       "hw4_voltage_gain": {
         "english": "Hobbywing v4 voltage gain adjustment",
         "needs_translation": false,
-        "translation": "Hobbywing v4 Spannungsverstaerkung-Anpassung"
+        "translation": "Hobbywing v4 Spannungsverstärkung-Anpassung"
       },
       "pin_swap": {
         "english": "Swap the TX and RX pins for the ESC telemetry",
         "needs_translation": false,
-        "translation": "Tauschen der TX- und RX-Pins fuer die ESC-Telemetrie"
+        "translation": "Tauschen der TX- und RX-Pins für die ESC-Telemetrie"
       },
       "tbl_off": {
         "english": "Off",
@@ -994,14 +994,14 @@
       "voltage_correction": {
         "english": "Adjust the voltage correction",
         "needs_translation": false,
-        "translation": "Anpassen der Spannungskorrektur"
+        "translation": "Spannungskorrektur anpassen"
       }
     },
     "FILTER_CONFIG": {
       "dyn_notch_count": {
         "english": "Number of notches to apply.",
         "needs_translation": false,
-        "translation": "Anzahl der Noteches."
+          "translation": "Anzahl der Notches."
       },
       "dyn_notch_max_hz": {
         "english": "Maximum frequency to which the notch is applied.",
@@ -1016,7 +1016,7 @@
       "dyn_notch_q": {
         "english": "Quality factor of the notch filter.",
         "needs_translation": false,
-        "translation": "Qualitaetsfaktor des dynamischen Notch-Filters."
+          "translation": "Qualitätsfaktor des dynamischen Notch-Filters."
       },
       "gyro_lpf1_dyn_max_hz": {
         "english": "Dynamic filter max cutoff in Hz.",
@@ -1103,32 +1103,32 @@
       "gov_handover_throttle": {
         "english": "Governor activates above this %. Below this the input throttle is passed to the ESC.",
         "needs_translation": false,
-        "translation": "Der Governor aktiviert sich ueber diesem Wert in %. Darunter wird das Eingangs-Gas an den ESC weitergegeben."
+        "translation": "Der Governor aktiviert sich über diesem Wert in %. Darunter wird das Eingangs-Gas an den ESC weitergegeben."
       },
       "gov_recovery_time": {
         "english": "Time constant for recovery spoolup, in seconds, measuring the time from zero to full headspeed.",
         "needs_translation": false,
-        "translation": "Zeitkonstante fuer die Wiederherstellung des Hochfahrens in Sekunden, gemessen von null bis zur vollen Drehzahl."
+        "translation": "Zeitkonstante für die Wiederherstellung des Hochfahrens in Sekunden, gemessen von null bis zur vollen Drehzahl."
       },
       "gov_spoolup_min_throttle": {
         "english": "Minimum throttle to use for slow spoolup, in percent. For electric motors the default is 5%, for nitro this should be set so the clutch starts to engage for a smooth spoolup 10-15%.",
         "needs_translation": false,
-        "translation": "Minimaler Gaswert fuer langsames Hochfahren in Prozent. Bei Elektromotoren ist der Standardwert 5 %, bei Nitro sollte der Wert so eingestellt werden, dass die Kupplung fuer ein sanftes Hochfahren zu greifen beginnt (10-15 %)."
+        "translation": "Minimaler Gaswert für langsames Hochfahren in Prozent. Bei Elektromotoren ist der Standardwert 5 %, bei Nitro sollte der Wert so eingestellt werden, dass die Kupplung für ein sanftes Hochfahren zu greifen beginnt (10-15 %)."
       },
       "gov_spoolup_time": {
         "english": "Time constant for slow spoolup, in seconds, measuring the time from zero to full headspeed.",
         "needs_translation": false,
-        "translation": "Zeitkonstante fuer das langsame Hochfahren in Sekunden, gemessen von null bis zur vollen Drehzahl."
+        "translation": "Zeitkonstante für das langsame Hochfahren in Sekunden, gemessen von null bis zur vollen Drehzahl."
       },
       "gov_startup_time": {
         "english": "Time constant for slow startup, in seconds, measuring the time from zero to full headspeed.",
         "needs_translation": false,
-        "translation": "Zeitkonstante fuer den langsamen Start in Sekunden, gemessen von null bis zur vollen Drehzahl."
+        "translation": "Zeitkonstante für den langsamen Start in Sekunden, gemessen von null bis zur vollen Drehzahl."
       },
       "gov_tracking_time": {
         "english": "Time constant for headspeed changes, in seconds, measuring the time from zero to full headspeed.",
         "needs_translation": false,
-        "translation": "Zeitkonstante fuer Drehzahlaenderungen in Sekunden, gemessen von null bis zur vollen Drehzahl."
+        "translation": "Zeitkonstante für Drehzahländerungen in Sekunden, gemessen von null bis zur vollen Drehzahl."
       },
       "governor_auto_throttle": {
         "english": "Auto throttle",
@@ -1147,8 +1147,8 @@
       },
       "tbl_govmode_direct": {
         "english": "DIRECT",
-        "needs_translation": true,
-        "translation": "DIRECT"
+        "needs_translation": false,
+        "translation": "DIREKT"
       },
       "tbl_govmode_electric": {
         "english": "ELECTRIC",
@@ -1157,7 +1157,7 @@
       },
       "tbl_govmode_limit": {
         "english": "LIMIT",
-        "needs_translation": true,
+        "needs_translation": false,
         "translation": "LIMIT"
       },
       "tbl_govmode_mode1": {
@@ -1192,8 +1192,8 @@
       },
       "tbl_throttle_type_function": {
         "english": "FUNCTION",
-        "needs_translation": true,
-        "translation": "FUNCTION"
+        "needs_translation": false,
+        "translation": "FUNKTION"
       },
       "tbl_throttle_type_normal": {
         "english": "NORMAL",
@@ -1202,8 +1202,8 @@
       },
       "tbl_throttle_type_switch": {
         "english": "SWITCH",
-        "needs_translation": true,
-        "translation": "SWITCH"
+        "needs_translation": false,
+        "translation": "SCHALTER"
       }
     },
     "GOVERNOR_PROFILE": {
@@ -1220,27 +1220,27 @@
       "governor_d_gain": {
         "english": "PID loop D-term gain.",
         "needs_translation": false,
-        "translation": "D-Term-Verstaerkung der PID-Regler."
+        "translation": "D-Term-Verstärkung der PID-Regler."
       },
       "governor_f_gain": {
         "english": "Feedforward gain.",
         "needs_translation": false,
-        "translation": "Feedforward-Verstaerkung."
+        "translation": "Feedforward-Verstärkung."
       },
       "governor_gain": {
         "english": "Master PID loop gain.",
         "needs_translation": false,
-        "translation": "Master-Verstaerkung der PID-Regler."
+        "translation": "Master-Verstärkung der PID-Regler."
       },
       "governor_headspeed": {
         "english": "Target headspeed for the current profile.",
         "needs_translation": false,
-        "translation": "Ziel-Drehzahl fuer das aktuelle Profil."
+        "translation": "Ziel-Drehzahl für das aktuelle Profil."
       },
       "governor_i_gain": {
         "english": "PID loop I-term gain.",
         "needs_translation": false,
-        "translation": "I-Term-Verstaerkung der PID-Regler."
+        "translation": "I-Term-Verstärkung der PID-Regler."
       },
       "governor_max_throttle": {
         "english": "Maximum output throttle the governor is allowed to use.",
@@ -1255,17 +1255,17 @@
       "governor_p_gain": {
         "english": "PID loop P-term gain.",
         "needs_translation": false,
-        "translation": "P-Term-Verstaerkung der PID-Regler."
+        "translation": "P-Term-Verstärkung der PID-Regler."
       },
       "governor_tta_gain": {
         "english": "TTA gain applied to increase headspeed to control the tail in the negative direction (e.g. motorised tail less than idle speed).",
         "needs_translation": false,
-        "translation": "TTA-Verstaerkung zur Erhoehung der Drehzahl zur Steuerung des Hecks in die negative Richtung (z. B. motorisiertes Heck unter Leerlaufdrehzahl)."
+        "translation": "TTA-Verstärkung zur Erhöhung der Drehzahl zur Steuerung des Hecks in die negative Richtung (z. B. motorisiertes Heck unter Leerlaufdrehzahl)."
       },
       "governor_tta_limit": {
         "english": "TTA max headspeed increase over full headspeed.",
         "needs_translation": false,
-        "translation": "Maximale TTA-Drehzahlerhoehung ueber die volle Drehzahl hinaus."
+        "translation": "Maximale TTA-Drehzahlerhöhung über die volle Drehzahl hinaus."
       },
       "governor_yaw_ff_weight": {
         "english": "Yaw precompensation weight - how much yaw is mixed into the feedforward.",
@@ -1287,12 +1287,12 @@
       "collective_tilt_correction_neg": {
         "english": "Adjust the collective tilt correction scaling for negative collective pitch.",
         "needs_translation": false,
-        "translation": "Skalierung der Kollektiv-Neigungskorrektur fuer negativen Pitch."
+        "translation": "Skalierung der Kollektiv-Neigungskorrektur für negativen Pitch."
       },
       "collective_tilt_correction_pos": {
         "english": "Adjust the collective tilt correction scaling for positive collective pitch.",
         "needs_translation": false,
-        "translation": "Skalierung der Kollektiv-Neigungskorrektur fuer positiven Pitch."
+        "translation": "Skalierung der Kollektiv-Neigungskorrektur für positiven Pitch."
       },
       "swash_geo_correction": {
         "english": "Adjust if there is too much negative collective or too much positive collective.",
@@ -1302,7 +1302,7 @@
       "swash_phase": {
         "english": "Phase offset for the swashplate controls.",
         "needs_translation": false,
-        "translation": "Phasenversatz fuer die Taumelscheibensteuerung."
+        "translation": "Phasenversatz für die Taumelscheibensteuerung."
       },
       "swash_pitch_limit": {
         "english": "Maximum amount of combined cyclic and collective blade pitch.",
@@ -1312,27 +1312,27 @@
       "swash_trim_0": {
         "english": "Swash trim to level the swash plate when using fixed links.",
         "needs_translation": false,
-        "translation": "Taumelscheiben-Trimmung zur Nivellierung bei festen Gestaengen."
+        "translation": "Taumelscheiben-Trimmung zur Nivellierung bei festen Gestängen."
       },
       "swash_trim_1": {
         "english": "Swash trim to level the swash plate when using fixed links.",
         "needs_translation": false,
-        "translation": "Taumelscheiben-Trimmung zur Nivellierung bei festen Gestaengen."
+        "translation": "Taumelscheiben-Trimmung zur Nivellierung bei festen Gestängen."
       },
       "swash_trim_2": {
         "english": "Swash trim to level the swash plate when using fixed links.",
         "needs_translation": false,
-        "translation": "Taumelscheiben-Trimmung zur Nivellierung bei festen Gestaengen."
+        "translation": "Taumelscheiben-Trimmung zur Nivellierung bei festen Gestängen."
       },
       "swash_tta_precomp": {
         "english": "Mixer precomp for 0 yaw.",
         "needs_translation": false,
-        "translation": "Mischer-Vorkompensation fuer 0 Gier."
+        "translation": "Mischer-Vorkompensation für 0 Gier."
       },
       "tail_center_trim": {
         "english": "Sets tail rotor trim for 0 yaw for variable pitch, or tail motor throttle for 0 yaw for motorized.",
         "needs_translation": false,
-        "translation": "Heckrotor-Trimmung fuer 0 Gier bei variablem Pitch oder Heckmotor-Gas fuer 0 Gier bei motorisiertem Heck."
+        "translation": "Heckrotor-Trimmung für 0 Gier bei variablem Pitch oder Heckmotor-Gas für 0 Gier bei motorisiertem Heck."
       },
       "tail_motor_idle": {
         "english": "Minimum throttle signal sent to the tail motor. This should be set just high enough that the motor does not stop.",
@@ -1351,30 +1351,30 @@
       },
       "tbl_tail_bidirectional": {
         "english": "Bidirectional",
-        "needs_translation": true,
-        "translation": "Bidirectional"
+        "needs_translation": false,
+        "translation": "Bidirektional"
       },
       "tbl_tail_motororized_tail": {
         "english": "Motorized Tail",
-        "needs_translation": true,
-        "translation": "Motorized Tail"
+        "needs_translation": false,
+        "translation": "Motorisiertes Heck"
       },
       "tbl_tail_variable_pitch": {
         "english": "Variable Pitch",
-        "needs_translation": true,
-        "translation": "Variable Pitch"
+        "needs_translation": false,
+        "translation": "Variabler Pitch"
       }
     },
     "MIXER_INPUT": {
       "tbl_normal": {
         "english": "Normal",
-        "needs_translation": true,
+        "needs_translation": false,
         "translation": "Normal"
       },
       "tbl_reversed": {
         "english": "Reversed",
-        "needs_translation": true,
-        "translation": "Reversed"
+        "needs_translation": false,
+        "translation": "Umgekehrt"
       }
     },
     "MOTOR_CONFIG": {
@@ -1430,13 +1430,13 @@
       },
       "tbl_off": {
         "english": "OFF",
-        "needs_translation": true,
-        "translation": "Off"
+        "needs_translation": false,
+        "translation": "AUS"
       },
       "tbl_on": {
         "english": "ON",
-        "needs_translation": true,
-        "translation": "On"
+        "needs_translation": false,
+        "translation": "AN"
       }
     },
     "PID_PROFILE": {
@@ -1448,7 +1448,7 @@
       "angle_level_strength": {
         "english": "Determines how aggressively the helicopter tilts back to level while in Angle Mode.",
         "needs_translation": false,
-        "translation": "Bestimmt, wie stark der Heli im Winkelmodus zur Horizontalen zurueckkippt."
+        "translation": "Bestimmt, wie stark der Heli im Winkelmodus zur Horizontalen zurückkippt."
       },
       "bterm_cutoff_0": {
         "english": "B-term cutoff in Hz.",
@@ -1468,12 +1468,12 @@
       "cyclic_cross_coupling_cutoff": {
         "english": "Frequency limit for the compensation. Higher value will make the compensation action faster.",
         "needs_translation": false,
-        "translation": "Frequenzgrenze fuer die Kompensation. Hoeher bedeutet schnellere Korrektur."
+        "translation": "Frequenzgrenze für die Kompensation. Höher bedeutet schnellere Korrektur."
       },
       "cyclic_cross_coupling_gain": {
         "english": "Amount of compensation applied for pitch-to-roll decoupling.",
         "needs_translation": false,
-        "translation": "Menge der angewendeten Kompensation fuer Pitch-Roll-Entkopplung."
+        "translation": "Menge der angewendeten Kompensation für Pitch-Roll-Entkopplung."
       },
       "cyclic_cross_coupling_ratio": {
         "english": "Amount of roll-to-pitch compensation needed, vs. pitch-to-roll.",
@@ -1498,12 +1498,12 @@
       "error_decay_limit_cyclic": {
         "english": "Maximum bleed-off speed for cyclic I-term.",
         "needs_translation": false,
-        "translation": "Maximale Geschwindigkeit fuer das Reduzieren des zyklischen I-Terms."
+        "translation": "Maximale Geschwindigkeit für das Reduzieren des zyklischen I-Terms."
       },
       "error_decay_time_cyclic": {
         "english": "Time constant for bleeding off cyclic I-term. Higher will stabilize hover, lower will drift.",
         "needs_translation": false,
-        "translation": "Zeitkonstante fuer das allmaehliche Reduzieren des zyklischen I-Terms. Hoeher stabilisiert den Schwebeflug, niedriger fuehrt zu mehr Drift."
+        "translation": "Zeitkonstante für das allmähliche Reduzieren des zyklischen I-Terms. Höher stabilisiert den Schwebeflug, niedriger führt zu mehr Drift."
       },
       "error_decay_time_ground": {
         "english": "Bleeds off the current controller error when the craft is not airborne to stop the craft tipping over.",
@@ -1513,17 +1513,17 @@
       "error_limit_0": {
         "english": "Hard limit for the angle error in the PID loop. The absolute error and thus the I-term will never go above these limits.",
         "needs_translation": false,
-        "translation": "Harte Begrenzung fuer den Winkel-Fehler im PID-Regler. Der absolute Fehler und damit der I-Term werden nie ueber diese Grenzen hinausgehen."
+        "translation": "Harte Begrenzung für den Winkel-Fehler im PID-Regler. Der absolute Fehler und damit der I-Term werden nie über diese Grenzen hinausgehen."
       },
       "error_limit_1": {
         "english": "Hard limit for the angle error in the PID loop. The absolute error and thus the I-term will never go above these limits.",
         "needs_translation": false,
-        "translation": "Harte Begrenzung fuer den Winkel-Fehler im PID-Regler."
+        "translation": "Harte Begrenzung für den Winkel-Fehler im PID-Regler."
       },
       "error_limit_2": {
         "english": "Hard limit for the angle error in the PID loop. The absolute error and thus the I-term will never go above these limits.",
         "needs_translation": false,
-        "translation": "Harte Begrenzung fuer den Winkel-Fehler im PID-Regler."
+        "translation": "Harte Begrenzung für den Winkel-Fehler im PID-Regler."
       },
       "error_rotation": {
         "english": "Rotates the current roll and pitch error terms around yaw when the craft rotates. This is sometimes called Piro Compensation.",
@@ -1548,12 +1548,12 @@
       "horizon_level_strength": {
         "english": "Determines how aggressively the helicopter tilts back to level while in Horizon Mode.",
         "needs_translation": false,
-        "translation": "Bestimmt, wie stark der Heli im Horizontmodus zur Horizontalen zurueckkippt."
+        "translation": "Bestimmt, wie stark der Heli im Horizontmodus zur Horizontalen zurückkippt."
       },
       "iterm_relax_cutoff_0": {
         "english": "Helps reduce bounce back after fast stick movements. Can cause inconsistency in small stick movements if too low.",
         "needs_translation": false,
-        "translation": "Hilft, das Nachschwingen nach schnellen Knueppelbewegungen zu reduzieren. Kann zu Inkonsistenzen bei kleinen Knueppelbewegungen fuehren, wenn zu niedrig."
+        "translation": "Hilft, das Nachschwingen nach schnellen Knüppelbewegungen zu reduzieren. Kann zu Inkonsistenzen bei kleinen Knüppelbewegungen führen, wenn zu niedrig."
       },
       "iterm_relax_cutoff_1": {
         "english": "Helps reduce bounce back after fast stick movements. Can cause inconsistency in small stick movements if too low.",
@@ -1568,22 +1568,22 @@
       "iterm_relax_type": {
         "english": "Choose the axes in which this is active. RP: Roll, Pitch. RPY: Roll, Pitch, Yaw.",
         "needs_translation": false,
-        "translation": "Waehlen Sie die Achsen, auf denen dies aktiv ist. RP: Roll, Pitch. RPY: Roll, Pitch, Gier."
+        "translation": "Wählen Sie die Achsen, auf denen dies aktiv ist. RP: Roll, Pitch. RPY: Roll, Pitch, Gier."
       },
       "offset_limit_0": {
         "english": "Hard limit for the High Speed Integral offset angle in the PID loop. The O-term will never go over these limits.",
         "needs_translation": false,
-        "translation": "Harte Begrenzung fuer den High Speed Integral Offset-Winkel in der PID-Schleife. Der O-Term wird nie ueber diese Grenzen hinausgehen."
+        "translation": "Harte Begrenzung für den High Speed Integral Offset-Winkel in der PID-Schleife. Der O-Term wird nie über diese Grenzen hinausgehen."
       },
       "offset_limit_1": {
         "english": "Hard limit for the High Speed Integral offset angle in the PID loop. The O-term will never go over these limits.",
         "needs_translation": false,
-        "translation": "Harte Begrenzung fuer den High Speed Integral Offset-Winkel."
+        "translation": "Harte Begrenzung für den High Speed Integral Offset-Winkel."
       },
       "pitch_collective_ff_gain": {
         "english": "Increasing will compensate for the pitching up motion caused by tail drag when climbing.",
         "needs_translation": false,
-        "translation": "Erhoehen, um das Nick-Aufrichten durch Heckwiderstand beim Steigen auszugleichen."
+        "translation": "Erhöhen, um das Nick-Aufrichten durch Heckwiderstand beim Steigen auszugleichen."
       },
       "tbl_off": {
         "english": "OFF",
@@ -1613,22 +1613,22 @@
       "trainer_gain": {
         "english": "Determines how aggressively the helicopter tilts back to the maximum angle (if exceeded) while in Acro Trainer Mode.",
         "needs_translation": false,
-        "translation": "Bestimmt, wie stark der Heli im Acro-Trainer-Modus zurueckkippt, wenn der Maximalwinkel ueberschritten wird."
+        "translation": "Bestimmt, wie stark der Heli im Acro-Trainer-Modus zurückkippt, wenn der Maximalwinkel überschritten wird."
       },
       "yaw_ccw_stop_gain": {
         "english": "Stop gain (PD) for counter-clockwise rotation.",
         "needs_translation": false,
-        "translation": "Stopp-Verstaerkung (PD) fuer die Drehung gegen den Uhrzeigersinn."
+        "translation": "Stopp-Verstärkung (PD) für die Drehung gegen den Uhrzeigersinn."
       },
       "yaw_collective_dynamic_decay": {
         "english": "Decay time for the extra yaw precomp on collective input.",
         "needs_translation": false,
-        "translation": "Abfallzeit fuer die zusaetzliche Gier-Vorkompensation bei kollektiven Eingaben."
+        "translation": "Abfallzeit für die zusätzliche Gier-Vorkompensation bei kollektiven Eingaben."
       },
       "yaw_collective_dynamic_gain": {
         "english": "An extra boost of yaw precomp on collective input.",
         "needs_translation": false,
-        "translation": "Zusaetzlicher Gier-Vorkompensations-Boost bei kollektiven Eingaben."
+        "translation": "Zusätzlicher Gier-Vorkompensations-Boost bei kollektiven Eingaben."
       },
       "yaw_collective_ff_gain": {
         "english": "Collective feedforward mixed into yaw (collective-to-yaw precomp).",
@@ -1638,7 +1638,7 @@
       "yaw_cw_stop_gain": {
         "english": "Stop gain (PD) for clockwise rotation.",
         "needs_translation": false,
-        "translation": "Stopp-Verstaerkung (PD) fuer die Drehung im Uhrzeigersinn."
+        "translation": "Stopp-Verstärkung (PD) für die Drehung im Uhrzeigersinn."
       },
       "yaw_cyclic_ff_gain": {
         "english": "Cyclic feedforward mixed into yaw (cyclic-to-yaw precomp).",
@@ -1648,39 +1648,39 @@
       "yaw_inertia_precomp_cutoff": {
         "english": "Cutoff. Derivative cutoff frequency in 1/10Hz steps. Controls how sharp the precomp is. Higher value is sharper.",
         "needs_translation": false,
-        "translation": "Grenzfrequenz der Ableitung in 1/10Hz-Schritten. Hoeher bedeutet schaerfere Vorkompensation."
+        "translation": "Grenzfrequenz der Ableitung in 1/10Hz-Schritten. Höher bedeutet schärfere Vorkompensation."
       },
       "yaw_inertia_precomp_gain": {
         "english": "Scalar gain. The strength of the main rotor inertia. Higher value means more precomp is applied to yaw control.",
         "needs_translation": false,
-        "translation": "Staerke der Hauptrotor-Traegheit. Hoeher bedeutet mehr Vorkompensation in der Giersteuerung."
+        "translation": "Stärke der Hauptrotor-Trägheit. Höher bedeutet mehr Vorkompensation in der Giersteuerung."
       },
       "yaw_precomp_cutoff": {
         "english": "Frequency limit for all yaw precompensation actions.",
         "needs_translation": false,
-        "translation": "Frequenzgrenze fuer alle Gier-Vorkompensationen."
+        "translation": "Frequenzgrenze für alle Gier-Vorkompensationen."
       }
     },
     "PID_TUNING": {
       "pid_0_B": {
         "english": "Additional boost on the feedforward to make the heli react more to quick stick movements.",
         "needs_translation": false,
-        "translation": "Zusaetzlicher Feedforward-Boost, um das System reaktionsschneller auf schnelle Knueppelbewegungen zu machen."
+        "translation": "Zusätzlicher Feedforward-Boost, um das System reaktionsschneller auf schnelle Knüppelbewegungen zu machen."
       },
       "pid_0_D": {
         "english": "Strength of dampening to any motion on the system, including external influences. Also reduces overshoot.",
         "needs_translation": false,
-        "translation": "Staerke der Daempfung gegen jede Bewegung des Systems, einschliesslich aeusserer Einfluesse. Reduziert auch das Ueberschwingen."
+        "translation": "Stärke der Dämpfung gegen jede Bewegung des Systems, einschließlich äußerer Einflüsse. Reduziert auch das Überschwingen."
       },
       "pid_0_F": {
         "english": "Helps push P-term based on stick input. Increasing will make response more sharp, but can cause overshoot.",
         "needs_translation": false,
-        "translation": "Hilft, den P-Term basierend auf Knueppelbewegungen zu verstaerken. Erhoehen macht die Reaktion schaerfer, kann aber zu Ueberschwingern fuehren."
+        "translation": "Hilft, den P-Term basierend auf Knüppelbewegungen zu verstärken. Erhöhen macht die Reaktion schärfer, kann aber zu Überschwingern führen."
       },
       "pid_0_I": {
         "english": "How tightly the system holds its position.",
         "needs_translation": false,
-        "translation": "Wie genau das System seine Position haelt."
+        "translation": "Wie genau das System seine Position hält."
       },
       "pid_0_O": {
         "english": "Used to prevent the craft from rolling when using high collective.",
@@ -1690,27 +1690,27 @@
       "pid_0_P": {
         "english": "How tightly the system tracks the desired setpoint.",
         "needs_translation": false,
-        "translation": "Wie genau das System dem gewuenschten Sollwert folgt."
+        "translation": "Wie genau das System dem gewünschten Sollwert folgt."
       },
       "pid_1_B": {
         "english": "Additional boost on the feedforward to make the heli react more to quick stick movements.",
         "needs_translation": false,
-        "translation": "Zusaetzlicher Feedforward-Boost, um das System reaktionsschneller auf schnelle Knueppelbewegungen zu machen."
+        "translation": "Zusätzlicher Feedforward-Boost, um das System reaktionsschneller auf schnelle Knüppelbewegungen zu machen."
       },
       "pid_1_D": {
         "english": "Strength of dampening to any motion on the system, including external influences. Also reduces overshoot.",
         "needs_translation": false,
-        "translation": "Staerke der Daempfung gegen jede Bewegung des Systems, einschliesslich aeusserer Einfluesse. Reduziert auch das Ueberschwingen."
+        "translation": "Stärke der Dämpfung gegen jede Bewegung des Systems, einschließlich äußerer Einflüsse. Reduziert auch das Überschwingen."
       },
       "pid_1_F": {
         "english": "Helps push P-term based on stick input. Increasing will make response more sharp, but can cause overshoot.",
         "needs_translation": false,
-        "translation": "Hilft, den P-Term basierend auf Knueppelbewegungen zu verstaerken. Erhoehen macht die Reaktion schaerfer, kann aber zu Ueberschwingern fuehren."
+        "translation": "Hilft, den P-Term basierend auf Knüppelbewegungen zu verstärken. Erhöhen macht die Reaktion schärfer, kann aber zu Überschwingern führen."
       },
       "pid_1_I": {
         "english": "How tightly the system holds its position.",
         "needs_translation": false,
-        "translation": "Wie genau das System seine Position haelt."
+        "translation": "Wie genau das System seine Position hält."
       },
       "pid_1_O": {
         "english": "Used to prevent the craft from pitching when using high collective.",
@@ -1720,61 +1720,61 @@
       "pid_1_P": {
         "english": "How tightly the system tracks the desired setpoint.",
         "needs_translation": false,
-        "translation": "Wie genau das System dem gewuenschten Sollwert folgt."
+        "translation": "Wie genau das System dem gewünschten Sollwert folgt."
       },
       "pid_2_B": {
         "english": "Additional boost on the feedforward to make the heli react more to quick stick movements.",
         "needs_translation": false,
-        "translation": "Zusaetzlicher Feedforward-Boost, um das System reaktionsschneller auf schnelle Knueppelbewegungen zu machen."
+        "translation": "Zusätzlicher Feedforward-Boost, um das System reaktionsschneller auf schnelle Knüppelbewegungen zu machen."
       },
       "pid_2_D": {
         "english": "Strength of dampening to any motion on the system, including external influences. Also reduces overshoot.",
         "needs_translation": false,
-        "translation": "Staerke der Daempfung gegen jede Bewegung des Systems, einschliesslich aeusserer Einfluesse. Reduziert auch das Ueberschwingen."
+        "translation": "Stärke der Dämpfung gegen jede Bewegung des Systems, einschließlich äußerer Einflüsse. Reduziert auch das Überschwingen."
       },
       "pid_2_F": {
         "english": "Helps push P-term based on stick input. Increasing will make response more sharp, but can cause overshoot.",
         "needs_translation": false,
-        "translation": "Hilft, den P-Term basierend auf Knueppelbewegungen zu verstaerken. Erhoehen macht die Reaktion schaerfer, kann aber zu Ueberschwingern fuehren."
+        "translation": "Hilft, den P-Term basierend auf Knüppelbewegungen zu verstärken. Erhöhen macht die Reaktion schärfer, kann aber zu Überschwingern führen."
       },
       "pid_2_I": {
         "english": "How tightly the system holds its position.",
         "needs_translation": false,
-        "translation": "Wie genau das System seine Position haelt."
+        "translation": "Wie genau das System seine Position hält."
       },
       "pid_2_P": {
         "english": "How tightly the system tracks the desired setpoint.",
         "needs_translation": false,
-        "translation": "Wie genau das System dem gewuenschten Sollwert folgt."
+        "translation": "Wie genau das System dem gewünschten Sollwert folgt."
       }
     },
     "PILOT_CONFIG": {
       "model_param1_value": {
         "english": "Set this to the expected flight time in seconds.  The transmitter will beep when the flight time is reached.",
         "needs_translation": false,
-        "translation": "Setzen Sie die erwartete Flugzeit in Sekunden. Die Fernsteuerung biept sobald die Flugzeit erreicht wurde."
+        "translation": "Setzen Sie die erwartete Flugzeit in Sekunden. Die Fernsteuerung piept sobald die Flugzeit erreicht wurde."
       }
     },
     "RC_CONFIG": {
       "rc_arm_throttle": {
         "english": "Throttle must be at or below this value in microseconds (us) to allow arming. Must be at least 10us lower than minimum throttle.",
         "needs_translation": false,
-        "translation": "Das Gas muss bei diesem Wert oder darunter liegen (in µs), um das Schaerfen zu ermoeglichen. Muss mindestens 10 µs unter dem Mindestgaswert liegen."
+        "translation": "Das Gas muss bei diesem Wert oder darunter liegen (in µs), um das Schärfen zu ermöglichen. Muss mindestens 10 µs unter dem Mindestgaswert liegen."
       },
       "rc_center": {
         "english": "Stick center in microseconds (us).",
         "needs_translation": false,
-        "translation": "Knueppelmittelpunkt in Mikrosekunden (µs)."
+        "translation": "Knüppelmittelpunkt in Mikrosekunden (µs)."
       },
       "rc_deadband": {
         "english": "Deadband for cyclic control in microseconds (us).",
         "needs_translation": false,
-        "translation": "Totzone fuer die zyklische Steuerung in Mikrosekunden (µs)."
+        "translation": "Totzone für die zyklische Steuerung in Mikrosekunden (µs)."
       },
       "rc_deflection": {
         "english": "Stick deflection from center in microseconds (us).",
         "needs_translation": false,
-        "translation": "Knueppelausschlag vom Mittelpunkt in Mikrosekunden (µs)."
+        "translation": "Knüppelausschlag vom Mittelpunkt in Mikrosekunden (µs)."
       },
       "rc_max_throttle": {
         "english": "Maximum throttle (100% throttle output) expected from radio, in microseconds (us).",
@@ -1789,89 +1789,89 @@
       "rc_yaw_deadband": {
         "english": "Deadband for yaw control in microseconds (us).",
         "needs_translation": false,
-        "translation": "Totzone fuer die Giersteuerung in Mikrosekunden (µs)."
+        "translation": "Totzone für die Giersteuerung in Mikrosekunden (µs)."
       }
     },
     "RC_TUNING": {
       "accel_limit_1": {
         "english": "Maximum acceleration of the craft in response to a stick movement.",
         "needs_translation": false,
-        "translation": "Maximale Beschleunigung des Modells als Reaktion auf eine Knueppelbewegung."
+        "translation": "Maximale Beschleunigung des Modells als Reaktion auf eine Knüppelbewegung."
       },
       "accel_limit_2": {
         "english": "Maximum acceleration of the craft in response to a stick movement.",
         "needs_translation": false,
-        "translation": "Maximale Beschleunigung des Modells als Reaktion auf eine Knueppelbewegung."
+        "translation": "Maximale Beschleunigung des Modells als Reaktion auf eine Knüppelbewegung."
       },
       "accel_limit_3": {
         "english": "Maximum acceleration of the craft in response to a stick movement.",
         "needs_translation": false,
-        "translation": "Maximale Beschleunigung des Modells als Reaktion auf eine Knueppelbewegung."
+        "translation": "Maximale Beschleunigung des Modells als Reaktion auf eine Knüppelbewegung."
       },
       "accel_limit_4": {
         "english": "Maximum acceleration of the craft in response to a stick movement.",
         "needs_translation": false,
-        "translation": "Maximale Beschleunigung des Modells als Reaktion auf eine Knueppelbewegung."
+      "translation": "Maximale Beschleunigung des Modells als Reaktion auf eine Knüppelbewegung."
       },
       "response_time_1": {
         "english": "Increase or decrease the response time of the rate to smooth heli movements.",
         "needs_translation": false,
-        "translation": "Erhoeht oder verringert die Reaktionszeit der Rate, um die Heli-Bewegungen zu glaetten."
+        "translation": "Erhöht oder verringert die Reaktionszeit der Rate, um die Heli-Bewegungen zu glätten."
       },
       "response_time_2": {
         "english": "Increase or decrease the response time of the rate to smooth heli movements.",
         "needs_translation": false,
-        "translation": "Erhoeht oder verringert die Reaktionszeit der Rate, um die Heli-Bewegungen zu glaetten."
+        "translation": "Erhöht oder verringert die Reaktionszeit der Rate, um die Heli-Bewegungen zu glätten."
       },
       "response_time_3": {
         "english": "Increase or decrease the response time of the rate to smooth heli movements.",
         "needs_translation": false,
-        "translation": "Erhoeht oder verringert die Reaktionszeit der Rate, um die Heli-Bewegungen zu glaetten."
+      "translation": "Erhöht oder verringert die Reaktionszeit der Rate, um die Heli-Bewegungen zu glätten."
       },
       "response_time_4": {
         "english": "Increase or decrease the response time of the rate to smooth heli movements.",
         "needs_translation": false,
-        "translation": "Erhoeht oder verringert die Reaktionszeit der Rate, um die Heli-Bewegungen zu glaetten."
+      "translation": "Erhöht oder verringert die Reaktionszeit der Rate, um die Heli-Bewegungen zu glätten."
       },
       "setpoint_boost_cutoff_1": {
         "english": "Boost cutoff for the setpoint.",
         "needs_translation": false,
-        "translation": "Boost-Grenzwert fuer den Sollwert."
+        "translation": "Boost-Grenzwert für den Sollwert."
       },
       "setpoint_boost_cutoff_2": {
         "english": "Boost cutoff for the setpoint.",
         "needs_translation": false,
-        "translation": "Boost-Grenzwert fuer den Sollwert."
+      "translation": "Boost-Grenzwert für den Sollwert."
       },
       "setpoint_boost_cutoff_3": {
         "english": "Boost cutoff for the setpoint.",
         "needs_translation": false,
-        "translation": "Boost-Grenzwert fuer den Sollwert."
+      "translation": "Boost-Grenzwert für den Sollwert."
       },
       "setpoint_boost_cutoff_4": {
         "english": "Boost cutoff for the setpoint.",
         "needs_translation": false,
-        "translation": "Boost-Grenzwert fuer den Sollwert."
+      "translation": "Boost-Grenzwert für den Sollwert."
       },
       "setpoint_boost_gain_1": {
         "english": "Boost gain for the setpoint.",
         "needs_translation": false,
-        "translation": "Boost-Verstaerkung fuer den Sollwert."
+        "translation": "Boost-Verstärkung für den Sollwert."
       },
       "setpoint_boost_gain_2": {
         "english": "Boost gain for the setpoint.",
         "needs_translation": false,
-        "translation": "Boost-Verstaerkung fuer den Sollwert."
+      "translation": "Boost-Verstärkung für den Sollwert."
       },
       "setpoint_boost_gain_3": {
         "english": "Boost gain for the setpoint.",
         "needs_translation": false,
-        "translation": "Boost-Verstaerkung fuer den Sollwert."
+      "translation": "Boost-Verstärkung für den Sollwert."
       },
       "setpoint_boost_gain_4": {
         "english": "Boost gain for the setpoint.",
         "needs_translation": false,
-        "translation": "Boost-Verstaerkung fuer den Sollwert."
+      "translation": "Boost-Verstärkung für den Sollwert."
       },
       "yaw_dynamic_ceiling_gain": {
         "english": "The maximum gain applied to the yaw dynamic ceiling.",
@@ -1893,7 +1893,7 @@
       "rescue_climb_collective": {
         "english": "Collective value for rescue climb.",
         "needs_translation": false,
-        "translation": "Kollektivwert fuer den Steigflug waehrend der Rettung."
+      "translation": "Kollektivwert für den Steigflug während der Rettung."
       },
       "rescue_climb_time": {
         "english": "Length of time the climb collective is applied before switching to hover.",
@@ -1903,12 +1903,12 @@
       "rescue_exit_time": {
         "english": "This limits rapid application of negative collective if the helicopter has rolled during rescue.",
         "needs_translation": false,
-        "translation": "Begrenzt die schnelle Anwendung von negativem Kollektiv, falls der Heli sich waehrend der Rettung gedreht hat."
+      "translation": "Begrenzt die schnelle Anwendung von negativem Kollektiv, falls der Heli sich während der Rettung gedreht hat."
       },
       "rescue_flip_gain": {
         "english": "Determine how aggressively the heli flips during inverted rescue.",
         "needs_translation": false,
-        "translation": "Bestimmt, wie aggressiv der Heli waehrend der invertierten Rettung flippt."
+      "translation": "Bestimmt, wie aggressiv der Heli während der invertierten Rettung flippt."
       },
       "rescue_flip_mode": {
         "english": "If rescue is activated while inverted, flip to upright - or remain inverted.",
@@ -1923,32 +1923,32 @@
       "rescue_hover_collective": {
         "english": "Collective value for hover.",
         "needs_translation": false,
-        "translation": "Kollektivwert fuer das Schweben."
+        "translation": "Kollektivwert für das Schweben."
       },
       "rescue_level_gain": {
         "english": "Determine how aggressively the heli levels during rescue.",
         "needs_translation": false,
-        "translation": "Bestimmt, wie aggressiv der Heli sich waehrend der Rettung ausrichtet."
+        "translation": "Bestimmt, wie aggressiv der Heli sich während der Rettung ausrichtet."
       },
       "rescue_max_setpoint_accel": {
         "english": "Limit how fast the helicopter accelerates into a roll/pitch. Larger helicopters may need slower acceleration.",
         "needs_translation": false,
-        "translation": "Begrenzt, wie schnell der Heli in eine Roll-/Nick-Bewegung beschleunigt. Groessere Helis benoetigen moeglicherweise langsamere Beschleunigungswerte."
+        "translation": "Begrenzt, wie schnell der Heli in eine Roll-/Nick-Bewegung beschleunigt. Grössere Helis benötigen möglicherweise langsamere Beschleunigungswerte."
       },
       "rescue_max_setpoint_rate": {
         "english": "Limit rescue roll/pitch rate. Larger helicopters may need slower rotation rates.",
         "needs_translation": false,
-        "translation": "Begrenzt die Roll-/Nick-Rate waehrend der Rettung. Groessere Helis benoetigen moeglicherweise langsamere Drehgeschwindigkeiten."
+        "translation": "Begrenzt die Roll-/Nick-Rate wöhrend der Rettung. Grössere Helis benötigen möglicherweise langsamere Drehgeschwindigkeiten."
       },
       "rescue_pull_up_collective": {
         "english": "Collective value for pull-up climb.",
         "needs_translation": false,
-        "translation": "Kollektivwert fuer das Hochziehen."
+        "translation": "Kollektivwert für das Hochziehen."
       },
       "rescue_pull_up_time": {
         "english": "When rescue is activated, helicopter will apply pull-up collective for this time period before moving to flip or climb stage.",
         "needs_translation": false,
-        "translation": "Wenn die Rettung aktiviert wird, wird fuer diese Dauer kollektives Steigen angewendet, bevor zum Flip- oder Steigstadium uebergegangen wird."
+        "translation": "Wenn die Rettung aktiviert wird, wird für diese Dauer kollektives Steigen angewendet, bevor zum Flip- oder Steigstadium übergegangen wird."
       },
       "tbl_flip": {
         "english": "FLIP",
@@ -1973,6 +1973,16 @@
     }
   },
   "app": {
+    "header_configuration": {
+      "english": "Configuration",
+      "needs_translation": false,
+      "translation": "Konfiguration"
+    },
+    "header_system": {
+      "english": "System",
+      "needs_translation": false,
+      "translation": "System"
+    },
     "btn_cancel": {
       "english": "CANCEL",
       "needs_translation": false,
@@ -1996,7 +2006,7 @@
     "check_bg_task": {
       "english": "Please enable the background task.",
       "needs_translation": false,
-      "translation": "Bitte aktivieren Sie die Background-Task."
+        "translation": "Bitte aktivieren Sie den Hintergrundtask."
     },
     "check_discovered_sensors": {
       "english": "Please check you have discovered all sensors.",
@@ -2006,7 +2016,7 @@
     "check_heli_on": {
       "english": "Please check your heli is powered up and radio connected.",
       "needs_translation": false,
-      "translation": "Bitte ueberpruefen Sie, ob Ihr Heli eingeschaltet und der Empfaenger verbunden ist."
+        "translation": "Bitte überprüfen Sie, ob Ihr Heli eingeschaltet und der Empfänger verbunden ist."
     },
     "check_msp_version": {
       "english": "Unable to determine MSP version in use.",
@@ -2016,22 +2026,22 @@
     "check_rf_module_on": {
       "english": "Please check your rf module is turned on.",
       "needs_translation": false,
-      "translation": "Bitte ueberpruefen Sie, ob Ihr RF-Modul eingeschaltet ist."
+      "translation": "Bitte überprüfen Sie, ob Ihr RF-Modul eingeschaltet ist."
     },
     "check_supported_version": {
       "english": "This version of the Lua script \ncan't be used with the selected model",
       "needs_translation": false,
-      "translation": "Diese Version des Lua-Skripts\nkann nicht mit dem ausgewaehlten Modell verwendet werden."
+        "translation": "Diese Version des Lua-Skripts\nkann nicht mit dem ausgewählten Modell verwendet werden."
     },
     "error_timed_out": {
       "english": "Error: timed out",
       "needs_translation": false,
-      "translation": "Fehler: Zeitueberschreitung"
+        "translation": "Fehler: Zeitüberschreitung"
     },
     "menu_section_about": {
       "english": "About",
       "needs_translation": false,
-      "translation": "Ueber"
+        "translation": "Über"
     },
     "menu_section_advanced": {
       "english": "Advanced",
@@ -2063,7 +2073,7 @@
         "help_p1": {
           "english": "The accelerometer is used to measure the angle of the flight controller in relation to the horizon. This data is used to stabilize the aircraft and provide self-leveling functionality.",
           "needs_translation": false,
-          "translation": "Der Beschleunigungssensor wird verwendet, um den Winkel des Flugcontrollers in Bezug auf den Horizont zu messen. Diese Daten werden zur Stabilisierung des Fluggeraets und zur Bereitstellung der Selbstnivellierungsfunktion verwendet."
+          "translation": "Der Beschleunigungssensor wird verwendet, um den Winkel des Flugcontrollers in Bezug auf den Horizont zu messen. Diese Daten werden zur Stabilisierung des Fluggeräts und zur Bereitstellung der Selbstnivellierungsfunktion verwendet."
         },
         "msg_calibrate": {
           "english": "Calibrate the accelerometer?",
@@ -2100,7 +2110,7 @@
         "help_p2": {
           "english": "Choose the source and destinations and save to copy the profile.",
           "needs_translation": false,
-          "translation": "Waehlen Sie die Quelle und das Ziel aus und speichern Sie, um das Profil zu kopieren."
+          "translation": "Wählen Sie die Quelle und das Ziel aus und speichern Sie, um das Profil zu kopieren."
         },
         "msgbox_msg": {
           "english": "Save current page to flight controller?",
@@ -2154,7 +2164,7 @@
         "consumption_correction": {
           "english": "Consumption Correction",
           "needs_translation": false,
-          "translation": "Verbrauchskorrektur"
+          "translation": "Verbrauchskorrektur anpassen"
         },
         "current_correction": {
           "english": "Current Correction",
@@ -2164,12 +2174,12 @@
         "front": {
           "english": "Front",
           "needs_translation": false,
-          "translation": "Vorne"
+          "translation": "Vorn"
         },
         "half_duplex": {
           "english": "Half Duplex",
-          "needs_translation": true,
-          "translation": "Half Duplex"
+          "needs_translation": false,
+          "translation": "Halbduplex-Modus für ESC-Telemetrie"
         },
         "help_p1": {
           "english": "Configure the motor and speed controller features.",
@@ -2208,8 +2218,8 @@
         },
         "motor_pwm_rate": {
           "english": "Update frequency",
-          "needs_translation": true,
-          "translation": "Update frequency"
+          "needs_translation": false,
+          "translation": "Aktualisierungsrate"
         },
         "name": {
           "english": "ESC/Motors",
@@ -2218,8 +2228,8 @@
         },
         "pin_swap": {
           "english": "Pin Swap",
-          "needs_translation": true,
-          "translation": "Pin Swap"
+          "needs_translation": false,
+          "translation": "Pin-Tausch"
         },
         "pinion": {
           "english": "Pinion",
@@ -2233,13 +2243,13 @@
         },
         "rpm": {
           "english": "RPM",
-          "needs_translation": true,
+          "needs_translation": false,
           "translation": "RPM"
         },
         "rpm_sensor_source": {
           "english": "RPM Sensor",
-          "needs_translation": true,
-          "translation": "RPM Sensor"
+          "needs_translation": false,
+          "translation": "RPM-Sensor"
         },
         "tail_motor_ratio": {
           "english": "Tail Motor Ratio",
@@ -2248,38 +2258,38 @@
         },
         "telemetry": {
           "english": "Telemetry",
-          "needs_translation": true,
-          "translation": "Telemetry"
+          "needs_translation": false,
+          "translation": "Telemetrie"
         },
         "telemetry_protocol": {
           "english": "Telemetry Protocol",
-          "needs_translation": true,
-          "translation": "Telemetry Protocol"
+          "needs_translation": false,
+          "translation": "Telemetrieprotokoll"
         },
         "throttle": {
           "english": "Throttle",
-          "needs_translation": true,
-          "translation": "Throttle"
+          "needs_translation": false,
+          "translation": "Gas"
         },
         "throttle_protocol": {
           "english": "Throttle Protocol",
-          "needs_translation": true,
-          "translation": "Throttle Protocol"
+          "needs_translation": false,
+          "translation": "Gasprotokoll"
         },
         "unsynced": {
           "english": "Unsynced ESC Update",
-          "needs_translation": true,
-          "translation": "Unsynced ESC Update"
+          "needs_translation": false,
+          "translation": "Asynchrone ESC-Aktualisierung"
         },
         "use_dshot_telemetry": {
           "english": "DShot RPM Telemetry",
-          "needs_translation": true,
-          "translation": "DShot RPM Telemetry"
+          "needs_translation": false,
+          "translation": "DShot RPM-Telemetrie"
         },
         "voltage_correction": {
           "english": "Voltage Correction",
           "needs_translation": false,
-          "translation": "Spannungskorrektur"
+          "translation": "Spannungskorrektur anpassen"
         }
       },
       "esc_tools": {
@@ -2287,7 +2297,7 @@
           "flrtr": {
             "active_freewheel": {
               "english": "Active Freewheeling",
-              "needs_translation": true,
+              "needs_translation": false,
               "translation": "Active Freewheeling"
             },
             "advanced": {
@@ -2297,7 +2307,7 @@
             },
             "auto_restart_time": {
               "english": "Auto Bailout Time",
-              "needs_translation": true,
+              "needs_translation": false,
               "translation": "Auto restart time"
             },
             "basic": {
@@ -2308,7 +2318,7 @@
             "battery_capacity": {
               "english": "Capacity Limit",
               "needs_translation": false,
-              "translation": "Batteriekapazitaet"
+              "translation": "Batteriekapazität"
             },
             "bec_voltage": {
               "english": "SBEC Voltage",
@@ -2318,7 +2328,7 @@
             "buzzer_volume": {
               "english": "Beeper Volume",
               "needs_translation": false,
-              "translation": "Summerlautstaerke"
+              "translation": "Summerlautstärke"
             },
             "cell_count": {
               "english": "LiPo Cell Count",
@@ -2328,27 +2338,27 @@
             "current_gain": {
               "english": "Current Gain",
               "needs_translation": false,
-              "translation": "Stromverstaerkung"
+              "translation": "Verstärkungswert für den Stromsensor"
             },
             "drive_freq": {
               "english": "Drive Frequency",
               "needs_translation": false,
-              "translation": "Drive frequency"
+              "translation": "PWM drive frequency"
             },
             "electrical_angle": {
               "english": "Electrical Angle",
               "needs_translation": false,
-              "translation": "Timing-Winkel"
+              "translation": "Timing-Winkel für den Motor"
             },
             "esc_mode": {
               "english": "ESC Mode",
-              "needs_translation": true,
-              "translation": "ESC Mode"
+              "needs_translation": false,
+              "translation": "ESC-Modus"
             },
             "fan_control": {
               "english": "Cooling Fan Mode",
               "needs_translation": false,
-              "translation": "Lueftersteuerung"
+              "translation": "Lüftersteuerung"
             },
             "gov": {
               "english": "Governor",
@@ -2358,12 +2368,12 @@
             "gov_i": {
               "english": "Governor I",
               "needs_translation": false,
-              "translation": "Gov-I"
+              "translation": "Integralwert für den Governor"
             },
             "gov_p": {
               "english": "Governor P",
               "needs_translation": false,
-              "translation": "Gov-P"
+              "translation": "Proportionalwert für den Governor"
             },
             "governor": {
               "english": "Governor",
@@ -2378,17 +2388,17 @@
             "low_voltage_protection": {
               "english": "Low Voltage Limit",
               "needs_translation": false,
-              "translation": "Unterspannungsschutz"
+              "translation": "Spannung, bei der die Leistung reduziert wird"
             },
             "motor_direction": {
               "english": "Motor Direction",
               "needs_translation": false,
-              "translation": "Motordrehrichtung"
+              "translation": "Motordrehrichtung (CCW/CW)"
             },
             "motor_erpm_max": {
               "english": "Maximum Motor ERPM",
               "needs_translation": false,
-              "translation": "Max. Motor-ERPM"
+              "translation": "Maximale RPM"
             },
             "motor_temp": {
               "english": "Motor Temperture Limit",
@@ -2505,12 +2515,12 @@
             "gov_i_gain": {
               "english": "I-Gain",
               "needs_translation": false,
-              "translation": "I-Verst."
+              "translation": "I-Verstärkung"
             },
             "gov_p_gain": {
               "english": "P-Gain",
               "needs_translation": false,
-              "translation": "P-Verst."
+              "translation": "P-Verstärkung"
             },
             "governor": {
               "english": "Governor",
@@ -2550,7 +2560,7 @@
             "rotation": {
               "english": "Rotation",
               "needs_translation": false,
-              "translation": "Drehrichtung"
+              "translation": "Drehrichtung (CCW/CW)"
             },
             "soft_start": {
               "english": "Soft Start",
@@ -2607,7 +2617,7 @@
             "capacity_correction": {
               "english": "Capacity Correction",
               "needs_translation": false,
-              "translation": "Kapazitaetskorrektur"
+              "translation": "Kapazitätskorrektur"
             },
             "cell_cutoff": {
               "english": "Cell Cutoff",
@@ -2622,12 +2632,12 @@
             "gov_i": {
               "english": "Gov-I",
               "needs_translation": false,
-              "translation": "Gov-I"
+              "translation": "Gov-I-Verstärkung"
             },
             "gov_p": {
               "english": "Gov-P",
               "needs_translation": false,
-              "translation": "Gov-P"
+              "translation": "Gov-P-Verstärkung"
             },
             "governor": {
               "english": "Governor",
@@ -2652,7 +2662,7 @@
             "motor_direction": {
               "english": "Motor Direction",
               "needs_translation": false,
-              "translation": "Motordrehrichtung"
+              "translation": "Motordrehrichtung (CCW/CW)"
             },
             "motor_poles": {
               "english": "Motor Poles",
@@ -2667,7 +2677,7 @@
             "smart_fan": {
               "english": "Smart Fan",
               "needs_translation": false,
-              "translation": "Intelligenter Luefter"
+              "translation": "Intelligenter Lüfter"
             },
             "sr_function": {
               "english": "SR Function",
@@ -2719,17 +2729,17 @@
             "extra_msg_save": {
               "english": "Please reboot the ESC to apply the changes",
               "needs_translation": false,
-              "translation": "Bitte starten Sie den ESC neu, um die Aenderungen zu uebernehmen"
+              "translation": "Bitte starten Sie den ESC neu, um die Änderungen zu übernehmen"
             },
             "gov_integral": {
               "english": "Gov Integral",
               "needs_translation": false,
-              "translation": "Gov Integral"
+              "translation": "Gov Integral-Verstärkung"
             },
             "gov_proportional": {
               "english": "Gov Proportional",
               "needs_translation": false,
-              "translation": "Gov Proportional"
+              "translation": "Gov Proportional-Verstärkung"
             },
             "limits": {
               "english": "Limits",
@@ -2769,12 +2779,12 @@
             "protection_delay": {
               "english": "Protection Delay",
               "needs_translation": false,
-              "translation": "Schutzverzoegerung"
+              "translation": "Schutzverzögerung"
             },
             "rotation": {
               "english": "Rotation",
               "needs_translation": false,
-              "translation": "Drehrichtung"
+              "translation": "Drehrichtung (CCW/CW)"
             },
             "runup_time": {
               "english": "Runup Time",
@@ -2789,7 +2799,7 @@
             "telemetry_protocol": {
               "english": "Telemetry Protocol",
               "needs_translation": false,
-              "translation": "Telemetrieprotokoll"
+              "translation": "Telemetrie Protokoll"
             }
           },
           "xdfly": {
@@ -2821,7 +2831,7 @@
             "capacity_correction": {
               "english": "Capacity Correction",
               "needs_translation": false,
-              "translation": "Kapazitaetskorrektur"
+              "translation": "Kapazitätskorrektur"
             },
             "cell_cutoff": {
               "english": "Cell Cutoff",
@@ -2836,12 +2846,12 @@
             "gov_i": {
               "english": "Gov-I",
               "needs_translation": false,
-              "translation": "Gov-I"
+              "translation": "Gov-I-Verstärkung"
             },
             "gov_p": {
               "english": "Gov-P",
               "needs_translation": false,
-              "translation": "Gov-P"
+              "translation": "Gov-P-Verstärkung"
             },
             "governor": {
               "english": "Governor",
@@ -2866,12 +2876,12 @@
             "motor_direction": {
               "english": "Motor Direction",
               "needs_translation": false,
-              "translation": "Motordrehrichtung"
+              "translation": "Motordrehrichtung (CCW/CW)"
             },
             "motor_poles": {
               "english": "Motor Poles",
               "needs_translation": false,
-              "translation": "Motorpole"
+              "translation": "Motor Pole"
             },
             "name": {
               "english": "XDFLY",
@@ -2881,7 +2891,7 @@
             "smart_fan": {
               "english": "Smart Fan",
               "needs_translation": false,
-              "translation": "Intelligenter Luefter"
+              "translation": "Intelligenter Lüfter"
             },
             "sr_function": {
               "english": "SR Function",
@@ -2933,7 +2943,7 @@
             "direction": {
               "english": "Direction",
               "needs_translation": false,
-              "translation": "Richtung"
+              "translation": "Drehrichtung (CCW/CW)"
             },
             "esc": {
               "english": "ESC",
@@ -2953,12 +2963,12 @@
             "gov_i": {
               "english": "Gov-I",
               "needs_translation": false,
-              "translation": "Gov-I"
+              "translation": "Gov-I-Verstärkung"
             },
             "gov_p": {
               "english": "Gov-P",
               "needs_translation": false,
-              "translation": "Gov-P"
+              "translation": "Gov-P-Verstärkung"
             },
             "limits": {
               "english": "Limits",
@@ -2968,12 +2978,12 @@
             "lv_bec_voltage": {
               "english": "BEC",
               "needs_translation": false,
-              "translation": "BEC"
+              "translation": "BEC Spannung"
             },
             "main_teeth": {
               "english": "Main Teeth",
               "needs_translation": false,
-              "translation": "Hauptzahnrad-Zaehne"
+              "translation": "Hauptzahnrad-Zähne"
             },
             "max_start_power": {
               "english": "Max Start Power",
@@ -2988,7 +2998,7 @@
             "motor_pole_pairs": {
               "english": "Motor Pole Pairs",
               "needs_translation": false,
-              "translation": "Motor-Polpaare"
+              "translation": "Motor Polpaare"
             },
             "name": {
               "english": "YGE",
@@ -3003,7 +3013,7 @@
             "pinion_teeth": {
               "english": "Pinion Teeth",
               "needs_translation": false,
-              "translation": "Ritzel-Zaehne"
+              "translation": "Ritzel-Zähne"
             },
             "stick_range_us": {
               "english": "Stick Range",
@@ -3029,107 +3039,107 @@
           "ztw": {
             "acceleration": {
               "english": "Acceleration",
-              "needs_translation": true,
-              "translation": "Acceleration"
+              "needs_translation": false,
+              "translation": "Beschleunigung"
             },
             "advanced": {
               "english": "Advanced",
-              "needs_translation": true,
-              "translation": "Advanced"
+              "needs_translation": false,
+              "translation": "Erweitert"
             },
             "auto_restart_time": {
               "english": "Auto Restart Time",
-              "needs_translation": true,
-              "translation": "Auto Restart Time"
+              "needs_translation": false,
+              "translation": "Neustartzeit"
             },
             "basic": {
               "english": "Basic",
-              "needs_translation": true,
-              "translation": "Basic"
+              "needs_translation": false,
+              "translation": "Grundlegend"
             },
             "brake_force": {
               "english": "Brake Force",
-              "needs_translation": true,
-              "translation": "Brake Force"
+              "needs_translation": false,
+              "translation": "Bremskraft"
             },
             "capacity_correction": {
               "english": "Capacity Correction",
-              "needs_translation": true,
-              "translation": "Capacity Correction"
+              "needs_translation": false,
+              "translation": "Kapazitätskorrektur"
             },
             "cell_cutoff": {
               "english": "Cell Cutoff",
-              "needs_translation": true,
-              "translation": "Cell Cutoff"
+              "needs_translation": false,
+              "translation": "Zellenabschaltung"
             },
             "gov": {
               "english": "Governor",
-              "needs_translation": true,
+              "needs_translation": false,
               "translation": "Governor"
             },
             "gov_i": {
               "english": "Gov-I",
-              "needs_translation": true,
-              "translation": "Gov-I"
+              "needs_translation": false,
+              "translation": "Gov-I-Verstärkung"
             },
             "gov_p": {
               "english": "Gov-P",
-              "needs_translation": true,
-              "translation": "Gov-P"
+              "needs_translation": false,
+              "translation": "Gov-P-Verstärkung"
             },
             "governor": {
               "english": "Governor",
-              "needs_translation": true,
+              "needs_translation": false,
               "translation": "Governor"
             },
             "hv_bec_voltage": {
               "english": "HV BEC Voltage",
-              "needs_translation": true,
-              "translation": "HV BEC Voltage"
+              "needs_translation": false,
+              "translation": "HV BEC-Spannung"
             },
             "led_color": {
               "english": "LED Color",
-              "needs_translation": true,
-              "translation": "LED Color"
+              "needs_translation": false,
+              "translation": "LED-Farbe"
             },
             "lv_bec_voltage": {
               "english": "LV BEC Voltage",
-              "needs_translation": true,
-              "translation": "LV BEC Voltage"
+              "needs_translation": false,
+              "translation": "LV BEC-Spannung"
             },
             "motor_direction": {
               "english": "Motor Direction",
-              "needs_translation": true,
-              "translation": "Motor Direction"
+              "needs_translation": false,
+              "translation": "Motordrehrichtung (CCW/CW)"
             },
             "motor_poles": {
               "english": "Motor Poles",
-              "needs_translation": true,
-              "translation": "Motor Poles"
+              "needs_translation": false,
+              "translation": "Motorpole"
             },
             "name": {
               "english": "ZTW",
-              "needs_translation": true,
+              "needs_translation": false,
               "translation": "ZTW"
             },
             "smart_fan": {
               "english": "Smart Fan",
-              "needs_translation": true,
-              "translation": "Smart Fan"
+              "needs_translation": false,
+              "translation": "Intelligenter Lüfter"
             },
             "sr_function": {
               "english": "SR Function",
-              "needs_translation": true,
-              "translation": "SR Function"
+              "needs_translation": false,
+              "translation": "SR-Funktion"
             },
             "startup_power": {
               "english": "Startup Power",
-              "needs_translation": true,
-              "translation": "Startup Power"
+              "needs_translation": false,
+              "translation": "Anlaufleistung"
             },
             "timing": {
               "english": "Timing",
-              "needs_translation": true,
+              "needs_translation": false,
               "translation": "Timing"
             }
           }
@@ -3147,7 +3157,7 @@
         "searching": {
           "english": "Searching",
           "needs_translation": false,
-          "translation": "Suche"
+          "translation": "Suche..."
         },
         "unknown": {
           "english": "UNKNOWN",
@@ -3189,7 +3199,7 @@
         "arming_disable_flag_14": {
           "english": "CMS Menu",
           "needs_translation": false,
-          "translation": "CMS-Menue"
+          "translation": "CMS-Menü"
         },
         "arming_disable_flag_15": {
           "english": "BST",
@@ -3304,42 +3314,42 @@
         "erase": {
           "english": "Erase",
           "needs_translation": false,
-          "translation": "Loeschen"
+          "translation": "Löschen"
         },
         "erase_prompt": {
           "english": "Would you like to erase the dataflash?",
           "needs_translation": false,
-          "translation": "Moechten Sie den Datenspeicher loeschen?"
+          "translation": "Möchten Sie den Datenspeicher löschen?"
         },
         "erasing": {
           "english": "Erasing",
           "needs_translation": false,
-          "translation": "Loeschen"
+          "translation": "Löschen"
         },
         "erasing_dataflash": {
           "english": "Erasing dataflash...",
           "needs_translation": false,
-          "translation": "Datenspeicher wird geloescht..."
+          "translation": "Datenspeicher wird gelöscht..."
         },
         "fbl_date": {
           "english": "Date",
-          "needs_translation": true,
-          "translation": "Date"
+          "needs_translation": false,
+          "translation": "Datum"
         },
         "fbl_time": {
           "english": "Time",
-          "needs_translation": true,
-          "translation": "Time"
+          "needs_translation": false,
+          "translation": "Zeit"
         },
         "help_p1": {
           "english": "Use this page to view your current flight controller status. This can be useful when determining why your heli will not arm.",
           "needs_translation": false,
-          "translation": "Auf dieser Seite koennen Sie den aktuellen Status Ihres Flugcontrollers anzeigen. Dies kann hilfreich sein, um herauszufinden, warum Ihr Heli nicht schaerft."
+          "translation": "Auf dieser Seite können Sie den aktuellen Status Ihres Flugcontrollers anzeigen. Dies kann hilfreich sein, um herauszufinden, warum Ihr Heli nicht schärft."
         },
         "help_p2": {
           "english": "To erase the dataflash for more log file storage, press the button on the menu denoted by a '*'.",
           "needs_translation": false,
-          "translation": "Um den Dataflash fuer mehr Speicherplatz fuer Log-Dateien zu loeschen, druecken Sie die mit '*' markierte Schaltflaeche im Menue."
+          "translation": "Um den Dataflash für mehr Speicherplatz für Log-Dateien zu löschen, drücken Sie die mit '*' markierte Schaltfläche im Menü."
         },
         "megabyte": {
           "english": "MB",
@@ -3364,144 +3374,144 @@
         "unsupported": {
           "english": "Unsupported",
           "needs_translation": false,
-          "translation": "Nicht unterstuetzt"
+          "translation": "Nicht unterstützt"
         }
       },
       "fbusout": {
         "cancel": {
           "english": "CANCEL",
-          "needs_translation": true,
-          "translation": "CANCEL"
+          "needs_translation": false,
+          "translation": "ABBRECHEN"
         },
         "ch_prefix": {
           "english": "CH",
-          "needs_translation": true,
+          "needs_translation": false,
           "translation": "CH"
         },
         "channel_page": {
           "english": "Fbus out / CH",
-          "needs_translation": true,
-          "translation": "Fbus out / CH"
+          "needs_translation": false,
+          "translation": "Fbus Ausgang / CH"
         },
         "channel_prefix": {
           "english": "CHANNEL ",
-          "needs_translation": true,
-          "translation": "CHANNEL "
+          "needs_translation": false,
+          "translation": "KANAL "
         },
         "help_default_p1": {
           "english": "Configure advanced mixing and channel mapping if you have SBUS Out enabled on a serial port.",
-          "needs_translation": true,
-          "translation": "Configure advanced mixing and channel mapping if you have SBUS Out enabled on a serial port."
+          "needs_translation": false,
+          "translation": "Erweiterte Misch- und Kanalzuordnung konfigurieren, wenn FBUS-Ausgang auf einem seriellen Port aktiviert ist."
         },
         "help_default_p2": {
           "english": "- For RX channels or servos (wideband), use 1000, 2000 or 500,1000 for narrow band servos.",
-          "needs_translation": true,
-          "translation": "- For RX channels or servos (wideband), use 1000, 2000 or 500,1000 for narrow band servos."
+          "needs_translation": false,
+          "translation": "- Für RX-Kanäle oder Servos (Breitband) 1000, 2000 oder 500,1000 für Schmalband-Servos verwenden."
         },
         "help_default_p3": {
           "english": "- For mixer rules, use -1000, 1000.",
-          "needs_translation": true,
-          "translation": "- For mixer rules, use -1000, 1000."
+          "needs_translation": false,
+          "translation": "- Für Mischregeln -1000, 1000 verwenden."
         },
         "help_default_p4": {
           "english": "- For motors, use 0, 1000.",
-          "needs_translation": true,
-          "translation": "- For motors, use 0, 1000."
+          "needs_translation": false,
+          "translation": "- Für Motoren 0, 1000 verwenden."
         },
         "help_default_p5": {
           "english": "- Or you can customize your own mapping.",
-          "needs_translation": true,
-          "translation": "- Or you can customize your own mapping."
+          "needs_translation": false,
+          "translation": "- Oder Sie können Ihre eigene Zuordnung anpassen."
         },
         "help_fields_max": {
           "english": "The maximum pwm value to send",
-          "needs_translation": true,
-          "translation": "The maximum pwm value to send"
+          "needs_translation": false,
+          "translation": "Der maximale PWM-Wert, der gesendet wird."
         },
         "help_fields_min": {
           "english": "The minimum pwm value to send.",
-          "needs_translation": true,
-          "translation": "The minimum pwm value to send."
+          "needs_translation": false,
+          "translation": "Der minimale PWM-Wert, der gesendet wird."
         },
         "help_fields_source": {
           "english": "Source id for the mix, counting from 0-15.",
-          "needs_translation": true,
-          "translation": "Source id for the mix, counting from 0-15."
+          "needs_translation": false,
+          "translation": "Quellen-ID für den Mix, zählt von 0-15."
         },
         "max": {
           "english": "Max",
-          "needs_translation": true,
+          "needs_translation": false,
           "translation": "Max"
         },
         "min": {
           "english": "Min",
-          "needs_translation": true,
+          "needs_translation": false,
           "translation": "Min"
         },
         "mixer": {
           "english": "Mixer",
-          "needs_translation": true,
-          "translation": "Mixer"
+          "needs_translation": false,
+          "translation": "Mischer"
         },
         "motor": {
           "english": "Motor",
-          "needs_translation": true,
+          "needs_translation": false,
           "translation": "Motor"
         },
         "name": {
           "english": "FBUS Out",
-          "needs_translation": true,
-          "translation": "FBUS Out"
+          "needs_translation": false,
+          "translation": "FBUS-Ausgang"
         },
         "ok": {
           "english": "OK",
-          "needs_translation": true,
+          "needs_translation": false,
           "translation": "OK"
         },
         "receiver": {
           "english": "Receiver",
-          "needs_translation": true,
-          "translation": "Receiver"
+          "needs_translation": false,
+          "translation": "Empfänger"
         },
         "save_prompt": {
           "english": "Save current page to flight controller?",
-          "needs_translation": true,
-          "translation": "Save current page to flight controller?"
+          "needs_translation": false,
+          "translation": "Aktuelle Seite zum Flugcontroller speichern?"
         },
         "save_settings": {
           "english": "Save settings",
-          "needs_translation": true,
-          "translation": "Save settings"
+          "needs_translation": false,
+          "translation": "Einstellungen speichern"
         },
         "saving": {
           "english": "Saving",
-          "needs_translation": true,
-          "translation": "Saving"
+          "needs_translation": false,
+          "translation": "Speichern"
         },
         "saving_data": {
           "english": "Saving data...",
-          "needs_translation": true,
-          "translation": "Saving data..."
+          "needs_translation": false,
+          "translation": "Speichere Daten..."
         },
         "servo": {
           "english": "Servo",
-          "needs_translation": true,
+          "needs_translation": false,
           "translation": "Servo"
         },
         "source": {
           "english": "Source",
-          "needs_translation": true,
-          "translation": "Source"
+          "needs_translation": false,
+          "translation": "Quelle"
         },
         "title": {
           "english": "FBUS Output",
-          "needs_translation": true,
+          "needs_translation": false,
           "translation": "FBUS Output"
         },
         "type": {
           "english": "Type",
-          "needs_translation": true,
-          "translation": "Type"
+          "needs_translation": false,
+          "translation": "Typ"
         }
       },
       "filters": {
@@ -3528,12 +3538,12 @@
         "help_p1": {
           "english": "Typically you would not edit this page without checking your Blackbox logs!",
           "needs_translation": false,
-          "translation": "Normalerweise sollten Sie diese Seite nicht bearbeiten, ohne Ihre Blackbox-Logs zu ueberpruefen!"
+          "translation": "Normalerweise sollten Sie diese Seite nicht bearbeiten, ohne Ihre Blackbox-Logs zu überprüfen!"
         },
         "help_p2": {
           "english": "Gyro lowpass: Lowpass filters for the gyro signal. Typically left at default.",
           "needs_translation": false,
-          "translation": "Gyro-Tiefpass: Tiefpassfilter fuer das Gyro-Signal. In der Regel auf Standard belassen."
+          "translation": "Gyro-Tiefpass: Tiefpassfilter für das Gyro-Signal. In der Regel auf Standard belassen."
         },
         "help_p3": {
           "english": "Gyro notch filters: Use for filtering specific frequency ranges. Typically not needed in most helis.",
@@ -3624,8 +3634,8 @@
       "governor": {
         "auto_timeout": {
           "english": "Autorotation Timeout",
-          "needs_translation": true,
-          "translation": "Autorotation Timeout"
+          "needs_translation": false,
+          "translation": "Autorotations-Timeout"
         },
         "collective": {
           "english": "Collective",
@@ -3660,32 +3670,32 @@
         "handover_throttle": {
           "english": "Handover throttle%",
           "needs_translation": false,
-          "translation": "Uebergabe-Gas%"
+          "translation": "Übergabe-Gas%"
         },
         "help_p1": {
           "english": "These parameters apply globally to the governor regardless of the profile in use.",
           "needs_translation": false,
-          "translation": "Diese Parameter gelten global fuer den Drehzahlreger (Governor), unabhaengig vom verwendeten Profil."
+          "translation": "Diese Parameter gelten global für den Drehzahlregler (Governor), unabhängig vom verwendeten Profil."
         },
         "help_p2": {
           "english": "Each parameter is simply a time value in seconds for each governor action.",
           "needs_translation": false,
-          "translation": "Jeder Parameter ist einfach ein Zeitwert in Sekunden fuer jede Regleraktion."
+          "translation": "Jeder Parameter ist einfach ein Zeitwert in Sekunden für jede Regleraktion."
         },
         "idle_collective": {
           "english": "Col->Idle Throttle",
           "needs_translation": false,
-          "translation": "Kollektiv-Leerlauf"
+          "translation": "Kollektiv->Leerlauf"
         },
         "menu_curves": {
           "english": "Bypass Curve",
-          "needs_translation": true,
-          "translation": "Curves"
+          "needs_translation": false,
+          "translation": "Bypass-Kurve"
         },
         "menu_curves_long": {
           "english": "Governor Bypass Curve",
-          "needs_translation": true,
-          "translation": "Governor Bypass Curve"
+          "needs_translation": false,
+          "translation": "Governor-Bypass-Kurve"
         },
         "menu_filters": {
           "english": "Filters",
@@ -3705,7 +3715,7 @@
         "menu_time": {
           "english": "Ramp Time",
           "needs_translation": false,
-          "translation": "Rampezeit"
+          "translation": "Rampenzeit"
         },
         "mode": {
           "english": "Mode",
@@ -3720,7 +3730,7 @@
         "ramp_time": {
           "english": "Ramp time",
           "needs_translation": false,
-          "translation": "Rampezeit"
+          "translation": "Rampenzeit"
         },
         "recovery_time": {
           "english": "Recovery time",
@@ -3760,12 +3770,12 @@
         "tracking_time": {
           "english": "Tracking time",
           "needs_translation": false,
-          "translation": "Tracking-Zeit"
+          "translation": "Drehzahländerungen"
         },
         "wot_collective": {
           "english": "Col->Full Throttle",
           "needs_translation": false,
-          "translation": "Kollektiv-Vollgas"
+          "translation": "Kollektiv->Vollgas"
         }
       },
       "info": {
@@ -3819,12 +3829,12 @@
         "help_logs_p1": {
           "english": "Please select a log file from the list below.",
           "needs_translation": false,
-          "translation": "Bitte waehlen Sie eine Log-Datei aus der untenstehenden Liste aus."
+          "translation": "Bitte wählen Sie eine Log-Datei aus der untenstehenden Liste aus."
         },
         "help_logs_p2": {
           "english": "Note. To enable logging it is essential for you to have the following sensors enabled.",
           "needs_translation": false,
-          "translation": "Hinweis: Um das Logging zu aktivieren, muessen Sie die folgenden Sensoren aktiviert haben."
+          "translation": "Hinweis: Um das Logging zu aktivieren, müssen Sie die folgenden Sensoren aktiviert haben."
         },
         "help_logs_p3": {
           "english": "- arm status, voltage, headspeed, current, esc temperature",
@@ -3855,18 +3865,18 @@
         },
         "collective_calibration": {
           "english": "Collective Calibration",
-          "needs_translation": true,
-          "translation": "Collective Calibration"
+          "needs_translation": false,
+          "translation": "Kollektiv-Kalibrierung"
         },
         "collective_direction": {
           "english": "Collective Direction",
           "needs_translation": false,
-          "translation": "Collective Direction"
+          "translation": "Kollektiv-Richtung"
         },
         "collective_pitch_limit": {
           "english": "Collective Pitch Limit",
-          "needs_translation": true,
-          "translation": "Collective Pitch Limit"
+          "needs_translation": false,
+          "translation": "Kollektiv-Pitch-Limit"
         },
         "collective_tilt_correction": {
           "english": "Collective Tilt Correction",
@@ -3875,38 +3885,38 @@
         },
         "collective_tilt_correction_neg": {
           "english": "Collective Tilt Correction -",
-          "needs_translation": true,
-          "translation": "Collective Tilt Correction -"
+          "needs_translation": false,
+          "translation": "Kollektiv-Neigungskorrektur -"
         },
         "collective_tilt_correction_pos": {
           "english": "Collective Tilt Correction +",
-          "needs_translation": true,
-          "translation": "Collective Tilt Correction +"
+          "needs_translation": false,
+          "translation": "Kollektiv-Neigungskorrektur +"
         },
         "configuration": {
           "english": "Configuration",
-          "needs_translation": true,
-          "translation": "Configuration"
+          "needs_translation": false,
+          "translation": "Konfiguration"
         },
         "cyclic_calibration": {
           "english": "Cyclic Calibration",
-          "needs_translation": true,
-          "translation": "Cyclic Calibration"
+          "needs_translation": false,
+          "translation": "Zyklische Kalibrierung"
         },
         "cyclic_pitch_limit": {
           "english": "Cyclic Pitch Limit",
-          "needs_translation": true,
-          "translation": "Cyclic Pitch Limit"
+          "needs_translation": false,
+          "translation": "Zyklisches Pitch-Limit"
         },
         "directions": {
           "english": "Mix Directions",
-          "needs_translation": true,
-          "translation": "Mix Directions"
+          "needs_translation": false,
+          "translation": "Mischrichtungen"
         },
         "elevator_direction": {
           "english": "Elevator Direction",
           "needs_translation": false,
-          "translation": "Elevator Direction"
+          "translation": "Höhenruder-Richtung"
         },
         "geo_correction": {
           "english": "Geo Correction",
@@ -3915,8 +3925,8 @@
         },
         "geometry": {
           "english": "Geometry",
-          "needs_translation": true,
-          "translation": "Geometry"
+          "needs_translation": false,
+          "translation": "Geometrie"
         },
         "help_p1": {
           "english": "Adust swash plate geometry, phase angles, and limits.",
@@ -3925,8 +3935,8 @@
         },
         "main_rotor_dir": {
           "english": "Rotor Direction",
-          "needs_translation": true,
-          "translation": "Rotor Direction"
+          "needs_translation": false,
+          "translation": "Rotor-Drehrichtung"
         },
         "name": {
           "english": "Mixer",
@@ -3935,13 +3945,13 @@
         },
         "settings": {
           "english": "Settings",
-          "needs_translation": true,
-          "translation": "Settings"
+          "needs_translation": false,
+          "translation": "Einstellungen"
         },
         "swash": {
           "english": "Swash",
-          "needs_translation": true,
-          "translation": "Swash"
+          "needs_translation": false,
+          "translation": "Taumelscheibe"
         },
         "swash_phase": {
           "english": "Phase Angle",
@@ -3960,18 +3970,18 @@
         },
         "swash_type": {
           "english": "Swash Type",
-          "needs_translation": true,
-          "translation": "Swash Type"
+          "needs_translation": false,
+          "translation": "Taumelscheibentyp"
         },
         "tail": {
           "english": "Tail",
-          "needs_translation": true,
-          "translation": "Tail"
+          "needs_translation": false,
+          "translation": "Heck"
         },
         "tail_center_offset": {
           "english": "Tail Center Offset",
-          "needs_translation": true,
-          "translation": "Tail Center Offset"
+          "needs_translation": false,
+          "translation": "Heck-Mittenversatz"
         },
         "tail_motor_idle": {
           "english": "Tail Idle Thr%",
@@ -3980,50 +3990,50 @@
         },
         "tail_rotor_mode": {
           "english": "Tail Mode",
-          "needs_translation": true,
-          "translation": "Tail Mode"
+          "needs_translation": false,
+          "translation": "Heck-Modus"
         },
         "trims": {
           "english": "Trims",
-          "needs_translation": true,
-          "translation": "Trims"
+          "needs_translation": false,
+          "translation": "Trimmungen"
         },
         "yaw_calibration": {
           "english": "Yaw Calibration",
-          "needs_translation": true,
-          "translation": "Yaw Calibration"
+          "needs_translation": false,
+          "translation": "Gier-Kalibrierung"
         },
         "yaw_ccw_limit": {
           "english": "Yaw CCW Limit",
-          "needs_translation": true,
-          "translation": "Yaw CCW Limit"
+          "needs_translation": false,
+          "translation": "Gier CCW-Limit"
         },
         "yaw_center_trim": {
           "english": "Yaw Center Trim",
-          "needs_translation": true,
-          "translation": "Yaw Center Trim"
+          "needs_translation": false,
+          "translation": "Gier-Mitten-Trimmung"
         },
         "yaw_cw_limit": {
           "english": "Yaw CW Limit",
-          "needs_translation": true,
-          "translation": "Yaw CW Limit"
+          "needs_translation": false,
+          "translation": "Gier CW-Limit"
         },
         "yaw_direction": {
           "english": "Yaw Direction",
           "needs_translation": false,
-          "translation": "Yaw Direction"
+          "translation": "Gier-Richtung"
         }
       },
       "msp_exp": {
         "help_p1": {
           "english": "This tool provides the ability to send a custom byte string to the flight controller. It is useful for developers when debugging values.",
           "needs_translation": false,
-          "translation": "Dieses Tool ermoeglicht das Senden einer benutzerdefinierten Byte-Zeichenfolge an den Flugcontroller. Es ist nuetzlich fuer Entwickler beim Debuggen von Werten."
+          "translation": "Dieses Tool ermöglicht das Senden einer benutzerdefinierten Byte-Zeichenfolge an den Flugcontroller. Es ist nützlich für Entwickler beim Debuggen von Werten."
         },
         "help_p2": {
           "english": "If you do not understand what you are doing, do not use it as bad things can happen.",
           "needs_translation": false,
-          "translation": "Wenn Sie nicht verstehen, was Sie tun, verwenden Sie es nicht, da dies zu Problemen fuehren kann."
+          "translation": "Wenn Sie nicht verstehen, was Sie tun, verwenden Sie es nicht, da dies zu Problemen führen kann."
         },
         "name": {
           "english": "MSP Expermental",
@@ -4040,12 +4050,12 @@
         "checksum_errors": {
           "english": "Checksum errors",
           "needs_translation": false,
-          "translation": "Pruefsummenfehler"
+          "translation": "Prüfsummenfehler"
         },
         "help_p1": {
           "english": "This tool attempts to determine the quality of your MSP data link by performing as many large MSP queries within 30 seconds as possible.",
           "needs_translation": false,
-          "translation": "Dieses Tool versucht, die Qualitaet Ihrer MSP-Datenverbindung zu bestimmen, indem es innerhalb von 30 Sekunden so viele grosse MSP-Abfragen wie moeglich durchfuehrt."
+          "translation": "Dieses Tool versucht, die Qualität Ihrer MSP-Datenverbindung zu bestimmen, indem es innerhalb von 30 Sekunden so viele große MSP-Abfragen wie möglich durchführt."
         },
         "max_query_time": {
           "english": "Maximum query time",
@@ -4105,7 +4115,7 @@
         "start_prompt": {
           "english": "Would you like to start the test? Choose the test run time below.",
           "needs_translation": false,
-          "translation": "Moechten Sie den Test starten? Waehlen Sie unten die Testlaufzeit aus."
+          "translation": "Möchten Sie den Test starten? Wählen Sie unten die Testlaufzeit aus."
         },
         "successful_queries": {
           "english": "Successful queries",
@@ -4130,7 +4140,7 @@
         "timeouts": {
           "english": "Timeouts",
           "needs_translation": false,
-          "translation": "Zeitueberschreitungen"
+          "translation": "Zeitüberschreitungen"
         },
         "total_queries": {
           "english": "Total queries",
@@ -4150,31 +4160,26 @@
           "translation": "D"
         },
         "f": {
-          "english": "F",
+          "english": "FF",
           "needs_translation": false,
-          "translation": "F"
+          "translation": "FF"
         },
         "help_p1": {
           "english": "FeedForward (Roll/Pitch): Start at 70, increase until stops are sharp with no drift. Keep roll and pitch equal.",
           "needs_translation": false,
-          "translation": "FeedForward (Roll/Nick): Beginnen Sie bei 70, erhoehen Sie den Wert, bis Stopps scharf sind und kein Driften auftritt. Halten Sie Roll und Nick gleich."
+          "translation": "FeedForward (Roll/Nick): Beginnen Sie bei 70, erhöhen Sie den Wert, bis Stopps scharf sind und kein Driften auftritt. Halten Sie Roll und Nick gleich."
         },
         "help_p2": {
           "english": "I Gain (Roll/Pitch): Raise gradually for stable piro pitch pumps. Too high causes wobbles; match roll/pitch values.",
           "needs_translation": false,
-          "translation": "I-Gain (Roll/Nick): Erhoehen Sie den Wert schrittweise fuer stabile Piro-Pitch-Pumps. Ein zu hoher Wert verursacht Wackeln; Roll- und Nick-Werte sollten uebereinstimmen."
+          "translation": "I-Gain (Roll/Nick): Erhöhen Sie den Wert schrittweise für stabile Piro-Pitch-Pumps. Ein zu hoher Wert verursacht Wackeln; Roll- und Nick-Werte sollten übereinstimmen."
         },
         "help_p3": {
           "english": "Tail P/I/D Gains: Increase P until slight wobble in funnels, then back off slightly. Raise I until tail holds firm in hard moves (too high causes slow wag). Adjust D for smooth stops-higher for slow servos, lower for fast ones.",
           "needs_translation": false,
-          "translation": "Heck P/I/D-Gains: Erhoehen Sie P, bis leichtes Wackeln in Funnels auftritt, dann leicht reduzieren. Erhoehen Sie I, bis das Heck in harten Manoevern stabil bleibt (zu hoch verursacht langsames Schwingen). D anpassen fuer sanfte Stopps – hoeher fuer langsame Servos, niedriger fuer schnelle."
+          "translation": "Heck P/I/D-Gains: Erhöhen Sie P, bis leichtes Wackeln in Funnels auftritt, dann leicht reduzieren. Erhöhen Sie I, bis das Heck in harten Manövern stabil bleibt (zu hoch verursacht langsames Schwingen). D anpassen für sanfte Stopps – höher für langsame Servos, niedriger für schnelle."
         },
         "help_p4": {
-          "english": "Tail Stop Gain (CW/CCW): Adjust separately for clean, bounce-free stops in both directions.",
-          "needs_translation": false,
-          "translation": "Heck-Stopp-Gain (CW/CCW): Separat anpassen fuer saubere, Stopps ohne Pendeln in beide Richtungen."
-        },
-        "help_p5": {
           "english": "Test & Adjust: Fly, observe, and fine-tune for best performance in real conditions.",
           "needs_translation": false,
           "translation": "Testen & Anpassen: Fliegen, beobachten und feinjustieren, um die beste Leistung unter realen Bedingungen zu erreichen."
@@ -4218,103 +4223,103 @@
       "power": {
         "alert_name": {
           "english": "Alerts",
-          "needs_translation": true,
-          "translation": "Alerts"
+          "needs_translation": false,
+          "translation": "Alarme"
         },
         "alert_type": {
           "english": "Rx Voltage Alert",
-          "needs_translation": true,
-          "translation": "Rx Voltage Alert"
+          "needs_translation": false,
+          "translation": "Rx-Spannungsalarm"
         },
         "battery_capacity": {
           "english": "Battery Capacity",
-          "needs_translation": true,
-          "translation": "Battery Capacity"
+          "needs_translation": false,
+          "translation": "Batteriekapazität"
         },
         "battery_name": {
           "english": "Battery",
-          "needs_translation": true,
-          "translation": "Battery"
+          "needs_translation": false,
+          "translation": "Batterie"
         },
         "bec_voltage_alert": {
           "english": "BEC Alert Value",
-          "needs_translation": true,
-          "translation": "BEC Alert Value"
+          "needs_translation": false,
+          "translation": "BEC-Alarmwert"
         },
         "calcfuel_local": {
           "english": "Calculate Fuel Using",
-          "needs_translation": true,
-          "translation": "Calculate Fuel Using"
+          "needs_translation": false,
+          "translation": "Kraftstoff berechnen mit"
         },
         "cell_count": {
           "english": "Cell Count",
-          "needs_translation": true,
-          "translation": "Cell Count"
+          "needs_translation": false,
+          "translation": "Zellenanzahl"
         },
         "consumption_warning_percentage": {
           "english": "Consumption Warning %",
-          "needs_translation": true,
-          "translation": "Consumption Warning %"
+          "needs_translation": false,
+          "translation": "Verbrauchswarnung %"
         },
         "current_meter_source": {
           "english": "Current Source",
-          "needs_translation": true,
-          "translation": "Current Source"
+          "needs_translation": false,
+          "translation": "Stromquelle"
         },
         "full_cell_voltage": {
           "english": "Full Cell Voltage",
-          "needs_translation": true,
-          "translation": "Full Cell Voltage"
+          "needs_translation": false,
+          "translation": "Spannung volle Zelle"
         },
         "help_p1": {
           "english": "The battery settings are used to configure the flight controller to monitor the battery voltage and provide warnings when the voltage drops below a certain level.",
-          "needs_translation": true,
-          "translation": "The battery settings are used to configure the flight controller to monitor the battery voltage and provide warnings when the voltage drops below a certain level."
+          "needs_translation": false,
+          "translation": "Die Batterieeinstellungen werden verwendet, um den Flugcontroller so zu konfigurieren, dass er die Batteriespannung überwacht und Warnungen ausgibt, wenn die Spannung unter einen bestimmten Wert fällt."
         },
         "max_cell_voltage": {
           "english": "Max Cell Voltage",
-          "needs_translation": true,
-          "translation": "Max Cell Voltage"
+          "needs_translation": false,
+          "translation": "Max. Zellenspannung"
         },
         "min_cell_voltage": {
           "english": "Min Cell Voltage",
-          "needs_translation": true,
-          "translation": "Min Cell Voltage"
+          "needs_translation": false,
+          "translation": "Min. Zellenspannung"
         },
         "name": {
           "english": "Power",
-          "needs_translation": true,
-          "translation": "Power"
+          "needs_translation": false,
+          "translation": "Stromversorgung"
         },
         "rx_voltage_alert": {
           "english": "RxBatt Alert Value",
-          "needs_translation": true,
-          "translation": "RxBatt Alert Value"
+          "needs_translation": false,
+          "translation": "RxBatt-Alarmwert"
         },
         "source_name": {
           "english": "Sources",
-          "needs_translation": true,
-          "translation": "Sources"
+          "needs_translation": false,
+          "translation": "Quellen"
         },
         "timer": {
           "english": "Flight Time Alarm",
-          "needs_translation": true,
-          "translation": "Flight Time Alarm"
+          "needs_translation": false,
+          "translation": "Flugzeitalarm"
         },
         "voltage_meter_source": {
           "english": "Voltage Source",
-          "needs_translation": true,
-          "translation": "Voltage Source"
+          "needs_translation": false,
+          "translation": "Spannungsquelle"
         },
         "voltage_multiplier": {
           "english": "Sag Compensation",
-          "needs_translation": true,
-          "translation": "Sag Compensation"
+          "needs_translation": false,
+          "translation": "Einbruchskompensation"
         },
         "warn_cell_voltage": {
           "english": "Warn Cell Voltage",
-          "needs_translation": true,
-          "translation": "Warn Cell Voltage"
+          "needs_translation": false,
+          "translation": "Warn-Zellenspannung"
         }
       },
       "profile_autolevel": {
@@ -4331,22 +4336,22 @@
         "gain": {
           "english": "Gain",
           "needs_translation": false,
-          "translation": "Verstaerkung"
+          "translation": "Verstärkung"
         },
         "help_p1": {
           "english": "Acro Trainer: How aggressively the heli tilts back to level when flying in Acro Trainer Mode.",
           "needs_translation": false,
-          "translation": "Acro-Trainer: Rueckstellkraft des Helikopters zurueck zur Waagerechten im Acro-Trainer-Modus ."
+          "translation": "Acro-Trainer: Rückstellkraft des Helikopters zurück zur Waagerechten im Acro-Trainer-Modus."
         },
         "help_p2": {
           "english": "Angle Mode: How aggressively the heli tilts back to level when flying in Angle Mode.",
           "needs_translation": false,
-          "translation": "Winkelmodus: Rueckstellkraft des Helikopters zurueck zur Waagerechten im Winkelmodus."
+          "translation": "Winkelmodus: Rückstellkraft des Helikopters zurück zur Waagerechten im Winkelmodus."
         },
         "help_p3": {
           "english": "Horizon Mode: How aggressively the heli tilts back to level when flying in Horizon Mode.",
           "needs_translation": false,
-          "translation": "Horizontmodus: Rueckstellkraft des Helikopters zurueck zur Waagerechten im Horizontmodus."
+          "translation": "Horizontmodus: Rückstellkraft des Helikopters zurück zur Waagerechten im Horizontmodus."
         },
         "horizon_mode": {
           "english": "Horizon mode",
@@ -4433,12 +4438,12 @@
         "gain": {
           "english": "PID master gain",
           "needs_translation": false,
-          "translation": "PID-Masterverstaerkung"
+          "translation": "PID-Masterverstärkung"
         },
         "gains": {
           "english": "Gains",
           "needs_translation": false,
-          "translation": "Verstaerkungen"
+          "translation": "Verstärkungen"
         },
         "help_p1": {
           "english": "Full headspeed: Headspeed target when at 100% throttle input.",
@@ -4448,17 +4453,17 @@
         "help_p2": {
           "english": "PID master gain: How hard the governor works to hold the RPM.",
           "needs_translation": false,
-          "translation": "PID-Masterverstaerkung: Wie stark der Regler arbeitet, um die Drehzahl zu halten."
+          "translation": "PID-Masterverstärkung: Wie stark der Regler arbeitet, um die Drehzahl zu halten."
         },
         "help_p3": {
           "english": "Gains: Fine tuning of the governor.",
           "needs_translation": false,
-          "translation": "Verstaerkungen: Feineinstellung des Governors."
+          "translation": "Verstärkungen: Feineinstellung des Governors."
         },
         "help_p4": {
           "english": "Precomp: Governor precomp gain for yaw, cyclic, and collective inputs.",
           "needs_translation": false,
-          "translation": "Vorkompensation: Governor-Vorkompensation fuer Gier-, zyklische und kollektive Eingaben."
+          "translation": "Vorkompensation: Governor-Vorkompensation für Gier-, zyklische und kollektive Eingaben."
         },
         "help_p5": {
           "english": "Max throttle: The maximum throttle % the governor is allowed to use.",
@@ -4468,7 +4473,7 @@
         "help_p6": {
           "english": "Tail Torque Assist: For motorized tails. Gain and limit of headspeed increase when using main rotor torque for yaw assist.",
           "needs_translation": false,
-          "translation": "Heck-Drehmoment-Unterstuetzung: Fuer motorisierte Heckrotoren. Verstaerkung und Begrenzung der Drehzahlerhoehung beim Gierausgleich durch das Hauptrotordrehmoment."
+          "translation": "Heck-Drehmoment-Unterstützung: Für motorisierte Heckrotoren. Verstärkung und Begrenzung der Drehzahlerhöhung beim Gierausgleich durch das Hauptrotordrehmoment."
         },
         "hs_adjustment": {
           "english": "Headspeed Adjustment",
@@ -4575,27 +4580,27 @@
         "gain": {
           "english": "Gain",
           "needs_translation": false,
-          "translation": "Verstaerkung"
+          "translation": "Verstärkung"
         },
         "help_p1": {
           "english": "Collective Pitch Compensation: Increasing will compensate for the pitching motion caused by tail drag when climbing.",
           "needs_translation": false,
-          "translation": "Kollektive Pitch-Kompensation: Erhoehen Sie diesen Wert, um das Kippmoment durch den Heckrotorzug beim Steigen auszugleichen."
+          "translation": "Kollektive Pitch-Kompensation: Erhöhen Sie diesen Wert, um das Kippmoment durch den Heckrotorzug beim Steigen auszugleichen."
         },
         "help_p2": {
           "english": "Cross Coupling Gain: Removes roll coupling when only elevator is applied.",
           "needs_translation": false,
-          "translation": "Kreuzkopplungs-Verstaerkung: Entfernt Roll-Kopplung, wenn nur Hoehenruder (Elevator) angewendet wird."
+          "translation": "Kreuzkopplungs-Verstärkung: Entfernt Roll-Kopplung, wenn nur Höhenruder (Elevator) angewendet wird."
         },
         "help_p3": {
           "english": "Cross Coupling Ratio: Amount of compensation (pitch vs roll) to apply.",
           "needs_translation": false,
-          "translation": "Kreuzkopplungs-Verhaeltnis: Menge der angewandten Kompensation (Nick vs. Roll)."
+          "translation": "Kreuzkopplungs-Verhältnis: Menge der angewandten Kompensation (Nick vs. Roll)."
         },
         "help_p4": {
           "english": "Cross Coupling Freq. Limit: Frequency limit for the compensation, higher value will make the compensation action faster.",
           "needs_translation": false,
-          "translation": "Kreuzkopplungs-Frequenzgrenze: Frequenzgrenze fuer die Kompensation – ein hoeherer Wert fuehrt zu einer schnelleren Kompensationsreaktion."
+          "translation": "Kreuzkopplungs-Frequenzgrenze: Frequenzgrenze für die Kompensation – ein höherer Wert führt zu einer schnelleren Kompensationsreaktion."
         },
         "name": {
           "english": "Main Rotor",
@@ -4605,7 +4610,7 @@
         "ratio": {
           "english": "Ratio",
           "needs_translation": false,
-          "translation": "Verhaeltnis"
+          "translation": "Verhältnis"
         }
       },
       "profile_pidbandwidth": {
@@ -4674,12 +4679,12 @@
         "ground_error_decay": {
           "english": "Ground Error Decay",
           "needs_translation": false,
-          "translation": "Fehlerrueckgang am Boden"
+          "translation": "Fehlerrückgang am Boden"
         },
         "help_p1": {
           "english": "Error decay ground: PID decay to help prevent heli from tipping over when on the ground.",
           "needs_translation": false,
-          "translation": "Fehlerrueckgang am Boden: PID-Abfall zur Vermeidung eines Kippens des Helis am Boden."
+          "translation": "Fehlerrückgang am Boden: PID-Abfall zur Vermeidung eines Kippens des Helis am Boden."
         },
         "help_p2": {
           "english": "Error limit: Angle limit for I-term.",
@@ -4689,17 +4694,17 @@
         "help_p3": {
           "english": "Offset limit: Angle limit for High Speed Integral (O-term).",
           "needs_translation": false,
-          "translation": "Offset-Grenze: Winkelbegrenzung fuer High Speed Integral (O-Term)."
+          "translation": "Offset-Grenze: Winkelbegrenzung für High Speed Integral (O-Term)."
         },
         "help_p4": {
           "english": "Error rotation: Allow errors to be shared between all axes.",
           "needs_translation": false,
-          "translation": "Fehlerrotation: Ermoeglicht das Teilen von Fehlern zwischen allen Achsen."
+          "translation": "Fehlerrotation: Ermöglicht das Teilen von Fehlern zwischen allen Achsen."
         },
         "help_p5": {
           "english": "I-term relax: Limit accumulation of I-term during fast movements - helps reduce bounce back after fast stick movements. Generally needs to be lower for large helis and can be higher for small helis. Best to only reduce as much as is needed for your flying style.",
           "needs_translation": false,
-          "translation": "I-Term-Entspannung: Begrenzung der I-Term-Akkumulation bei schnellen Bewegungen – hilft, das Nachschwingen nach schnellen Steuerbewegungen zu reduzieren. Sollte fuer grosse Helis niedriger und fuer kleine Helis hoeher sein. Am besten nur so weit reduzieren, wie es fuer den eigenen Flugstil erforderlich ist."
+          "translation": "I-Term-Entspannung: Begrenzung der I-Term-Akkumulation bei schnellen Bewegungen – hilft, das Nachschwingen nach schnellen Steuerbewegungen zu reduzieren. Sollte für große Helis niedriger und für kleine Helis höher sein. Am besten nur so weit reduzieren, wie es für den eigenen Flugstil erforderlich ist."
         },
         "hsi_offset_limit": {
           "english": "HSI Offset limit",
@@ -4709,7 +4714,7 @@
         "inflight_error_decay": {
           "english": "Inflight Error Decay",
           "needs_translation": false,
-          "translation": "Fehlerrueckgang im Flug"
+          "translation": "Fehlerrückgang im Flug"
         },
         "iterm_relax": {
           "english": "I-term relax",
@@ -4786,12 +4791,12 @@
         "gains": {
           "english": "Gains",
           "needs_translation": false,
-          "translation": "Verstaerkungen"
+          "translation": "Verstärkungen"
         },
         "help_p1": {
           "english": "Flip to upright: Flip the heli upright when rescue is activated.",
           "needs_translation": false,
-          "translation": "Aufrichten: Richtet den Heli aus dem Rueckenflug auf, wenn der Rettungsmodus aktiviert wird."
+          "translation": "Aufrichten: Richtet den Heli aus dem Rückenflug auf, wenn der Rettungsmodus aktiviert wird."
         },
         "help_p2": {
           "english": "Pull-up: How much collective and for how long to arrest the fall.",
@@ -4801,12 +4806,12 @@
         "help_p3": {
           "english": "Climb: How much collective to maintain a steady climb - and how long.",
           "needs_translation": false,
-          "translation": "Steigen: Wie viel Kollektiv benoetigt wird, um einen gleichmaessigen Steigflug zu halten – und wie lange."
+          "translation": "Steigen: Wie viel Kollektiv benötigt wird, um einen gleichmäßigen Steigflug zu halten – und wie lange."
         },
         "help_p4": {
           "english": "Hover: How much collective to maintain a steady hover.",
           "needs_translation": false,
-          "translation": "Schweben: Wie viel Kollektiv benoetigt wird, um ein stabiles Schweben zu halten."
+          "translation": "Schweben: Wie viel Kollektiv benötigt wird, um ein stabiles Schweben zu halten."
         },
         "help_p5": {
           "english": "Flip: How long to wait before aborting because the flip did not work.",
@@ -4816,12 +4821,12 @@
         "help_p6": {
           "english": "Gains: How hard to fight to keep heli level when engaging rescue mode.",
           "needs_translation": false,
-          "translation": "Verstaerkungen: Wie stark der Heli kaempft, um in der Waagerechten zu bleiben, wenn der Rettungsmodus aktiviert wird."
+          "translation": "Verstärkungen: Wie stark der Heli kämpft, um in der Waagerechten zu bleiben, wenn der Rettungsmodus aktiviert wird."
         },
         "help_p7": {
           "english": "Rate and Accel: Max rotation and acceleration rates when leveling during rescue.",
           "needs_translation": false,
-          "translation": "Rate und Beschleunigung: Maximale Rotations- und Beschleunigungswerte beim Aufrichten waehrend der Rettung."
+          "translation": "Rate und Beschleunigung: Maximale Rotations- und Beschleunigungswerte beim Aufrichten während der Rettung."
         },
         "hover": {
           "english": "Hover",
@@ -4868,17 +4873,17 @@
         "help_p1": {
           "english": "Set the current flight profile or rate profile you would like to use.",
           "needs_translation": false,
-          "translation": "Waehlen Sie das aktuelle Flugprofil oder Rate-Profil aus, das Sie verwenden moechten."
+          "translation": "Wählen Sie das aktuelle Flugprofil oder Rate-Profil aus, das Sie verwenden möchten."
         },
         "help_p2": {
           "english": "If you use a switch on your radio to change flight or rate modes, this will override this choice as soon as you toggle the switch.",
           "needs_translation": false,
-          "translation": "Wenn Sie einen Schalter an Ihrer Fernsteuerung verwenden, um Flug- oder Rate-Modi zu aendern, wird diese Auswahl ueberschrieben, sobald Sie den Schalter umlegen."
+          "translation": "Wenn Sie einen Schalter an Ihrer Fernsteuerung verwenden, um Flug- oder Rate-Modi zu ändern, wird diese Auswahl überschrieben, sobald Sie den Schalter umlegen."
         },
         "name": {
           "english": "Select Profile",
           "needs_translation": false,
-          "translation": "Profil auswaehlen"
+          "translation": "Profil auswählen"
         },
         "ok": {
           "english": "OK",
@@ -4920,7 +4925,7 @@
         "collective_ff_gain": {
           "english": "Collective FF gain",
           "needs_translation": false,
-          "translation": "Kollektive FF-Verstaerkung"
+          "translation": "Kollektive FF-Verstärkung"
         },
         "collective_impulse_ff": {
           "english": "Collective Impulse FF",
@@ -4940,7 +4945,7 @@
         "cyclic_ff_gain": {
           "english": "Cyclic FF gain",
           "needs_translation": false,
-          "translation": "Zyklische FF-Verstaerkung"
+          "translation": "Zyklische FF-Verstärkung"
         },
         "decay": {
           "english": "Decay",
@@ -4950,37 +4955,37 @@
         "gain": {
           "english": "Gain",
           "needs_translation": false,
-          "translation": "Verst."
+          "translation": "Verstärkung"
         },
         "help_p1": {
           "english": "Yaw Stop Gain: Higher stop gain will make the tail stop more aggressively but may cause oscillations if too high. Adjust CW or CCW to make the yaw stops even.",
           "needs_translation": false,
-          "translation": "Gier-Stopp-Verstaerkung: Eine hoehere Stopp-Verstaerkung fuehrt zu aggressiveren Heckstopps, kann aber bei zu hohen Werten zu Oszillationen fuehren. Passen Sie CW oder CCW an, um gleichmaessige Gierstopps zu erzielen."
+          "translation": "Gier-Stopp-Verstärkung: Eine höhere Stopp-Verstärkung führt zu aggressiveren Heckstopps, kann aber bei zu hohen Werten zu Oszillationen führen. Passen Sie CW oder CCW an, um gleichmäßige Gierstopps zu erzielen."
         },
         "help_p2": {
           "english": "Precomp Cutoff: Frequency limit for all yaw precompensation actions.",
           "needs_translation": false,
-          "translation": "Vorkompensation Grenzwert: Frequenzgrenze fuer alle Gier-Vorkompensationsaktionen."
+          "translation": "Vorkompensation Grenzwert: Frequenzgrenze für alle Gier-Vorkompensationsaktionen."
         },
         "help_p3": {
           "english": "Cyclic FF Gain: Tail precompensation for cyclic inputs.",
           "needs_translation": false,
-          "translation": "Zyklische FF-Verstaerkung: Heck-Vorkompensation fuer zyklische Eingaben."
+          "translation": "Zyklische FF-Verstärkung: Heck-Vorkompensation für zyklische Eingaben."
         },
         "help_p4": {
           "english": "Collective FF Gain: Tail precompensation for collective inputs.",
           "needs_translation": false,
-          "translation": "Kollektive FF-Verstaerkung: Heck-Vorkompensation fuer kollektive Eingaben."
+          "translation": "Kollektive FF-Verstärkung: Heck-Vorkompensation für kollektive Eingaben."
         },
         "help_p5": {
           "english": "Collective Impulse FF: Impulse tail precompensation for collective inputs. If you need extra tail precompensation at the beginning of collective input.",
           "needs_translation": false,
-          "translation": "Kollektiv-Impuls-FF: Impulsartige Heck-Vorkompensation fuer kollektive Eingaben. Falls zusaetzliche Heck-Vorkompensation zu Beginn einer kollektiven Eingabe erforderlich ist."
+          "translation": "Kollektiv-Impuls-FF: Impulsartige Heck-Vorkompensation für kollektive Eingaben. Falls zusätzliche Heck-Vorkompensation zu Beginn einer kollektiven Eingabe erforderlich ist."
         },
         "inertia_precomp": {
           "english": "Inertia Precomp",
           "needs_translation": false,
-          "translation": "Traegheits-Vorkomp."
+          "translation": "Trögheits-Vorkomp."
         },
         "name": {
           "english": "Tail Rotor",
@@ -4995,7 +5000,7 @@
         "yaw_stop_gain": {
           "english": "Yaw stop gain",
           "needs_translation": false,
-          "translation": "Gier-Stopp-Verstaerkung"
+          "translation": "Gier-Stopp-Verstärkung"
         }
       },
       "radio_config": {
@@ -5027,7 +5032,7 @@
         "help_p1": {
           "english": "Configure your radio settings. Stick center, arm, throttle hold, and throttle cut.",
           "needs_translation": false,
-          "translation": "Konfigurieren Sie Ihre Fernsteuerungseinstellungen: Knueppelzentrum, Arm, Gas-Hold und Gas-Abschaltung."
+          "translation": "Konfigurieren Sie Ihre Fernsteuerungseinstellungen: Knüppelzentrum, Arm, Gas-Hold und Gas-Abschaltung."
         },
         "max_throttle": {
           "english": "Max",
@@ -5047,7 +5052,7 @@
         "stick": {
           "english": "Stick",
           "needs_translation": false,
-          "translation": "Knueppel"
+          "translation": "Knüppel"
         },
         "throttle": {
           "english": "Throttle",
@@ -5094,7 +5099,7 @@
         "help_default_p1": {
           "english": "Default: We keep this to make button appear for rates.",
           "needs_translation": false,
-          "translation": "Standard: Diese Option bleibt erhalten, damit der Button fuer die Rates erscheint."
+          "translation": "Standard: Diese Option bleibt erhalten, damit der Button für die Rates erscheint."
         },
         "help_default_p2": {
           "english": "We will use the sub keys below.",
@@ -5109,77 +5114,77 @@
         "help_table_1_p1": {
           "english": "RC Rate: Maximum rotation rate at full stick deflection.",
           "needs_translation": false,
-          "translation": "RC-Rate: Maximale Rotationsgeschwindigkeit bei vollem Knueppelausschlag."
+          "translation": "RC-Rate: Maximale Rotationsgeschwindigkeit bei vollem Knüppelausschlag."
         },
         "help_table_1_p2": {
           "english": "SuperRate: Increases maximum rotation rate while reducing sensitivity around half stick.",
           "needs_translation": false,
-          "translation": "SuperRate: Erhoeht die maximale Rotationsgeschwindigkeit und verringert gleichzeitig die Empfindlichkeit in der Mitte des Knueppelwegs."
+          "translation": "SuperRate: Erhöht die maximale Rotationsgeschwindigkeit und verringert gleichzeitig die Empfindlichkeit in der Mitte des Knüppelwegs."
         },
         "help_table_1_p3": {
           "english": "Expo: Reduces sensitivity near the stick's center where fine controls are needed.",
           "needs_translation": false,
-          "translation": "Expo: Verringert die Empfindlichkeit nahe der Knueppelmitte fuer feinere Steuerung."
+          "translation": "Expo: Verringert die Empfindlichkeit nahe der Knüppelmitte für feinere Steuerung."
         },
         "help_table_2_p1": {
           "english": "Rate: Maximum rotation rate at full stick deflection in degrees per second.",
           "needs_translation": false,
-          "translation": "Rate: Maximale Rotationsgeschwindigkeit bei vollem Knueppelausschlag in Grad pro Sekunde."
+          "translation": "Rate: Maximale Rotationsgeschwindigkeit bei vollem Knüppelausschlag in Grad pro Sekunde."
         },
         "help_table_2_p2": {
           "english": "Acro+: Increases the maximum rotation rate while reducing sensitivity around half stick.",
           "needs_translation": false,
-          "translation": "Acro+: Erhoeht die maximale Rotationsgeschwindigkeit und verringert die Empfindlichkeit in der Mitte des Knueppelwegs."
+          "translation": "Acro+: Erhöht die maximale Rotationsgeschwindigkeit und verringert die Empfindlichkeit in der Mitte des Knüppelwegs."
         },
         "help_table_2_p3": {
           "english": "Expo: Reduces sensitivity near the stick's center where fine controls are needed.",
           "needs_translation": false,
-          "translation": "Expo: Verringert die Empfindlichkeit nahe der Knueppelmitte fuer feinere Steuerung."
+          "translation": "Expo: Verringert die Empfindlichkeit nahe der Knüppelmitte für feinere Steuerung."
         },
         "help_table_3_p1": {
           "english": "RC Rate: Maximum rotation rate at full stick deflection.",
           "needs_translation": false,
-          "translation": "RC-Rate: Maximale Rotationsgeschwindigkeit bei vollem Knueppelausschlag."
+          "translation": "RC-Rate: Maximale Rotationsgeschwindigkeit bei vollem Knüppelausschlag."
         },
         "help_table_3_p2": {
           "english": "Rate: Increases maximum rotation rate while reducing sensitivity around half stick.",
           "needs_translation": false,
-          "translation": "Rate: Erhoeht die maximale Rotationsgeschwindigkeit und verringert die Empfindlichkeit in der Mitte des Knueppelwegs."
+          "translation": "Rate: Erhöht die maximale Rotationsgeschwindigkeit und verringert die Empfindlichkeit in der Mitte des Knüppelwegs."
         },
         "help_table_3_p3": {
           "english": "RC Curve: Reduces sensitivity near the stick's center where fine controls are needed.",
           "needs_translation": false,
-          "translation": "RC-Kurve: Verringert die Empfindlichkeit nahe der Knueppelmitte fuer feinere Steuerung."
+          "translation": "RC-Kurve: Verringert die Empfindlichkeit nahe der Knüppelmitte für feinere Steuerung."
         },
         "help_table_4_p1": {
           "english": "Center Sensitivity: Use to reduce sensitivity around center stick. Set Center Sensitivity to the same as Max Rate for a linear response. A lower number than Max Rate will reduce sensitivity around center stick. Note that higher than Max Rate will increase the Max Rate - not recommended as it causes issues in the Blackbox log.",
           "needs_translation": false,
-          "translation": "Zentrale Empfindlichkeit: Reduziert die Empfindlichkeit um die Knueppelmitte. Wenn die zentrale Empfindlichkeit auf denselben Wert wie die Maximalrate gesetzt wird, ist die Reaktion linear. Ein niedrigerer Wert als die Maximalrate reduziert die Empfindlichkeit um die Knueppelmitte. Ein hoeherer Wert als die Maximalrate erhoeht die Maximalrate – nicht empfohlen, da dies zu Problemen in den Blackbox-Logs fuehrt."
+          "translation": "Zentrale Empfindlichkeit: Reduziert die Empfindlichkeit um die Knüppelmitte. Wenn die zentrale Empfindlichkeit auf denselben Wert wie die Maximalrate gesetzt wird, ist die Reaktion linear. Ein niedrigerer Wert als die Maximalrate reduziert die Empfindlichkeit um die Knüppelmitte. Ein höherer Wert als die Maximalrate erhöht die Maximalrate – nicht empfohlen, da dies zu Problemen in den Blackbox-Logs führt."
         },
         "help_table_4_p2": {
           "english": "Max Rate: Maximum rotation rate at full stick deflection in degrees per second.",
           "needs_translation": false,
-          "translation": "Maximalrate: Maximale Rotationsgeschwindigkeit bei vollem Knueppelausschlag in Grad pro Sekunde."
+          "translation": "Maximalrate: Maximale Rotationsgeschwindigkeit bei vollem Knüppelausschlag in Grad pro Sekunde."
         },
         "help_table_4_p3": {
           "english": "Expo: Reduces sensitivity near the stick's center where fine controls are needed.",
           "needs_translation": false,
-          "translation": "Expo: Verringert die Empfindlichkeit nahe der Knueppelmitte fuer feinere Steuerung."
+          "translation": "Expo: Verringert die Empfindlichkeit nahe der Knüppelmitte für feinere Steuerung."
         },
         "help_table_5_p1": {
           "english": "RC Rate: Use to reduce sensitivity around center stick. RC Rate set to one half of the Max Rate is linear. A lower number will reduce sensitivity around center stick. Higher than one half of the Max Rate will also increase the Max Rate.",
           "needs_translation": false,
-          "translation": "RC-Rate: Reduziert die Empfindlichkeit um die Knueppelmitte. Eine RC-Rate, die auf die Haelfte der Maximalrate eingestellt ist, ist linear. Ein niedrigerer Wert reduziert die Empfindlichkeit um die Knueppelmitte. Ein hoeherer Wert als die Haelfte der Maximalrate erhoeht auch die Maximalrate."
+          "translation": "RC-Rate: Reduziert die Empfindlichkeit um die Knüppelmitte. Eine RC-Rate, die auf die Hälfte der Maximalrate eingestellt ist, ist linear. Ein niedrigerer Wert reduziert die Empfindlichkeit um die Knüppelmitte. Ein höherer Wert als die Hälfte der Maximalrate erhöht auch die Maximalrate."
         },
         "help_table_5_p2": {
           "english": "Max Rate: Maximum rotation rate at full stick deflection in degrees per second.",
           "needs_translation": false,
-          "translation": "Maximalrate: Maximale Rotationsgeschwindigkeit bei vollem Knueppelausschlag in Grad pro Sekunde."
+          "translation": "Maximalrate: Maximale Rotationsgeschwindigkeit bei vollem Knüppelausschlag in Grad pro Sekunde."
         },
         "help_table_5_p3": {
           "english": "Expo: Reduces sensitivity near the stick's center where fine controls are needed.",
           "needs_translation": false,
-          "translation": "Expo: Verringert die Empfindlichkeit nahe der Knueppelmitte fuer feinere Steuerung."
+          "translation": "Expo: Verringert die Empfindlichkeit nahe der Knüppelmitte für feinere Steuerung."
         },
         "kiss": {
           "english": "KISS",
@@ -5238,13 +5243,13 @@
         },
         "rotorflight": {
           "english": "ROTORFLIGHT",
-          "needs_translation": true,
+          "needs_translation": false,
           "translation": "ROTORFLIGHT"
         },
         "shape": {
           "english": "Shape",
-          "needs_translation": true,
-          "translation": "Shape"
+          "needs_translation": false,
+          "translation": "Form"
         },
         "superrate": {
           "english": "SuperRate",
@@ -5270,8 +5275,8 @@
         },
         "advanced": {
           "english": "Advanced",
-          "needs_translation": true,
-          "translation": "Advanced"
+          "needs_translation": false,
+          "translation": "Erweitert"
         },
         "col": {
           "english": "Col",
@@ -5316,27 +5321,27 @@
         "gain": {
           "english": "Gain",
           "needs_translation": false,
-          "translation": "Verst."
+          "translation": "Verstärkung"
         },
         "help_p1": {
           "english": "Rates type: Choose the rate type you prefer flying with. Raceflight and Actual are the most straightforward.",
           "needs_translation": false,
-          "translation": "Raten-Typ: Waehlen Sie den Rate-Typ aus, mit dem Sie fliegen moechten. Raceflight und Actual sind die einfachsten."
+          "translation": "Raten-Typ: Wählen Sie den Rate-Typ aus, mit dem Sie fliegen möchten. Raceflight und Actual sind die einfachsten."
         },
         "help_p2": {
           "english": "Dynamics: Applied regardless of rates type. Typically left on defaults but can be adjusted to smooth heli movements, like with scale helis.",
           "needs_translation": false,
-          "translation": "Dynamik: Wird unabhaengig vom Rate-Typ angewendet. Anpassen, um Heli-Bewegungen weicher zu machen, z. B. fuer Scale-Helis."
+          "translation": "Dynamik: Wird unabhängig vom Rate-Typ angewendet. Anpassen, um Heli-Bewegungen weicher zu machen, z. B. für Scale-Helis."
         },
         "help_rate_table": {
           "english": "Please select the rate you would like to use. Saving will apply the choice to the active profile.",
           "needs_translation": false,
-          "translation": "Bitte waehlen Sie die Rates aus, den Sie verwenden moechten. Durch das Speichern wird die Auswahl auf das aktive Profil angewendet."
+          "translation": "Bitte wählen Sie die Rates aus, den Sie verwenden möchten. Durch das Speichern wird die Auswahl auf das aktive Profil angewendet."
         },
         "msg_reset_to_defaults": {
           "english": "Rate type changed. Values will be reset to defaults.",
           "needs_translation": false,
-          "translation": "Rate-Typ geaendert. Werte werden auf Standardwerte zurueckgesetzt."
+          "translation": "Rate-Typ geändert. Werte werden auf Standardwerte zurückgesetzt."
         },
         "name": {
           "english": "Rates",
@@ -5361,7 +5366,7 @@
         "rate_table": {
           "english": "Rate Table",
           "needs_translation": false,
-          "translation": "Rate Tabelle"
+          "translation": "Rate-Tabelle"
         },
         "rates_type": {
           "english": "Rates Type",
@@ -5400,8 +5405,8 @@
         },
         "table": {
           "english": "Rate Table",
-          "needs_translation": true,
-          "translation": "Rate Table"
+          "needs_translation": false,
+          "translation": "Rate-Tabelle"
         },
         "yaw": {
           "english": "Yaw",
@@ -5515,22 +5520,22 @@
         "help_default_p2": {
           "english": "- For RX channels or servos (wideband), use 1000, 2000 or 500,1000 for narrow band servos.",
           "needs_translation": false,
-          "translation": "- Fuer RX-Kanaele oder Servos (Breitband) 1000, 2000 oder 500,1000 fuer Schmalband-Servos verwenden."
+          "translation": "- Für RX-Kanäle oder Servos (Breitband) 1000, 2000 oder 500,1000 für Schmalband-Servos verwenden."
         },
         "help_default_p3": {
           "english": "- For mixer rules, use -1000, 1000.",
           "needs_translation": false,
-          "translation": "- Fuer Mischregeln -1000, 1000 verwenden."
+          "translation": "- Für Mischregeln -1000, 1000 verwenden."
         },
         "help_default_p4": {
           "english": "- For motors, use 0, 1000.",
           "needs_translation": false,
-          "translation": "- Fuer Motoren 0, 1000 verwenden."
+          "translation": "- Für Motoren 0, 1000 verwenden."
         },
         "help_default_p5": {
           "english": "- Or you can customize your own mapping.",
           "needs_translation": false,
-          "translation": "- Oder Sie koennen Ihre eigene Zuordnung anpassen."
+          "translation": "- Oder Sie können Ihre eigene Zuordnung anpassen."
         },
         "help_fields_max": {
           "english": "The maximum pwm value to send",
@@ -5545,7 +5550,7 @@
         "help_fields_source": {
           "english": "Source id for the mix, counting from 0-15.",
           "needs_translation": false,
-          "translation": "Quellen-ID fuer den Mix, zaehlt von 0-15."
+          "translation": "Quellen-ID für den Mix, zählt von 0-15."
         },
         "max": {
           "english": "Max",
@@ -5580,7 +5585,7 @@
         "receiver": {
           "english": "Receiver",
           "needs_translation": false,
-          "translation": "Empfaenger"
+          "translation": "Empfänger"
         },
         "save_prompt": {
           "english": "Save current page to flight controller?",
@@ -5647,37 +5652,37 @@
         "disable_servo_override": {
           "english": "Disable servo override",
           "needs_translation": false,
-          "translation": "Servo-Ueberschreibung deaktivieren"
+          "translation": "Servo-Überschreibung deaktivieren"
         },
         "disable_servo_override_msg": {
           "english": "Return control of the servos to the flight controller.",
           "needs_translation": false,
-          "translation": "Gibt die Steuerung der Servos an den Flugcontroller zurueck."
+          "translation": "Gibt die Steuerung der Servos an den Flugcontroller zurück."
         },
         "disabling_servo_override": {
           "english": "Disabling servo override...",
           "needs_translation": false,
-          "translation": "Deaktiviere Servo-Ueberschreibung..."
+          "translation": "Deaktiviere Servo-Überschreibung..."
         },
         "enable_servo_override": {
           "english": "Enable servo override",
           "needs_translation": false,
-          "translation": "Servo-Ueberschreibung aktivieren"
+          "translation": "Servo-Überschreibung aktivieren"
         },
         "enable_servo_override_msg": {
           "english": "Servo override allows you to 'trim' your servo center point in real time.",
           "needs_translation": false,
-          "translation": "Die Servo-Ueberschreibung ermoeglicht es Ihnen, den Servo-Mittelpunkt in Echtzeit zu 'trimmen'."
+          "translation": "Die Servo-Überschreibung ermöglicht es Ihnen, den Servo-Mittelpunkt in Echtzeit zu 'trimmen'."
         },
         "enabling_servo_override": {
           "english": "Enabling servo override...",
           "needs_translation": false,
-          "translation": "Aktiviere Servo-Ueberschreibung..."
+          "translation": "Aktiviere Servo-Überschreibung..."
         },
         "fbus": {
           "english": "FBUS Output",
-          "needs_translation": true,
-          "translation": "FBUS Output"
+          "needs_translation": false,
+          "translation": "FBUS-Ausgang"
         },
         "geometry": {
           "english": "Geometry",
@@ -5687,17 +5692,17 @@
         "help_default_p1": {
           "english": "Please select the servo you would like to configure from the list below.",
           "needs_translation": false,
-          "translation": "Bitte waehlen Sie das Servo aus, das Sie konfigurieren moechten, aus der untenstehenden Liste."
+          "translation": "Bitte wählen Sie das Servo aus, das Sie konfigurieren möchten, aus der untenstehenden Liste."
         },
         "help_default_p2": {
           "english": "Primary flight controls that use the rotorflight mixer will display in the section called 'mixer'.",
           "needs_translation": false,
-          "translation": "Primaere Flugsteuerungen, die den Rotorflight-Mischer verwenden, werden im Abschnitt 'Mischer' angezeigt."
+          "translation": "Primäre Flugsteuerungen, die den Rotorflight-Mischer verwenden, werden im Abschnitt 'Mischer' angezeigt."
         },
         "help_default_p3": {
           "english": "Any other servos that are not controlled by the primary flight mixer will be displayed in the section called 'Other servos'.",
           "needs_translation": false,
-          "translation": "Alle anderen Servos, die nicht vom primaeren Flugmischer gesteuert werden, werden im Abschnitt 'Andere Servos' angezeigt."
+          "translation": "Alle anderen Servos, die nicht vom primären Flugmischer gesteuert werden, werden im Abschnitt 'Andere Servos' angezeigt."
         },
         "help_fields_flags": {
           "english": "0 = Default, 1=Reverse, 2 = Geo Correction, 3 = Reverse + Geo Correction",
@@ -5742,7 +5747,7 @@
         "help_tool_p1": {
           "english": "Override: [*] Enable override to allow real-time updates of servo center point.",
           "needs_translation": false,
-          "translation": "Ueberschreiben: [*] Aktivieren Sie die Ueberschreibung, um Echtzeitaktualisierungen der Servo-Mittelposition zu ermoeglichen."
+          "translation": "Überschreiben: [*] Aktivieren Sie die Überschreibung, um Echtzeitaktualisierungen der Servo-Mittelposition zu ermöglichen."
         },
         "help_tool_p2": {
           "english": "Center: Adjust the center position of the servo.",
@@ -5752,7 +5757,7 @@
         "help_tool_p3": {
           "english": "Minimum/Maximum: Adjust the end points of the selected servo.",
           "needs_translation": false,
-          "translation": "Minimum/Maximum: Passen Sie die Endpunkte des ausgewaehlten Servos an."
+          "translation": "Minimum/Maximum: Passen Sie die Endpunkte des ausgewählten Servos an."
         },
         "help_tool_p4": {
           "english": "Scale: Adjust the amount the servo moves for a given input.",
@@ -5762,12 +5767,12 @@
         "help_tool_p5": {
           "english": "Rate: The frequency the servo runs best at - check with manufacturer.",
           "needs_translation": false,
-          "translation": "Rate: Die Frequenz, mit der das Servo am besten arbeitet – pruefen Sie dies beim Hersteller."
+          "translation": "Rate: Die Frequenz, mit der das Servo am besten arbeitet – prüfen Sie dies beim Hersteller."
         },
         "help_tool_p6": {
           "english": "Speed: The speed the servo moves. Generally only used for the cyclic servos to help the swash move evenly. Optional - leave all at 0 if unsure.",
           "needs_translation": false,
-          "translation": "Geschwindigkeit: Die Geschwindigkeit, mit der sich das Servo bewegt. Wird normalerweise nur fuer zyklische Servos verwendet, um eine gleichmaessige Bewegung der Taumelscheibe zu gewaehrleisten. Optional – alle Werte auf 0 lassen, wenn Sie unsicher sind."
+          "translation": "Geschwindigkeit: Die Geschwindigkeit, mit der sich das Servo bewegt. Wird normalerweise nur für zyklische Servos verwendet, um eine gleichmäßige Bewegung der Taumelscheibe zu gewährleisten. Optional – alle Werte auf 0 lassen, wenn Sie unsicher sind."
         },
         "maximum": {
           "english": "Maximum",
@@ -5786,8 +5791,8 @@
         },
         "pwm": {
           "english": "PWM Output",
-          "needs_translation": true,
-          "translation": "PWM Output"
+          "needs_translation": false,
+          "translation": "PWM-Ausgang"
         },
         "rate": {
           "english": "Rate",
@@ -5811,8 +5816,8 @@
         },
         "sbus": {
           "english": "SBUS Output",
-          "needs_translation": true,
-          "translation": "SBUS Output"
+          "needs_translation": false,
+          "translation": "SBUS-Ausgang"
         },
         "scale_negative": {
           "english": "Scale Negative",
@@ -5827,7 +5832,7 @@
         "servo_override": {
           "english": "Servo Override",
           "needs_translation": false,
-          "translation": "Servo-Ueberschreibung"
+          "translation": "Servo-Überschreibung"
         },
         "servo_prefix": {
           "english": "SERVO ",
@@ -5874,7 +5879,7 @@
         "altitude_unit": {
           "english": "Altitude Unit",
           "needs_translation": false,
-          "translation": "Hoeheneinheit"
+          "translation": "Höheneinheit"
         },
         "arming_flags": {
           "english": "Arming Flags",
@@ -5908,13 +5913,13 @@
         },
         "dashboard_loader": {
           "english": "Loader",
-          "needs_translation": true,
-          "translation": "Loader"
+          "needs_translation": false,
+          "translation": "Ladeanzeige"
         },
         "dashboard_loader_loader_style_select": {
           "english": "Theme loader style",
-          "needs_translation": true,
-          "translation": "Theme loader style"
+          "needs_translation": false,
+          "translation": "Stil der Ladeanzeige"
         },
         "dashboard_settings": {
           "english": "Settings",
@@ -5934,17 +5939,17 @@
         "dashboard_theme_panel_global": {
           "english": "Default theme for all models",
           "needs_translation": false,
-          "translation": "Standard-Design fuer alle Modelle"
+          "translation": "Standard-Design für alle Modelle"
         },
         "dashboard_theme_panel_model": {
           "english": "Optional theme for this model",
           "needs_translation": false,
-          "translation": "Optionales Design fuer dieses Modell"
+          "translation": "Optionales Design für dieses Modell"
         },
         "dashboard_theme_panel_model_disabled": {
           "english": "Disabled",
           "needs_translation": false,
-          "translation": "Ausgeschalten"
+          "translation": "Ausgeschaltet"
         },
         "dashboard_theme_postflight": {
           "english": "Postflight Theme",
@@ -6033,18 +6038,18 @@
         },
         "loader_style_large": {
           "english": "LARGE",
-          "needs_translation": true,
-          "translation": "LARGE"
+          "needs_translation": false,
+          "translation": "GROSS"
         },
         "loader_style_medium": {
           "english": "MEDIUM",
-          "needs_translation": true,
-          "translation": "MEDIUM"
+          "needs_translation": false,
+          "translation": "MITTEL"
         },
         "loader_style_small": {
           "english": "SMALL",
-          "needs_translation": true,
-          "translation": "SMALL"
+          "needs_translation": false,
+          "translation": "KLEIN"
         },
         "localizations": {
           "english": "Localization",
@@ -6064,7 +6069,7 @@
         "no_themes_available_to_configure": {
           "english": "No configurable themes installed on this device",
           "needs_translation": false,
-          "translation": "Keine konfigurierbaren Designs auf dem Geraet installiert."
+          "translation": "Keine konfigurierbaren Designs auf dem Gerät installiert."
         },
         "pid_profile": {
           "english": "PID Profile",
@@ -6203,23 +6208,23 @@
         },
         "txt_hs_loader": {
           "english": "Progress Loader",
-          "needs_translation": true,
-          "translation": "Progress Loader"
+          "needs_translation": false,
+          "translation": "Fortschrittsanzeige"
         },
         "txt_hs_loader_fastclose": {
           "english": "CLOSE ASAP",
-          "needs_translation": true,
-          "translation": "CLOSE ASAP"
+          "needs_translation": false,
+          "translation": "SOFORT SCHLIESSEN"
         },
         "txt_hs_loader_wait": {
           "english": "CLOSE AT 100%",
-          "needs_translation": true,
-          "translation": "CLOSE AT 100%"
+          "needs_translation": false,
+          "translation": "BEI 100% SCHLIESSEN"
         },
         "txt_iconsize": {
           "english": "Icon Size",
           "needs_translation": false,
-          "translation": "Icongroesse"
+          "translation": "Icongröße"
         },
         "txt_info": {
           "english": "INFO",
@@ -6278,8 +6283,8 @@
         },
         "txt_overlaystatsadmin": {
           "english": "Overlay stats in admin",
-          "needs_translation": true,
-          "translation": "Overlay stats in admin"
+          "needs_translation": false,
+          "translation": "Overlay-Statistiken im Admin"
         },
         "txt_queuesize": {
           "english": "Log MSP queue size",
@@ -6288,13 +6293,13 @@
         },
         "txt_reload_confirm": {
           "english": "Confirm on reload",
-          "needs_translation": true,
-          "translation": "Confirm on reload"
+          "needs_translation": false,
+          "translation": "Bestätigen beim Neuladen"
         },
         "txt_save_confirm": {
           "english": "Confirm on save",
-          "needs_translation": true,
-          "translation": "Confirm on save"
+          "needs_translation": false,
+          "translation": "Bestätigen beim Speichern"
         },
         "txt_small": {
           "english": "SMALL",
@@ -6385,12 +6390,12 @@
         "disable_mixer_message": {
           "english": "Return control of the servos to the flight controller.",
           "needs_translation": false,
-          "translation": "Gibt die Steuerung der Servos an den Flugcontroller zurueck."
+          "translation": "Gibt die Steuerung der Servos an den Flugcontroller zurück."
         },
         "disable_mixer_override": {
           "english": "Disable mixer override",
           "needs_translation": false,
-          "translation": "Mischer-Ueberschreibung deaktivieren"
+          "translation": "Mischer-Überschreibung deaktivieren"
         },
         "enable_mixer_message": {
           "english": "Set all servos to their configured center position. \r\n\r\nThis will result in all values on this page being saved when adjusting the servo trim.",
@@ -6400,32 +6405,32 @@
         "enable_mixer_override": {
           "english": "Enable mixer override",
           "needs_translation": false,
-          "translation": "Mischer-Ueberschreibung aktivieren"
+          "translation": "Mischer-Überschreibung aktivieren"
         },
         "help_p1": {
           "english": "Link trims: Use to trim out small leveling issues in your swash plate. Typically only used if the swash links are non-adjustable.",
           "needs_translation": false,
-          "translation": "Trimmungen verknuepfen: Verwenden Sie dies, um kleine Nivellierungsprobleme in Ihrer Taumelscheibe zu korrigieren. Normalerweise nur notwendig, wenn die Taumelscheibenanlenkungen nicht verstellbar sind."
+          "translation": "Trimmungen verknüpfen: Verwenden Sie dies, um kleine Nivellierungsprobleme in Ihrer Taumelscheibe zu korrigieren. Normalerweise nur notwendig, wenn die Taumelscheibenanlenkungen nicht verstellbar sind."
         },
         "help_p2": {
           "english": "Motorised tail: If using a motorised tail, use this to set the minimum idle speed and zero yaw.",
           "needs_translation": false,
-          "translation": "Motorisiertes Heck: Falls ein motorisiertes Heck verwendet wird, koennen Sie hier die minimale Leerlaufdrehzahl und den Null-Gierpunkt einstellen."
+          "translation": "Motorisiertes Heck: Falls ein motorisiertes Heck verwendet wird, können Sie hier die minimale Leerlaufdrehzahl und den Null-Gierpunkt einstellen."
         },
         "mixer_override": {
           "english": "Mixer Override",
           "needs_translation": false,
-          "translation": "Mischer-Ueberschreibung"
+          "translation": "Mischer-Überschreibung"
         },
         "mixer_override_disabling": {
           "english": "Disabling mixer override...",
           "needs_translation": false,
-          "translation": "Mischer-Ueberschreibung wird deaktiviert..."
+          "translation": "Mischer-Überschreibung wird deaktiviert..."
         },
         "mixer_override_enabling": {
           "english": "Enabling mixer override...",
           "needs_translation": false,
-          "translation": "Mischer-Ueberschreibung wird aktiviert..."
+          "translation": "Mischer-Überschreibung wird aktiviert..."
         },
         "name": {
           "english": "Trim",
@@ -6467,7 +6472,7 @@
         "invalid": {
           "english": "INVALID",
           "needs_translation": false,
-          "translation": "UNGUELTIG"
+          "translation": "UNGÜLTIG"
         },
         "msg_repair": {
           "english": "Enable required sensors on flight controller?",
@@ -6477,7 +6482,7 @@
         "msg_repair_fin": {
           "english": "The flight controller has been configured? You may need to perform a discover sensors to see the changes.",
           "needs_translation": false,
-          "translation": "Der Flugcontroller wurde konfiguriert? Moeglicherweise muessen Sie Sensoren neu suchen, um die Aenderungen zu sehen."
+          "translation": "Der Flugcontroller wurde konfiguriert? Möglicherweise müssen Sie Sensoren neu suchen, um die Änderungen zu sehen."
         },
         "name": {
           "english": "Sensors",
@@ -6504,7 +6509,7 @@
     "msg_loading": {
       "english": "Loading...",
       "needs_translation": false,
-      "translation": "Laedt..."
+      "translation": "Lädt..."
     },
     "msg_loading_from_fbl": {
       "english": "Loading data from flight controller...",
@@ -6514,12 +6519,12 @@
     "msg_please_disarm_to_save": {
       "english": "Please disarm to save",
       "needs_translation": false,
-      "translation": "Bitte disarmen, um die Datensicherheit zu gewaehrleisten."
+      "translation": "Bitte disarmen, um die Datensicherheit zu gewöhrleisten."
     },
     "msg_please_disarm_to_save_warning": {
       "english": "Settings will only be saved to eeprom on disarm",
       "needs_translation": false,
-      "translation": "Einstellungen werden nur beim Entschaerfen im EEPROM gespeichert"
+      "translation": "Einstellungen werden nur beim Entschärfen im EEPROM gespeichert"
     },
     "msg_rebooting": {
       "english": "Rebooting...",
@@ -6539,7 +6544,7 @@
     "msg_save_not_commited": {
       "english": "Save not committed to EEPROM",
       "needs_translation": false,
-      "translation": "Speicherung nicht im EEPROM uebernommen"
+      "translation": "Speicherung nicht im EEPROM übernommen"
     },
     "msg_save_settings": {
       "english": "Save settings",
@@ -6567,9 +6572,9 @@
       "translation": "?"
     },
     "navigation_menu": {
-      "english": "MENU",
+      "english": "BACK",
       "needs_translation": false,
-      "translation": "MENUE"
+      "translation": "ZURÜCK"
     },
     "navigation_reload": {
       "english": "RELOAD",
@@ -6671,7 +6676,7 @@
     "altitude": {
       "english": "Altitude",
       "needs_translation": false,
-      "translation": "Hoehe"
+      "translation": "Höhe"
     },
     "armdisableflags": {
       "english": "Arming Disable",
@@ -6746,7 +6751,7 @@
     "link": {
       "english": "Link Quality",
       "needs_translation": false,
-      "translation": "Verbindungsqualitaet"
+      "translation": "Verbindungsqualität"
     },
     "mcu_temp": {
       "english": "MCU Temperature",
@@ -7461,7 +7466,7 @@
       "erase_dataflash": {
         "english": "Erase dataflash",
         "needs_translation": false,
-        "translation": "Blackbox speicher loeschen"
+        "translation": "Blackbox speicher löschen"
       },
       "erasing": {
         "english": "Erasing...",
@@ -7474,7 +7479,7 @@
       "title": {
         "english": "CRAFT NAME",
         "needs_translation": false,
-        "translation": "FLUGGERAET NAME"
+        "translation": "FLUGGERÄT NAME"
       },
       "txt_cancel": {
         "english": "Cancel",
@@ -7484,7 +7489,7 @@
       "txt_enter_craft_name": {
         "english": "Enter Craft Name",
         "needs_translation": false,
-        "translation": "Fluggeraetname eingeben"
+        "translation": "Fluggerätname eingeben"
       },
       "txt_save": {
         "english": "Save",
@@ -7496,12 +7501,12 @@
       "altitude": {
         "english": "Altitude",
         "needs_translation": false,
-        "translation": "Hoehe"
+        "translation": "Höhe"
       },
       "altitude_max": {
         "english": "Altitude Max",
         "needs_translation": false,
-        "translation": "Hoehe Max"
+        "translation": "Höhe Max"
       },
       "bec_voltage": {
         "english": "BEC Voltage",
@@ -7581,7 +7586,7 @@
       "fuel_remaining": {
         "english": "Fuel Remaining",
         "needs_translation": false,
-        "translation": "Verfuegbarer Kraftstoff"
+        "translation": "Verfügbarer Kraftstoff"
       },
       "governor": {
         "english": "Governor",
@@ -7686,12 +7691,12 @@
       "reset_flight_ask_text": {
         "english": "Are you sure you want to reset the flight?",
         "needs_translation": false,
-        "translation": "Sind Sie sicher, dass die den Flug zuruecksetzen moechten?"
+        "translation": "Sind Sie sicher, dass die den Flug zurücksetzen möchten?"
       },
       "reset_flight_ask_title": {
         "english": "Reset flight",
         "needs_translation": false,
-        "translation": "Flug zuruecksetzen"
+        "translation": "Flug zurücksetzen"
       },
       "rpm": {
         "english": "RPM",
@@ -7756,7 +7761,7 @@
       "validate_sensors": {
         "english": "PLEASE CHECK SENSORS",
         "needs_translation": false,
-        "translation": "BENOETIGTE SENSOREN NICHT VERFUEGBAR"
+        "translation": "BENÖTIGTE SENSOREN NICHT VERFÜGBAR"
       },
       "voltage": {
         "english": "Voltage",
@@ -7792,8 +7797,8 @@
       },
       "ARMED": {
         "english": "ARMED",
-        "needs_translation": true,
-        "translation": "ARMED"
+        "needs_translation": false,
+        "translation": "GESCHÄRFT"
       },
       "AUTOROT": {
         "english": "AUTOROT",

--- a/src/rfsuite/i18n/en.json
+++ b/src/rfsuite/i18n/en.json
@@ -1973,6 +1973,16 @@
     }
   },
   "app": {
+    "header_configuration": {
+      "english": "Configuration",
+      "needs_translation": false,
+      "translation": "Configuration"
+    },
+    "header_system": {
+      "english": "System",
+      "needs_translation": false,
+      "translation": "System"
+    },
     "btn_cancel": {
       "english": "CANCEL",
       "needs_translation": false,
@@ -4150,9 +4160,9 @@
           "translation": "D"
         },
         "f": {
-          "english": "F",
+          "english": "FF",
           "needs_translation": false,
-          "translation": "F"
+          "translation": "FF"
         },
         "help_p1": {
           "english": "FeedForward (Roll/Pitch): Start at 70, increase until stops are sharp with no drift. Keep roll and pitch equal.",
@@ -4170,11 +4180,6 @@
           "translation": "Tail P/I/D Gains: Increase P until slight wobble in funnels, then back off slightly. Raise I until tail holds firm in hard moves (too high causes slow wag). Adjust D for smooth stops-higher for slow servos, lower for fast ones."
         },
         "help_p4": {
-          "english": "Tail Stop Gain (CW/CCW): Adjust separately for clean, bounce-free stops in both directions.",
-          "needs_translation": false,
-          "translation": "Tail Stop Gain (CW/CCW): Adjust separately for clean, bounce-free stops in both directions."
-        },
-        "help_p5": {
           "english": "Test & Adjust: Fly, observe, and fine-tune for best performance in real conditions.",
           "needs_translation": false,
           "translation": "Test & Adjust: Fly, observe, and fine-tune for best performance in real conditions."
@@ -6567,9 +6572,9 @@
       "translation": "?"
     },
     "navigation_menu": {
-      "english": "MENU",
+      "english": "BACK",
       "needs_translation": false,
-      "translation": "MENU"
+      "translation": "BACK"
     },
     "navigation_reload": {
       "english": "RELOAD",

--- a/src/rfsuite/i18n/es.json
+++ b/src/rfsuite/i18n/es.json
@@ -1973,6 +1973,16 @@
     }
   },
   "app": {
+    "header_configuration": {
+      "english": "Configuration",
+      "needs_translation": true,
+      "translation": "Configuración"
+    },
+    "header_system": {
+      "english": "System",
+      "needs_translation": true,
+      "translation": "Sistema"
+    },
     "btn_cancel": {
       "english": "CANCEL",
       "needs_translation": false,
@@ -4150,9 +4160,9 @@
           "translation": "D"
         },
         "f": {
-          "english": "F",
+          "english": "FF",
           "needs_translation": false,
-          "translation": "F"
+          "translation": "FF"
         },
         "help_p1": {
           "english": "FeedForward (Roll/Pitch): Start at 70, increase until stops are sharp with no drift. Keep roll and pitch equal.",
@@ -4170,11 +4180,6 @@
           "translation": "Ganacia P/I/D de cola: Incremente P hasta un leve tambaleo durante embudos, luego disminuya levemente. Aumente I hasta que la cola se mantenga firme durante movimientos rápidos (demasiado alto causa un meneo lento de la cola). Ajuste D para paradas suaves - más alto para servos lentos, más bajo para rápidos."
         },
         "help_p4": {
-          "english": "Tail Stop Gain (CW/CCW): Adjust separately for clean, bounce-free stops in both directions.",
-          "needs_translation": false,
-          "translation": "Ganancia Detención Cola (Horaria CW/Antihoraria CCW): Ajuste separadamente para detenciones limpias, sin rebotes, en ambos sentidos."
-        },
-        "help_p5": {
           "english": "Test & Adjust: Fly, observe, and fine-tune for best performance in real conditions.",
           "needs_translation": false,
           "translation": "Prueba & Ajuste: Vuele, observe, y afine hasta la mejor performance en condiciones reales."
@@ -6569,7 +6574,7 @@
     "navigation_menu": {
       "english": "MENU",
       "needs_translation": false,
-      "translation": "Menú"
+      "translation": "Atrás"
     },
     "navigation_reload": {
       "english": "RELOAD",

--- a/src/rfsuite/i18n/fr.json
+++ b/src/rfsuite/i18n/fr.json
@@ -1973,6 +1973,16 @@
     }
   },
   "app": {
+    "header_configuration": {
+      "english": "Configuration",
+      "needs_translation": true,
+      "translation": "Configuration"
+    },
+    "header_system": {
+      "english": "System",
+      "needs_translation": true,
+      "translation": "Système"
+    },
     "btn_cancel": {
       "english": "CANCEL",
       "needs_translation": false,
@@ -4150,9 +4160,9 @@
           "translation": "D"
         },
         "f": {
-          "english": "F",
+          "english": "FF",
           "needs_translation": false,
-          "translation": "F"
+          "translation": "FF"
         },
         "help_p1": {
           "english": "FeedForward (Roll/Pitch): Start at 70, increase until stops are sharp with no drift. Keep roll and pitch equal.",
@@ -4170,11 +4180,6 @@
           "translation": "Gains P/I/D de queue: Augmentez P jusqu'a un leger tremblement en funnels, puis reduisez legerement. Montez I jusqu'a un maintien ferme de la queue dans les manoeuvres rapides (trop eleve provoque une oscillation lente). Ajustez D pour des arrets en douceur. Plus eleve pour les servos lents et plus faible pour des servos rapide"
         },
         "help_p4": {
-          "english": "Tail Stop Gain (CW/CCW): Adjust separately for clean, bounce-free stops in both directions.",
-          "needs_translation": false,
-          "translation": "Gain d'arret de la queue (Horaire/Anti-horaire): Ajustez separement pour des arrets nets et sans rebonds dans les deux directions."
-        },
-        "help_p5": {
           "english": "Test & Adjust: Fly, observe, and fine-tune for best performance in real conditions.",
           "needs_translation": false,
           "translation": "Tester & Ajuster : Volez, observez et affinez pour obtenir les meilleures performances dans des conditions reelles."
@@ -6569,7 +6574,7 @@
     "navigation_menu": {
       "english": "MENU",
       "needs_translation": false,
-      "translation": "MENU"
+      "translation": "Retour"
     },
     "navigation_reload": {
       "english": "RELOAD",

--- a/src/rfsuite/i18n/it.json
+++ b/src/rfsuite/i18n/it.json
@@ -1973,10 +1973,20 @@
     }
   },
   "app": {
+    "header_configuration": {
+      "english": "Configuration",
+      "needs_translation": true,
+      "translation": "Configurazione"
+    },
+    "header_system": {
+      "english": "System",
+      "needs_translation": true,
+      "translation": "Sistema"
+    },
     "btn_cancel": {
       "english": "CANCEL",
       "needs_translation": false,
-      "translation": "Configure the motor and speed controller features."
+      "translation": "ANNULLA"
     },
     "btn_close": {
       "english": "CLOSE",
@@ -4150,9 +4160,9 @@
           "translation": "D"
         },
         "f": {
-          "english": "F",
+          "english": "FF",
           "needs_translation": false,
-          "translation": "F"
+          "translation": "FF"
         },
         "help_p1": {
           "english": "FeedForward (Roll/Pitch): Start at 70, increase until stops are sharp with no drift. Keep roll and pitch equal.",
@@ -4170,11 +4180,6 @@
           "translation": "Guadagni P/I/D della coda: aumentare P fino a quando non si nota una leggera oscillazione negli imbuti, quindi diminuire leggermente. Aumentare I fino a quando la coda non rimane ferma nei movimenti bruschi (troppo alto provoca un'oscillazione lenta). Regolare D per arresti fluidi: piu' alto per i servi lenti, piu' basso per quelli veloci."
         },
         "help_p4": {
-          "english": "Tail Stop Gain (CW/CCW): Adjust separately for clean, bounce-free stops in both directions.",
-          "needs_translation": false,
-          "translation": "Guadagno di arresto della coda (CW/CCW): Regolare separatamente per arresti puliti e senza rimbalzi in entrambe le direzioni."
-        },
-        "help_p5": {
           "english": "Test & Adjust: Fly, observe, and fine-tune for best performance in real conditions.",
           "needs_translation": false,
           "translation": "Prova & regola: vola, osserva e regola per ottenere le migliori prestazioni in condizioni reali."
@@ -6569,7 +6574,7 @@
     "navigation_menu": {
       "english": "MENU",
       "needs_translation": false,
-      "translation": "MENU"
+      "translation": "Indietro"
     },
     "navigation_reload": {
       "english": "RELOAD",

--- a/src/rfsuite/i18n/nl.json
+++ b/src/rfsuite/i18n/nl.json
@@ -1973,6 +1973,16 @@
     }
   },
   "app": {
+    "header_configuration": {
+      "english": "Configuration",
+      "needs_translation": true,
+      "translation": "Configuratie"
+    },
+    "header_system": {
+      "english": "System",
+      "needs_translation": true,
+      "translation": "Systeem"
+    },
     "btn_cancel": {
       "english": "CANCEL",
       "needs_translation": false,
@@ -4150,9 +4160,9 @@
           "translation": "D"
         },
         "f": {
-          "english": "F",
+          "english": "FF",
           "needs_translation": false,
-          "translation": "F"
+          "translation": "FF"
         },
         "help_p1": {
           "english": "FeedForward (Roll/Pitch): Start at 70, increase until stops are sharp with no drift. Keep roll and pitch equal.",
@@ -4170,11 +4180,6 @@
           "translation": "Tail P/I/D Gains: Verhoog P tot een lichte wag in hurricanes, en ga dan iets terug. Verhoog I tot de staart locked-in is in harde bewegingen (te hoog veroorzaakt langzame wag). Pas D aan voor soepele stops: hoger voor langzame servo's, lager voor snelle."
         },
         "help_p4": {
-          "english": "Tail Stop Gain (CW/CCW): Adjust separately for clean, bounce-free stops in both directions.",
-          "needs_translation": false,
-          "translation": "Tail Stop Gain (CW/CCW): Afzonderlijk instelbaar voor een zuivere stop in beide richtingen."
-        },
-        "help_p5": {
           "english": "Test & Adjust: Fly, observe, and fine-tune for best performance in real conditions.",
           "needs_translation": false,
           "translation": "Test & Adjust: Vlieg, observeer en optimaliseer voor de beste prestaties onder reële omstandigheden.\n\n"
@@ -6569,7 +6574,7 @@
     "navigation_menu": {
       "english": "MENU",
       "needs_translation": false,
-      "translation": "MENU"
+      "translation": "Terug"
     },
     "navigation_reload": {
       "english": "RELOAD",


### PR DESCRIPTION
Add new headers for configuration and system, update translations, and modify navigation labels

- Added "header_configuration" and "header_system" entries in English, Spanish, French, Italian, and Dutch translations.
- Updated the translation for "F" to "FF" in multiple languages.
- Removed unnecessary help text for tail stop gain in multiple languages.
- Changed navigation menu label from "MENU" to "BACK" in English, Spanish, French, Italian, and Dutch.