### PR TITLE
Pcall should print error and not rely on sub system

### DIFF
--- a/src/rfsuite/app/app.lua
+++ b/src/rfsuite/app/app.lua
@@ -31,7 +31,7 @@ end
 function app.wakeup()
     local success, err = pcall(app.wakeup_protected)
     if not success then
-        log("Error in wakeup_protected: " .. tostring(err), "error")
+        print("Error in wakeup_protected: " .. tostring(err))
     end
 end
 

--- a/src/rfsuite/tasks/tasks.lua
+++ b/src/rfsuite/tasks/tasks.lua
@@ -712,7 +712,6 @@ function tasks.wakeup_protected()
             end
         else
             if tasks.callback then
-                tasks.msp.wakeup()
                 tasks.callback.wakeup()
             end
         end

--- a/src/rfsuite/tasks/tasks.lua
+++ b/src/rfsuite/tasks/tasks.lua
@@ -712,6 +712,7 @@ function tasks.wakeup_protected()
             end
         else
             if tasks.callback then
+                tasks.msp.wakeup()
                 tasks.callback.wakeup()
             end
         end
@@ -787,7 +788,7 @@ end
 function tasks.wakeup()
     local ok, err = pcall(tasks.wakeup_protected)
     if not ok then
-        utils.log("[scheduler] Task scheduler error: " .. tostring(err), "error")
+        print("[scheduler] Task scheduler error: " .. tostring(err))
     end
 end
 

--- a/src/rfsuite/widgets/dashboard/dashboard.lua
+++ b/src/rfsuite/widgets/dashboard/dashboard.lua
@@ -1358,7 +1358,7 @@ end
 function dashboard.wakeup()
     local success, err = pcall(dashboard.wakeup_protected)
     if not success then
-        log("Error in wakeup_protected: " .. tostring(err), "error")
+        print("Error in wakeup_protected: " .. tostring(err))
     end
 end
 


### PR DESCRIPTION
When an error is passed to pcall; we should use print - not log as we cant garuantee logging will output anything