### PR TITLE
Add check for events being active to reduce cpu burn

### DIFF
--- a/src/rfsuite/tasks/events/onarm/tasks.lua
+++ b/src/rfsuite/tasks/events/onarm/tasks.lua
@@ -64,6 +64,11 @@ function hook.resetAllTasks()
     hook.reset()
 end
 
+-- Tell the scheduler whether this hook currently has work pending.
+function hook.active()
+    return active
+end
+
 -- Runs hook tasks (if/when they exist). Safe no-op when the manifest is empty.
 function hook.wakeup()
     if not active then return end

--- a/src/rfsuite/tasks/events/ondisarm/tasks.lua
+++ b/src/rfsuite/tasks/events/ondisarm/tasks.lua
@@ -64,6 +64,11 @@ function hook.resetAllTasks()
     hook.reset()
 end
 
+-- Tell the scheduler whether this hook currently has work pending.
+function hook.active()
+    return active
+end
+
 -- Runs hook tasks (if/when they exist). Safe no-op when the manifest is empty.
 function hook.wakeup()
     if not active then return end

--- a/src/rfsuite/tasks/events/onflightmode/tasks.lua
+++ b/src/rfsuite/tasks/events/onflightmode/tasks.lua
@@ -64,6 +64,11 @@ function hook.resetAllTasks()
     hook.reset()
 end
 
+-- Tell the scheduler whether this hook currently has work pending.
+function hook.active()
+    return active
+end
+
 -- Runs hook tasks (if/when they exist). Safe no-op when the manifest is empty.
 function hook.wakeup()
     if not active then return end

--- a/src/rfsuite/tasks/events/onmodelchange/tasks.lua
+++ b/src/rfsuite/tasks/events/onmodelchange/tasks.lua
@@ -58,6 +58,11 @@ function hook.reset()
     hook.lastContext = nil
 end
 
+-- Tell the scheduler whether this hook currently has work pending.
+function hook.active()
+    return active
+end
+
 -- Compatibility with other task modules
 function hook.resetAllTasks()
     taskQueue = nil

--- a/src/rfsuite/tasks/events/ontransportchange/tasks.lua
+++ b/src/rfsuite/tasks/events/ontransportchange/tasks.lua
@@ -64,6 +64,11 @@ function hook.resetAllTasks()
     hook.reset()
 end
 
+-- Tell the scheduler whether this hook currently has work pending.
+function hook.active()
+    return active
+end
+
 -- Runs hook tasks (if/when they exist). Safe no-op when the manifest is empty.
 function hook.wakeup()
     if not active then return end


### PR DESCRIPTION
Some events never implimented the .active() call resulting in excessive cpu time.