### PR TITLE
Defer reload full until msp call is complete

### DIFF
--- a/src/rfsuite/app/tasks.lua
+++ b/src/rfsuite/app/tasks.lua
@@ -258,6 +258,9 @@ local function telemetryAndPageStateUpdates()
 end
 
 local function performReloadActions()
+
+    if rfsuite.session.mspBusy then return end
+
     local app = rfsuite.app
     if app.triggers.reload then
         app.triggers.reload = false


### PR DESCRIPTION
Update allows pages that issue a reloadFull to complete their msp call before reloading.