### PR TITLE
Centralise task error handling under scheduler pcall

### DIFF
--- a/src/rfsuite/tasks/events/onarm/tasks.lua
+++ b/src/rfsuite/tasks/events/onarm/tasks.lua
@@ -21,14 +21,11 @@ hook.lastContext = nil
 local function loadManifest()
     local fn, err = loadfile(MANIFEST_PATH)
     if not fn then
-        -- Missing manifest is non-fatal; treat as no tasks
         return {}
     end
-    local ok, manifestOrErr = pcall(fn)
-    if not ok then
-        utils.log(string.format("[hook:onarm] manifest error: %s", tostring(manifestOrErr)), "error")
-        return {}
-    end
+
+    local manifestOrErr = fn()
+
     if type(manifestOrErr) ~= "table" then
         return {}
     end

--- a/src/rfsuite/tasks/events/onconnect/tasks/apiversion.lua
+++ b/src/rfsuite/tasks/events/onconnect/tasks/apiversion.lua
@@ -55,27 +55,28 @@ function apiversion.wakeup()
 
                 local wantProto = probeProto
                 local policy = rfsuite.config.msp or {}
-                if policy.allowAutoUpgrade and policy.maxProtocol and policy.maxProtocol >= 2 then if policy.v2MinApiVersion and version_ge(apiVersionString, policy.v2MinApiVersion) then wantProto = 2 end end
+                if policy.allowAutoUpgrade and policy.maxProtocol and policy.maxProtocol >= 2 then
+                    if policy.v2MinApiVersion and version_ge(apiVersionString, policy.v2MinApiVersion) then
+                        wantProto = 2
+                    end
+                end
 
                 if wantProto ~= rfsuite.config.mspProtocolVersion then
                     rfsuite.config.mspProtocolVersion = wantProto
                     rfsuite.session.mspProtocolVersion = wantProto
 
                     if rfsuite.tasks.msp.common.setProtocolVersion then
-                        pcall(rfsuite.tasks.msp.common.setProtocolVersion, wantProto)
+                        rfsuite.tasks.msp.common.setProtocolVersion(wantProto)
                     elseif rfsuite.tasks.msp.reset then
-
-                        pcall(rfsuite.tasks.msp.reset)
+                        rfsuite.tasks.msp.reset()
                     end
 
                     rfsuite.utils.log(string.format("MSP protocol upgraded to v%d (api %s)", wantProto, apiVersionString), "info")
                     rfsuite.utils.log(string.format("MSP protocol upgraded to v%d (api %s)", wantProto, apiVersionString), "connect")
                 else
-
                     rfsuite.config.mspProtocolVersion = wantProto
                 end
             else
-
                 rfsuite.config.mspProtocolVersion = restoreProto
                 rfsuite.utils.log(string.format("MSP protocol restored to v%d", restoreProto), "info")
                 rfsuite.utils.log(string.format("MSP protocol restored to v%d", restoreProto), "connect")
@@ -83,9 +84,9 @@ function apiversion.wakeup()
 
             rfsuite.session.apiVersion = version
             rfsuite.session.apiVersionInvalid = false
-            if rfsuite.session.apiVersion then 
-                rfsuite.utils.log("API version: " .. rfsuite.session.apiVersion, "info") 
-                rfsuite.utils.log("API version: " .. rfsuite.session.apiVersion, "connect") 
+            if rfsuite.session.apiVersion then
+                rfsuite.utils.log("API version: " .. rfsuite.session.apiVersion, "info")
+                rfsuite.utils.log("API version: " .. rfsuite.session.apiVersion, "connect")
             end
         end)
         API.setUUID("22a683cb-db0e-439f-8d04-04687c9360f3")
@@ -98,12 +99,12 @@ function apiversion.reset()
     rfsuite.session.apiVersionInvalid = nil
     mspCallMade = false
 end
--- 
-function apiversion.isComplete() 
-    if rfsuite.session.apiVersion ~= nil then 
+
+function apiversion.isComplete()
+    if rfsuite.session.apiVersion ~= nil then
         rfsuite.utils.playFileCommon("beep.wav")
-        return true 
-    end 
+        return true
+    end
 end
 
 return apiversion

--- a/src/rfsuite/tasks/events/ondisarm/tasks.lua
+++ b/src/rfsuite/tasks/events/ondisarm/tasks.lua
@@ -21,14 +21,11 @@ hook.lastContext = nil
 local function loadManifest()
     local fn, err = loadfile(MANIFEST_PATH)
     if not fn then
