### PR TITLE
Harden msp sensor wakeup check if admin running

### DIFF
--- a/src/rfsuite/tasks/scheduler/sensors/msp.lua
+++ b/src/rfsuite/tasks/scheduler/sensors/msp.lua
@@ -399,7 +399,7 @@ function msp.wakeup()
     local armSource = tasks.telemetry.getSensorSource("armflags")
     if not armSource then return end
     local isArmed = armSource:value()
-    local isAdmin = rfsuite.app.guiIsRunning
+    local isAdmin = (rfsuite.app and rfsuite.app.guiIsRunning) or false
 
     local isConnected = rfsuite.session.isConnected == true
 


### PR DESCRIPTION
Small fix to harden the is check on isAdmin runniing in msp sensors