-        -- Missing manifest is non-fatal; treat as no tasks
         return {}
     end
-    local ok, manifestOrErr = pcall(fn)
-    if not ok then
-        utils.log(string.format("[hook:ondisarm] manifest error: %s", tostring(manifestOrErr)), "error")
-        return {}
-    end
+
+    local manifestOrErr = fn()
+
     if type(manifestOrErr) ~= "table" then
         return {}
     end
@@ -75,9 +72,6 @@ function hook.wakeup()
         return
     end
 
-    -- NOTE: Framework only. When you add tasks, you can implement execution here
-    -- similarly to onconnect/postconnect (timeouts, retries, etc).
-    -- For now we just clear the latch so the hook only fires once per edge.
     active = false
 end
 

--- a/src/rfsuite/tasks/events/onflightmode/tasks.lua
+++ b/src/rfsuite/tasks/events/onflightmode/tasks.lua
@@ -21,14 +21,11 @@ hook.lastContext = nil
 local function loadManifest()
     local fn, err = loadfile(MANIFEST_PATH)
     if not fn then
-        -- Missing manifest is non-fatal; treat as no tasks
         return {}
     end
-    local ok, manifestOrErr = pcall(fn)
-    if not ok then
-        utils.log(string.format("[hook:onflightmode] manifest error: %s", tostring(manifestOrErr)), "error")
-        return {}
-    end
+
+    local manifestOrErr = fn()
+
     if type(manifestOrErr) ~= "table" then
         return {}
     end
@@ -75,9 +72,6 @@ function hook.wakeup()
         return
     end
 
-    -- NOTE: Framework only. When you add tasks, you can implement execution here
-    -- similarly to onconnect/postconnect (timeouts, retries, etc).
-    -- For now we just clear the latch so the hook only fires once per edge.
     active = false
 end
 

--- a/src/rfsuite/tasks/events/onmodelchange/tasks.lua
+++ b/src/rfsuite/tasks/events/onmodelchange/tasks.lua
@@ -21,14 +21,11 @@ hook.lastContext = nil
 local function loadManifest()
     local fn, err = loadfile(MANIFEST_PATH)
     if not fn then
-        -- Missing manifest is non-fatal; treat as no tasks
         return {}
     end
-    local ok, manifestOrErr = pcall(fn)
-    if not ok then
-        utils.log(string.format("[hook:onmodelchange] manifest error: %s", tostring(manifestOrErr)), "error")
-        return {}
-    end
+
+    local manifestOrErr = fn()
+
     if type(manifestOrErr) ~= "table" then
         return {}
     end
@@ -75,9 +72,6 @@ function hook.wakeup()
         return
     end
 
-    -- NOTE: Framework only. When you add tasks, you can implement execution here
-    -- similarly to onconnect/postconnect (timeouts, retries, etc).
-    -- For now we just clear the latch so the hook only fires once per edge.
     active = false
 end
 

--- a/src/rfsuite/tasks/events/ontransportchange/tasks.lua
+++ b/src/rfsuite/tasks/events/ontransportchange/tasks.lua
@@ -21,14 +21,11 @@ hook.lastContext = nil
 local function loadManifest()
     local fn, err = loadfile(MANIFEST_PATH)
     if not fn then
-        -- Missing manifest is non-fatal; treat as no tasks
         return {}
     end
-    local ok, manifestOrErr = pcall(fn)
-    if not ok then
-        utils.log(string.format("[hook:ontransportchange] manifest error: %s", tostring(manifestOrErr)), "error")
-        return {}
-    end
+
+    local manifestOrErr = fn()
+
     if type(manifestOrErr) ~= "table" then
         return {}
     end
@@ -75,9 +72,6 @@ function hook.wakeup()
         return
     end
 
-    -- NOTE: Framework only. When you add tasks, you can implement execution here
-    -- similarly to onconnect/postconnect (timeouts, retries, etc).
-    -- For now we just clear the latch so the hook only fires once per edge.
     active = false
 end
 


### PR DESCRIPTION
**Centralised error handling for task execution**

All task and hook modules now execute without local pcall() wrappers.
Error protection has been consolidated into a single top-level scheduler pcall, which provides:

Zero per-task overhead (no hot-path pcall cost)

Consistent failure behaviour across all tasks and hooks

Cleaner task implementations (no defensive boilerplate)

Improved performance and reduced GC churn

Deterministic crash location when a task faults

Task modules are now treated as trusted execution units.
Any runtime error bubbles directly to the scheduler boundary, where it is safely contained.