### PR TITLE
Audio announcement

### DIFF
--- a/bin/i18n/json/app/de.json
+++ b/bin/i18n/json/app/de.json
@@ -3259,7 +3259,7 @@
     "rates": {
       "help_table_5_p2": {
         "english": "Max Rate: Maximum rotation rate at full stick deflection in degrees per second.",
-        "translation": "Maximalrate: Maximale Rotationsgeschwindigkeit bei vollem Knüppelausschlag in Grad pro Sekunde.",
+        "translation": "Maximaldrehrate: Maximale Rotationsgeschwindigkeit bei vollem Knüppelausschlag in Grad pro Sekunde.",
         "needs_translation": false
       },
       "rotorflight": {
@@ -3274,7 +3274,7 @@
       },
       "max_rate": {
         "english": "Max Rate",
-        "translation": "Max. Rate",
+        "translation": "Max. Drehrate",
         "needs_translation": false
       },
       "help_table_4_p3": {
@@ -3284,7 +3284,7 @@
       },
       "rate": {
         "english": "Rate",
-        "translation": "Rate",
+        "translation": "Drehrate",
         "needs_translation": false
       },
       "shape": {
@@ -3299,7 +3299,7 @@
       },
       "help_table_4_p2": {
         "english": "Max Rate: Maximum rotation rate at full stick deflection in degrees per second.",
-        "translation": "Maximalrate: Maximale Rotationsgeschwindigkeit bei vollem Knüppelausschlag in Grad pro Sekunde.",
+        "translation": "Maximaldrehrate: Maximale Rotationsgeschwindigkeit bei vollem Knüppelausschlag in Grad pro Sekunde.",
         "needs_translation": false
       },
       "center_sensitivity": {
@@ -3349,7 +3349,7 @@
       },
       "superrate": {
         "english": "SuperRate",
-        "translation": "SuperRate",
+        "translation": "Super-Drehrate",
         "needs_translation": false
       },
       "help_table_2_p3": {
@@ -3374,7 +3374,7 @@
       },
       "name": {
         "english": "Rates",
-        "translation": "Rates",
+        "translation": "Drehraten",
         "needs_translation": false
       },
       "help_table_5_p3": {
@@ -3394,7 +3394,7 @@
       },
       "help_table_1_p2": {
         "english": "SuperRate: Increases maximum rotation rate while reducing sensitivity around half stick.",
-        "translation": "SuperRate: Erhöht die maximale Rotationsgeschwindigkeit und verringert gleichzeitig die Empfindlichkeit in der Mitte des Knüppelwegs.",
+        "translation": "Super-Drehrate: Erhöht die maximale Rotationsgeschwindigkeit und verringert gleichzeitig die Empfindlichkeit in der Mitte des Knüppelwegs.",
         "needs_translation": false
       },
       "help_default_p2": {
@@ -3424,12 +3424,12 @@
       },
       "help_table_1_p1": {
         "english": "RC Rate: Maximum rotation rate at full stick deflection.",
-        "translation": "RC-Rate: Maximale Rotationsgeschwindigkeit bei vollem Knüppelausschlag.",
+        "translation": "RC-Drehrate: Maximale Rotationsgeschwindigkeit bei vollem Knüppelausschlag.",
         "needs_translation": false
       },
       "rc_rate": {
         "english": "RC Rate",
-        "translation": "RC-Rate",
+        "translation": "RC-Drehrate",
         "needs_translation": false
       },
       "help_table_2_p1": {
@@ -3449,7 +3449,22 @@
       },
       "help_table_3_p1": {
         "english": "RC Rate: Maximum rotation rate at full stick deflection.",
-        "translation": "RC-Rate: Maximale Rotationsgeschwindigkeit bei vollem Knüppelausschlag.",
+        "translation": "RC-Drehrate: Maximale Rotationsgeschwindigkeit bei vollem Knüppelausschlag.",
+        "needs_translation": false
+      },
+      "help_table_6_p1": {
+        "english": "Rate: Maximum rotation rate at full stick deflection in degrees per second.",
+        "translation": "Drehrate: Maximale Rotationsgeschwindigkeit bei vollem Knüppelausschlag in Grad pro Sekunde.",
+        "needs_translation": false
+      },
+      "help_table_6_p2": {
+        "english": "Shape: Shifts the vertex of the control curve. Up to this point, the signal translation is linear. This defines how far the stick travel remains proportional before the curve becomes progressive.",
+        "translation": "Form: Verschiebt den Scheitelpunkt der Steuerkurve. Bis zu diesem Punkt verläuft die Signalumsetzung linear. Dies definiert, wie weit der Knüppelweg proportional bleibt, bevor die Kurve progressiv wird.",
+        "needs_translation": false
+      },
+      "help_table_6_p3": {
+        "english": "Expo: Reduces sensitivity near the stick's center where fine controls are needed.",
+        "translation": "Expo: Verringert die Empfindlichkeit nahe der Knüppelmitte für feinere Steuerung.",
         "needs_translation": false
       }
     },

--- a/bin/i18n/json/app/de.json
+++ b/bin/i18n/json/app/de.json
@@ -619,6 +619,21 @@
         "english": "Adjustment Value",
         "translation": "Einstellungswert",
         "needs_translation": false
+      },
+      "otherSoundSettings": {
+        "english": "Other",
+        "translation": "Sonstiges",
+        "needs_translation": false
+      },
+      "modelAnnouncement": {
+        "english": "Model announcement",
+        "translation": "Modellansage",
+        "needs_translation": false
+      },
+      "help_modelAnnouncement": {
+        "english": "Model announcement requires a .wav file in the 'sounds' folder matching the model name (e.g. 'racer.wav' for model 'racer').",
+        "translation": "Für die Modellansage wird eine .wav-Datei im Ordner 'sounds' benötigt, die dem Modellnamen entspricht (z. B. 'racer.wav' für das Modell 'racer').",
+        "needs_translation": false
       }
     },
     "telemetry": {

--- a/bin/i18n/json/app/de.json
+++ b/bin/i18n/json/app/de.json
@@ -9,6 +9,11 @@
     "translation": "System",
     "needs_translation": false
   },
+  "header_help": {
+    "english": "Help",
+    "translation": "Hilfe",
+    "needs_translation": false
+  },
   "btn_ok": {
     "english": "          OK           ",
     "translation": "          OK           ",
@@ -631,8 +636,8 @@
         "needs_translation": false
       },
       "help_modelAnnouncement": {
-        "english": "Model announcement requires a .wav file in the 'sounds' folder matching the model name (e.g. 'racer.wav' for model 'racer').",
-        "translation": "Für die Modellansage wird eine .wav-Datei im Ordner 'sounds' benötigt, die dem Modellnamen entspricht (z. B. 'racer.wav' für das Modell 'racer').",
+        "english": "Model announcement requires a .wav file in the 'audio' folder matching the model name (e.g. 'racer.wav' for model 'racer').",
+        "translation": "Für die Modellansage wird eine .wav-Datei im Ordner 'audio' benötigt, die dem Modellnamen entspricht (z. B. 'racer.wav' für das Modell 'racer').",
         "needs_translation": false
       }
     },

--- a/bin/i18n/json/app/en.json
+++ b/bin/i18n/json/app/en.json
@@ -9,6 +9,11 @@
     "needs_translation": false,
     "translation": "System"
   },
+  "header_help": {
+    "english": "Help",
+    "translation": "Help",
+    "needs_translation": false
+  },
   "btn_ok": {
     "english": "          OK           ",
     "translation": "          OK           ",
@@ -631,8 +636,8 @@
         "needs_translation": false
       },
       "help_modelAnnouncement": {
-        "english": "Model announcement requires a .wav file in the 'sounds' folder matching the model name (e.g. 'racer.wav' for model 'racer').",
-        "translation": "Model announcement requires a .wav file in the 'sounds' folder matching the model name (e.g. 'racer.wav' for model 'racer').",
+        "english": "Model announcement requires a .wav file in the 'audio' folder matching the model name (e.g. 'racer.wav' for model 'racer').",
+        "translation": "Model announcement requires a .wav file in the 'audio' folder matching the model name (e.g. 'racer.wav' for model 'racer').",
         "needs_translation": false
       }
     },

--- a/bin/i18n/json/app/en.json
+++ b/bin/i18n/json/app/en.json
@@ -3451,6 +3451,21 @@
         "english": "RC Rate: Maximum rotation rate at full stick deflection.",
         "translation": "RC Rate: Maximum rotation rate at full stick deflection.",
         "needs_translation": false
+      },
+      "help_table_6_p1": {
+        "english": "Rate: Maximum rotation rate at full stick deflection in degrees per second.",
+        "translation": "Rate: Maximum rotation rate at full stick deflection in degrees per second.",
+        "needs_translation": false
+      },
+      "help_table_6_p2": {
+        "english": "Shape: Shifts the vertex of the control curve. Up to this point, the signal translation is linear. This defines how far the stick travel remains proportional before the curve becomes progressive.",
+        "translation": "Shape: Shifts the vertex of the control curve. Up to this point, the signal translation is linear. This defines how far the stick travel remains proportional before the curve becomes progressive.",
+        "needs_translation": false
+      },
+      "help_table_6_p3": {
+        "english": "Expo: Reduces sensitivity near the stick's center where fine controls are needed.",
+        "translation": "Expo: Reduces sensitivity near the stick's center where fine controls are needed.",
+        "needs_translation": false
       }
     },
     "mixer": {

--- a/bin/i18n/json/app/en.json
+++ b/bin/i18n/json/app/en.json
@@ -619,6 +619,21 @@
         "english": "Adjustment Value",
         "translation": "Adjustment Value",
         "needs_translation": false
+      },
+      "otherSoundSettings": {
+        "english": "Other",
+        "translation": "Other",
+        "needs_translation": false
+      },
+      "modelAnnouncement": {
+        "english": "Model announcement",
+        "translation": "Model announcement",
+        "needs_translation": false
+      },
+      "help_modelAnnouncement": {
+        "english": "Model announcement requires a .wav file in the 'sounds' folder matching the model name (e.g. 'racer.wav' for model 'racer').",
+        "translation": "Model announcement requires a .wav file in the 'sounds' folder matching the model name (e.g. 'racer.wav' for model 'racer').",
+        "needs_translation": false
       }
     },
     "telemetry": {

--- a/bin/i18n/json/app/es.json
+++ b/bin/i18n/json/app/es.json
@@ -3451,6 +3451,21 @@
         "english": "RC Rate: Maximum rotation rate at full stick deflection.",
         "translation": "Tasa RC: Tasa de rotación máxima durante el desplazamiento máximo del joystick.",
         "needs_translation": false
+      },
+      "help_table_6_p1": {
+        "english": "Rate: Maximum rotation rate at full stick deflection in degrees per second.",
+        "translation": "Tasa: Tasa máxima de rotación durante el desplazamiento máximo del joystick en grados por segundo.",
+        "needs_translation": false
+      },
+      "help_table_6_p2": {
+        "english": "Shape: Shifts the vertex of the control curve. Up to this point, the signal translation is linear. This defines how far the stick travel remains proportional before the curve becomes progressive.",
+        "translation": "Forma: Desplaza el vértice de la curva de mando. Hasta este punto, la conversión de la señal es lineal. Esto define hasta qué punto el recorrido del stick se mantiene proporcional antes de que la curva se vuelva progresiva.",
+        "needs_translation": false
+      },
+      "help_table_6_p3": {
+        "english": "Expo: Reduces sensitivity near the stick's center where fine controls are needed.",
+        "translation": "Expo: Reduce la sensibilidad cerca del centro del joystick donde hacen falta controles finos.",
+        "needs_translation": false
       }
     },
     "mixer": {

--- a/bin/i18n/json/app/es.json
+++ b/bin/i18n/json/app/es.json
@@ -9,6 +9,11 @@
     "translation": "Sistema",
     "needs_translation": true
   },
+  "header_help": {
+    "english": "Help",
+    "translation": "Ayuda",
+    "needs_translation": false
+  },
   "btn_ok": {
     "english": "          OK           ",
     "translation": "          OK           ",
@@ -631,8 +636,8 @@
         "needs_translation": false
       },
       "help_modelAnnouncement": {
-        "english": "Model announcement requires a .wav file in the 'sounds' folder matching the model name (e.g. 'racer.wav' for model 'racer').",
-        "translation": "El anuncio del modelo requiere un archivo .wav en la carpeta 'sounds' que coincida con el nombre del modelo (por ejemplo, 'racer.wav' para el modelo 'racer').",
+        "english": "Model announcement requires a .wav file in the 'audio' folder matching the model name (e.g. 'racer.wav' for model 'racer').",
+        "translation": "El anuncio del modelo requiere un archivo .wav en la carpeta 'audio' que coincida con el nombre del modelo (por ejemplo, 'racer.wav' para el modelo 'racer').",
         "needs_translation": false
       }
     },

--- a/bin/i18n/json/app/es.json
+++ b/bin/i18n/json/app/es.json
@@ -619,6 +619,21 @@
         "english": "Adjustment Value",
         "translation": "Valor de Ajuste",
         "needs_translation": false
+      },
+      "otherSoundSettings": {
+        "english": "Other",
+        "translation": "Otros",
+        "needs_translation": false
+      },
+      "modelAnnouncement": {
+        "english": "Model announcement",
+        "translation": "Anuncio de modelo",
+        "needs_translation": false
+      },
+      "help_modelAnnouncement": {
+        "english": "Model announcement requires a .wav file in the 'sounds' folder matching the model name (e.g. 'racer.wav' for model 'racer').",
+        "translation": "El anuncio del modelo requiere un archivo .wav en la carpeta 'sounds' que coincida con el nombre del modelo (por ejemplo, 'racer.wav' para el modelo 'racer').",
+        "needs_translation": false
       }
     },
     "telemetry": {

--- a/bin/i18n/json/app/fr.json
+++ b/bin/i18n/json/app/fr.json
@@ -3451,6 +3451,21 @@
         "english": "RC Rate: Maximum rotation rate at full stick deflection.",
         "translation": "Taux RC : Taux de rotation maximal a pleine deviation du manche.",
         "needs_translation": false
+      },
+      "help_table_6_p1": {
+        "english": "Rate: Maximum rotation rate at full stick deflection in degrees per second.",
+        "translation": "Taux : Taux de rotation maximal a pleine deviation du manche en degres par seconde.",
+        "needs_translation": false
+      },
+      "help_table_6_p2": {
+        "english": "Shape: Shifts the vertex of the control curve. Up to this point, the signal translation is linear. This defines how far the stick travel remains proportional before the curve becomes progressive.",
+        "translation": "Forme: Déplace le sommet de la courbe de contrôle. Jusqu'à ce point, la conversion du signal est linéaire. Cela définit jusqu'où la course du manche reste proportionnelle avant que la courbe ne devienne progressive.",
+        "needs_translation": false
+      },
+      "help_table_6_p3": {
+        "english": "Expo: Reduces sensitivity near the stick's center where fine controls are needed.",
+        "translation": "Expo : Reduit la sensibilite pres du centre du manche ou des controles fins sont necessaires.",
+        "needs_translation": false
       }
     },
     "mixer": {

--- a/bin/i18n/json/app/fr.json
+++ b/bin/i18n/json/app/fr.json
@@ -619,6 +619,21 @@
         "english": "Adjustment Value",
         "translation": "Valeur de réglage",
         "needs_translation": false
+      },
+      "otherSoundSettings": {
+        "english": "Other",
+        "translation": "Autre",
+        "needs_translation": false
+      },
+      "modelAnnouncement": {
+        "english": "Model announcement",
+        "translation": "Annonce du modèle",
+        "needs_translation": false
+      },
+      "help_modelAnnouncement": {
+        "english": "Model announcement requires a .wav file in the 'sounds' folder matching the model name (e.g. 'racer.wav' for model 'racer').",
+        "translation": "L'annonce du modèle nécessite un fichier .wav dans le dossier 'sounds' correspondant au nom du modèle (par ex. 'racer.wav' pour le modèle 'racer').",
+        "needs_translation": false
       }
     },
     "telemetry": {

--- a/bin/i18n/json/app/fr.json
+++ b/bin/i18n/json/app/fr.json
@@ -9,6 +9,11 @@
     "translation": "Système",
     "needs_translation": true
   },
+  "header_help": {
+    "english": "Help",
+    "translation": "Aide",
+    "needs_translation": false
+  },
   "btn_ok": {
     "english": "          OK           ",
     "translation": "          OK           ",
@@ -631,8 +636,8 @@
         "needs_translation": false
       },
       "help_modelAnnouncement": {
-        "english": "Model announcement requires a .wav file in the 'sounds' folder matching the model name (e.g. 'racer.wav' for model 'racer').",
-        "translation": "L'annonce du modèle nécessite un fichier .wav dans le dossier 'sounds' correspondant au nom du modèle (par ex. 'racer.wav' pour le modèle 'racer').",
+        "english": "Model announcement requires a .wav file in the 'audio' folder matching the model name (e.g. 'racer.wav' for model 'racer').",
+        "translation": "L'annonce du modèle nécessite un fichier .wav dans le dossier 'audio' correspondant au nom du modèle (par ex. 'racer.wav' pour le modèle 'racer').",
         "needs_translation": false
       }
     },

--- a/bin/i18n/json/app/it.json
+++ b/bin/i18n/json/app/it.json
@@ -3449,7 +3449,22 @@
       },
       "help_table_3_p1": {
         "english": "RC Rate: Maximum rotation rate at full stick deflection.",
-        "translation": "RC Rate: Velocita' di rotazione massima a piena deflessione dello Stick.",
+        "translation": "RC Rate: Velocita' di rotazione massima a piena deflessione dello stick.",
+        "needs_translation": false
+      },
+      "help_table_6_p1": {
+        "english": "Rate: Maximum rotation rate at full stick deflection in degrees per second.",
+        "translation": "Rate: Maximum rotation rate at full stick deflection in degrees per second.",
+        "needs_translation": true
+      },
+      "help_table_6_p2": {
+        "english": "Shape: Shifts the vertex of the control curve. Up to this point, the signal translation is linear. This defines how far the stick travel remains proportional before the curve becomes progressive.",
+        "translation": "Forma: Sposta il vertice della curva di controllo. Fino a questo punto, la conversione del segnale è lineare. Questo definisce quanto il movimento dello stick rimanga proporzionale prima che la curva diventi progressiva.",
+        "needs_translation": false
+      },
+      "help_table_6_p3": {
+        "english": "Expo: Reduces sensitivity near the stick's center where fine controls are needed.",
+        "translation": "Expo: Riduce la sensibilità vicino al centro dello stick dove sono necessari controlli precisi.",
         "needs_translation": false
       }
     },

--- a/bin/i18n/json/app/it.json
+++ b/bin/i18n/json/app/it.json
@@ -619,6 +619,21 @@
         "english": "Adjustment Value",
         "translation": "Valore Regolazione",
         "needs_translation": false
+      },
+      "otherSoundSettings": {
+        "english": "Other",
+        "translation": "Altro",
+        "needs_translation": false
+      },
+      "modelAnnouncement": {
+        "english": "Model announcement",
+        "translation": "Annuncio modello",
+        "needs_translation": false
+      },
+      "help_modelAnnouncement": {
+        "english": "Model announcement requires a .wav file in the 'sounds' folder matching the model name (e.g. 'racer.wav' for model 'racer').",
+        "translation": "L'annuncio del modello richiede un file .wav nella cartella 'sounds' corrispondente al nome del modello (ad es. 'racer.wav' per il modello 'racer').",
+        "needs_translation": false
       }
     },
     "telemetry": {

--- a/bin/i18n/json/app/it.json
+++ b/bin/i18n/json/app/it.json
@@ -9,6 +9,11 @@
     "translation": "Sistema",
     "needs_translation": true
   },
+  "header_help": {
+    "english": "Help",
+    "translation": "Help",
+    "needs_translation": true
+  },
   "btn_ok": {
     "english": "          OK           ",
     "translation": "          OK           ",
@@ -631,8 +636,8 @@
         "needs_translation": false
       },
       "help_modelAnnouncement": {
-        "english": "Model announcement requires a .wav file in the 'sounds' folder matching the model name (e.g. 'racer.wav' for model 'racer').",
-        "translation": "L'annuncio del modello richiede un file .wav nella cartella 'sounds' corrispondente al nome del modello (ad es. 'racer.wav' per il modello 'racer').",
+        "english": "Model announcement requires a .wav file in the 'audio' folder matching the model name (e.g. 'racer.wav' for model 'racer').",
+        "translation": "L'annuncio del modello richiede un file .wav nella cartella 'audio' corrispondente al nome del modello (ad es. 'racer.wav' per il modello 'racer').",
         "needs_translation": false
       }
     },

--- a/bin/i18n/json/app/nl.json
+++ b/bin/i18n/json/app/nl.json
@@ -619,6 +619,21 @@
         "english": "Adjustment Value",
         "translation": "Aanpassing waarde",
         "needs_translation": false
+      },
+      "otherSoundSettings": {
+        "english": "Other",
+        "translation": "Overige",
+        "needs_translation": false
+      },
+      "modelAnnouncement": {
+        "english": "Model announcement",
+        "translation": "Model aankondiging",
+        "needs_translation": false
+      },
+      "help_modelAnnouncement": {
+        "english": "Model announcement requires a .wav file in the 'sounds' folder matching the model name (e.g. 'racer.wav' for model 'racer').",
+        "translation": "Model aankondiging vereist een .wav bestand in de 'sounds' map dat overeenkomt met de modelnaam (bijv. 'racer.wav' voor model 'racer').",
+        "needs_translation": false
       }
     },
     "telemetry": {

--- a/bin/i18n/json/app/nl.json
+++ b/bin/i18n/json/app/nl.json
@@ -3451,6 +3451,21 @@
         "english": "RC Rate: Maximum rotation rate at full stick deflection.",
         "translation": "RC Rate: Maximale rotatie bij volledige stick inut.",
         "needs_translation": false
+      },
+      "help_table_6_p1": {
+        "english": "Rate: Maximum rotation rate at full stick deflection in degrees per second.",
+        "translation": "Rate: Maximale rotatiesnelheid bij volledige stickuitslag in graden per seconde.",
+        "needs_translation": false
+      },
+      "help_table_6_p2": {
+        "english": "Shape: Shifts the vertex of the control curve. Up to this point, the signal translation is linear. This defines how far the stick travel remains proportional before the curve becomes progressive.",
+        "translation": "Vorm: Verschuift de vertex van de controle curve. Tot dit punt is de signaalvertaling lineair. Dit bepaalt hoe ver de stick travel proportioneel blijft voordat de curve progressief wordt.",
+        "needs_translation": false
+      },
+      "help_table_6_p3": {
+        "english": "Expo: Reduces sensitivity near the stick's center where fine controls are needed.",
+        "translation": "Expo: Vermindert de gevoeligheid in het midden van de stick, waar nauwkeurige bediening nodig is.",
+        "needs_translation": false
       }
     },
     "mixer": {

--- a/bin/i18n/json/app/nl.json
+++ b/bin/i18n/json/app/nl.json
@@ -9,6 +9,11 @@
     "translation": "Systeem",
     "needs_translation": true
   },
+  "header_help": {
+    "english": "Help",
+    "translation": "Help",
+    "needs_translation": true
+  },
   "btn_ok": {
     "english": "          OK           ",
     "translation": "          OK           ",
@@ -631,8 +636,8 @@
         "needs_translation": false
       },
       "help_modelAnnouncement": {
-        "english": "Model announcement requires a .wav file in the 'sounds' folder matching the model name (e.g. 'racer.wav' for model 'racer').",
-        "translation": "Model aankondiging vereist een .wav bestand in de 'sounds' map dat overeenkomt met de modelnaam (bijv. 'racer.wav' voor model 'racer').",
+        "english": "Model announcement requires a .wav file in the 'audio' folder matching the model name (e.g. 'racer.wav' for model 'racer').",
+        "translation": "Model aankondiging vereist een .wav bestand in de 'audio' map dat overeenkomt met de modelnaam (bijv. 'racer.wav' voor model 'racer').",
         "needs_translation": false
       }
     },

--- a/src/rfsuite/app/lib/ui.lua
+++ b/src/rfsuite/app/lib/ui.lua
@@ -1617,7 +1617,7 @@ function ui.openPageHelp(txtData, title)
         message = txtData
     end
 
-    if not title then title = "Help - " .. (app.lastTitle or "") end
+    if not title then title = "@i18n(app.header_help)@ - " .. (app.lastTitle or "") end
 
     form.openDialog({width = app.lcdWidth, title = title, message = message, buttons = {{label = "@i18n(app.btn_close)@", action = function() return true end}}, options = TEXT_LEFT})
 end

--- a/src/rfsuite/app/lib/ui.lua
+++ b/src/rfsuite/app/lib/ui.lua
@@ -1595,9 +1595,9 @@ function ui.navigationButtons(x, y, w, h)
                         app.Page.onHelpMenu(app.Page)
                     else
                         if help.help[script] then
-                            app.ui.openPageHelp(help.help[script], section)
+                            app.ui.openPageHelp(help.help[script])
                         else
-                            app.ui.openPageHelp(help.help['default'], section)
+                            app.ui.openPageHelp(help.help['default'])
                         end
                     end
                 end
@@ -1609,11 +1609,17 @@ function ui.navigationButtons(x, y, w, h)
     end
 end
 
-function ui.openPageHelp(txtData, section)
+function ui.openPageHelp(txtData, title)
+    local message
+    if type(txtData) == "table" then
+        message = tableConcat(txtData, "\r\n\r\n")
+    else
+        message = txtData
+    end
 
+    if not title then title = "Help - " .. (app.lastTitle or "") end
 
-    local message = tableConcat(txtData, "\r\n\r\n")
-    form.openDialog({width = app.lcdWidth, title = "Help - " .. app.lastTitle, message = message, buttons = {{label = "@i18n(app.btn_close)@", action = function() return true end}}, options = TEXT_LEFT})
+    form.openDialog({width = app.lcdWidth, title = title, message = message, buttons = {{label = "@i18n(app.btn_close)@", action = function() return true end}}, options = TEXT_LEFT})
 end
 
 function ui.injectApiAttributes(formField, f, v)
@@ -2135,6 +2141,16 @@ function ui.adminStatsOverlay()
             drawBlock(key, label, v)
         end
     end
+end
+
+function ui.fieldHelpButton(parent, x, y, title, message)
+    form.addButton(parent, {x = x, y = y, w = 40, h = 30}, {
+        text = "?",
+        options = FONT_S,
+        press = function()
+            ui.openPageHelp(message, title)
+        end
+    })
 end
 
 return ui

--- a/src/rfsuite/app/modules/rates/help.lua
+++ b/src/rfsuite/app/modules/rates/help.lua
@@ -25,4 +25,6 @@ data["help"]["table"][4] = {"@i18n(app.modules.rates.help_table_4_p1)@", "@i18n(
 
 data["help"]["table"][5] = {"@i18n(app.modules.rates.help_table_5_p1)@", "@i18n(app.modules.rates.help_table_5_p2)@", "@i18n(app.modules.rates.help_table_5_p3)@"}
 
+data["help"]["table"][6] = {"@i18n(app.modules.rates.help_table_6_p1)@", "@i18n(app.modules.rates.help_table_6_p2)@", "@i18n(app.modules.rates.help_table_6_p3)@"}
+
 return data

--- a/src/rfsuite/app/modules/rates/rates.lua
+++ b/src/rfsuite/app/modules/rates/rates.lua
@@ -183,5 +183,13 @@ end
 
 local function wakeup() if activateWakeup == true and rfsuite.tasks.msp.mspQueue:isProcessed() then if rfsuite.session.activeRateProfile ~= nil then if rfsuite.app.formFields['title'] then rfsuite.app.formFields['title']:value(rfsuite.app.Page.title .. " #" .. rfsuite.session.activeRateProfile) end end end end
 
+local function onHelpMenu()
 
-return {apidata = apidata, title = "@i18n(app.modules.rates.name)@", reboot = false, eepromWrite = true, refreshOnRateChange = true, rows = mytable.rows, cols = mytable.cols, flagRateChange = flagRateChange, postLoad = postLoad, openPage = openPage, wakeup = wakeup, API = {}}
+    local helpPath = "app/modules/rates/help.lua"
+    local help = assert(loadfile(helpPath))()
+    print("Opening Help for Rate Table: " .. rfsuite.session.activeRateTable)
+    rfsuite.app.ui.openPageHelp(help.help["table"][rfsuite.session.activeRateTable])
+
+end
+
+return {apidata = apidata, title = "@i18n(app.modules.rates.name)@", reboot = false, eepromWrite = true, refreshOnRateChange = true, rows = mytable.rows, cols = mytable.cols, flagRateChange = flagRateChange, postLoad = postLoad, openPage = openPage, wakeup = wakeup, onHelpMenu = onHelpMenu, API = {}}

--- a/src/rfsuite/app/modules/rates/rates.lua
+++ b/src/rfsuite/app/modules/rates/rates.lua
@@ -187,7 +187,6 @@ local function onHelpMenu()
 
     local helpPath = "app/modules/rates/help.lua"
     local help = assert(loadfile(helpPath))()
-    print("Opening Help for Rate Table: " .. rfsuite.session.activeRateTable)
     rfsuite.app.ui.openPageHelp(help.help["table"][rfsuite.session.activeRateTable])
 
 end

--- a/src/rfsuite/app/modules/rates/rates.lua
+++ b/src/rfsuite/app/modules/rates/rates.lua
@@ -183,13 +183,5 @@ end
 
 local function wakeup() if activateWakeup == true and rfsuite.tasks.msp.mspQueue:isProcessed() then if rfsuite.session.activeRateProfile ~= nil then if rfsuite.app.formFields['title'] then rfsuite.app.formFields['title']:value(rfsuite.app.Page.title .. " #" .. rfsuite.session.activeRateProfile) end end end end
 
-local function onHelpMenu()
 
-    local helpPath = "app/modules/rates/help.lua"
-    local help = assert(loadfile(helpPath))()
-
-    rfsuite.app.ui.openPageHelp(help.help["table"][rfsuite.session.activeRateTable], "rates")
-
-end
-
-return {apidata = apidata, title = "@i18n(app.modules.rates.name)@", reboot = false, eepromWrite = true, refreshOnRateChange = true, rows = mytable.rows, cols = mytable.cols, flagRateChange = flagRateChange, postLoad = postLoad, openPage = openPage, wakeup = wakeup, onHelpMenu = onHelpMenu, API = {}}
+return {apidata = apidata, title = "@i18n(app.modules.rates.name)@", reboot = false, eepromWrite = true, refreshOnRateChange = true, rows = mytable.rows, cols = mytable.cols, flagRateChange = flagRateChange, postLoad = postLoad, openPage = openPage, wakeup = wakeup, API = {}}

--- a/src/rfsuite/app/modules/settings/tools/audio_events.lua
+++ b/src/rfsuite/app/modules/settings/tools/audio_events.lua
@@ -4,6 +4,7 @@
 ]] --
 
 local rfsuite = require("rfsuite")
+local lcd = lcd
 
 local config = {}
 local enableWakeup = false
@@ -155,6 +156,22 @@ local function openPage(pageIdx, title, script)
     setFieldEnabled(rfsuite.app.formFields[escFields.enable], true)
     setFieldEnabled(rfsuite.app.formFields[becFields.enable], true)
     setFieldEnabled(rfsuite.app.formFields[fuelFields.enable], true)
+
+    local otherEnabled = config.otherSoundCfg == true
+    local otherPanel = form.addExpansionPanel("@i18n(app.modules.settings.otherSoundSettings)@")
+    otherPanel:open(otherEnabled)
+
+    local w, h = lcd.getWindowSize()
+    local otherModelAnnouncement = otherPanel:addLine("")
+
+    rfsuite.app.ui.fieldHelpButton(otherModelAnnouncement, 0, 13, "@i18n(app.modules.settings.modelAnnouncement)@", "@i18n(app.modules.settings.help_modelAnnouncement)@")
+
+    form.addStaticText(otherModelAnnouncement, {x = 50, y = 10, w = w - 170, h = 35}, "@i18n(app.modules.settings.modelAnnouncement)@")
+
+    formFieldCount = formFieldCount + 1
+    rfsuite.app.formLineCnt = rfsuite.app.formLineCnt + 1
+    rfsuite.app.formFields[formFieldCount] = form.addBooleanField(otherModelAnnouncement, nil, function() return config.otherModelAnnounce == true end, function(val) config.otherModelAnnounce = val end)
+
 
     rfsuite.app.navButtons.save = true
 end

--- a/src/rfsuite/app/modules/settings/tools/audio_events.lua
+++ b/src/rfsuite/app/modules/settings/tools/audio_events.lua
@@ -4,16 +4,9 @@
 ]] --
 
 local rfsuite = require("rfsuite")
-local lcd = lcd
 
 local config = {}
 local enableWakeup = false
-
-local function sensorNameMap(sensorList)
-    local nameMap = {}
-    for _, sensor in ipairs(sensorList) do nameMap[sensor.key] = sensor.name end
-    return nameMap
-end
 
 local function setFieldEnabled(field, enabled) if field and field.enable then field:enable(enabled) end end
 
@@ -35,9 +28,6 @@ local function openPage(pageIdx, title, script)
     local app = rfsuite.app
     if app.formFields then for i = 1, #app.formFields do app.formFields[i] = nil end end
     if app.formLines then for i = 1, #app.formLines do app.formLines[i] = nil end end
-
-    local eventList = rfsuite.tasks.events.telemetry.eventTable
-    local eventNames = sensorNameMap(rfsuite.tasks.telemetry.listSensors())
 
     local savedEvents = rfsuite.preferences.events or {}
     for k, v in pairs(savedEvents) do config[k] = v end
@@ -161,12 +151,12 @@ local function openPage(pageIdx, title, script)
     local otherPanel = form.addExpansionPanel("@i18n(app.modules.settings.otherSoundSettings)@")
     otherPanel:open(otherEnabled)
 
-    local w, h = lcd.getWindowSize()
+    local w = rfsuite.app.lcdWidth
     local otherModelAnnouncement = otherPanel:addLine("")
 
-    rfsuite.app.ui.fieldHelpButton(otherModelAnnouncement, 0, 13, "@i18n(app.modules.settings.modelAnnouncement)@", "@i18n(app.modules.settings.help_modelAnnouncement)@")
+    rfsuite.app.ui.fieldHelpButton(otherModelAnnouncement, 0, rfsuite.app.radio.linePaddingTop, "@i18n(app.modules.settings.modelAnnouncement)@", "@i18n(app.modules.settings.help_modelAnnouncement)@")
 
-    form.addStaticText(otherModelAnnouncement, {x = 50, y = 10, w = w - 170, h = 35}, "@i18n(app.modules.settings.modelAnnouncement)@")
+    form.addStaticText(otherModelAnnouncement, {x = 50, y = rfsuite.app.radio.linePaddingTop, w = w - 170, h = rfsuite.app.radio.navbuttonHeight}, "@i18n(app.modules.settings.modelAnnouncement)@")
 
     formFieldCount = formFieldCount + 1
     rfsuite.app.formLineCnt = rfsuite.app.formLineCnt + 1

--- a/src/rfsuite/i18n/de.json
+++ b/src/rfsuite/i18n/de.json
@@ -5114,12 +5114,12 @@
         "help_table_1_p1": {
           "english": "RC Rate: Maximum rotation rate at full stick deflection.",
           "needs_translation": false,
-          "translation": "RC-Rate: Maximale Rotationsgeschwindigkeit bei vollem Knüppelausschlag."
+          "translation": "RC-Drehrate: Maximale Rotationsgeschwindigkeit bei vollem Knüppelausschlag."
         },
         "help_table_1_p2": {
           "english": "SuperRate: Increases maximum rotation rate while reducing sensitivity around half stick.",
           "needs_translation": false,
-          "translation": "SuperRate: Erhöht die maximale Rotationsgeschwindigkeit und verringert gleichzeitig die Empfindlichkeit in der Mitte des Knüppelwegs."
+          "translation": "Super-Drehrate: Erhöht die maximale Rotationsgeschwindigkeit und verringert gleichzeitig die Empfindlichkeit in der Mitte des Knüppelwegs."
         },
         "help_table_1_p3": {
           "english": "Expo: Reduces sensitivity near the stick's center where fine controls are needed.",
@@ -5144,7 +5144,7 @@
         "help_table_3_p1": {
           "english": "RC Rate: Maximum rotation rate at full stick deflection.",
           "needs_translation": false,
-          "translation": "RC-Rate: Maximale Rotationsgeschwindigkeit bei vollem Knüppelausschlag."
+          "translation": "RC-Drehrate: Maximale Rotationsgeschwindigkeit bei vollem Knüppelausschlag."
         },
         "help_table_3_p2": {
           "english": "Rate: Increases maximum rotation rate while reducing sensitivity around half stick.",
@@ -5164,7 +5164,7 @@
         "help_table_4_p2": {
           "english": "Max Rate: Maximum rotation rate at full stick deflection in degrees per second.",
           "needs_translation": false,
-          "translation": "Maximalrate: Maximale Rotationsgeschwindigkeit bei vollem Knüppelausschlag in Grad pro Sekunde."
+          "translation": "Maximaldrehrate: Maximale Rotationsgeschwindigkeit bei vollem Knüppelausschlag in Grad pro Sekunde."
         },
         "help_table_4_p3": {
           "english": "Expo: Reduces sensitivity near the stick's center where fine controls are needed.",
@@ -5179,9 +5179,24 @@
         "help_table_5_p2": {
           "english": "Max Rate: Maximum rotation rate at full stick deflection in degrees per second.",
           "needs_translation": false,
-          "translation": "Maximalrate: Maximale Rotationsgeschwindigkeit bei vollem Knüppelausschlag in Grad pro Sekunde."
+          "translation": "Maximaldrehrate: Maximale Rotationsgeschwindigkeit bei vollem Knüppelausschlag in Grad pro Sekunde."
         },
         "help_table_5_p3": {
+          "english": "Expo: Reduces sensitivity near the stick's center where fine controls are needed.",
+          "needs_translation": false,
+          "translation": "Expo: Verringert die Empfindlichkeit nahe der Knüppelmitte für feinere Steuerung."
+        },
+        "help_table_6_p1": {
+          "english": "Rate: Maximum rotation rate at full stick deflection in degrees per second.",
+          "needs_translation": false,
+          "translation": "Drehrate: Maximale Rotationsgeschwindigkeit bei vollem Knüppelausschlag in Grad pro Sekunde."
+        },
+        "help_table_6_p2": {
+          "english": "Shape: Shifts the vertex of the control curve. Up to this point, the signal translation is linear. This defines how far the stick travel remains proportional before the curve becomes progressive.",
+          "needs_translation": false,
+          "translation": "Form: Verschiebt den Scheitelpunkt der Steuerkurve. Bis zu diesem Punkt verläuft die Signalumsetzung linear. Dies definiert, wie weit der Knüppelweg proportional bleibt, bevor die Kurve progressiv wird."
+        },
+        "help_table_6_p3": {
           "english": "Expo: Reduces sensitivity near the stick's center where fine controls are needed.",
           "needs_translation": false,
           "translation": "Expo: Verringert die Empfindlichkeit nahe der Knüppelmitte für feinere Steuerung."
@@ -5194,12 +5209,12 @@
         "max_rate": {
           "english": "Max Rate",
           "needs_translation": false,
-          "translation": "Max. Rate"
+          "translation": "Max. Drehrate"
         },
         "name": {
           "english": "Rates",
           "needs_translation": false,
-          "translation": "Rates"
+          "translation": "Drehraten"
         },
         "none": {
           "english": "NONE",
@@ -5224,7 +5239,7 @@
         "rate": {
           "english": "Rate",
           "needs_translation": false,
-          "translation": "Rate"
+          "translation": "Drehrate"
         },
         "rc_curve": {
           "english": "RC Curve",
@@ -5234,7 +5249,7 @@
         "rc_rate": {
           "english": "RC Rate",
           "needs_translation": false,
-          "translation": "RC-Rate"
+          "translation": "RC-Drehrate"
         },
         "roll": {
           "english": "Roll",
@@ -5254,7 +5269,7 @@
         "superrate": {
           "english": "SuperRate",
           "needs_translation": false,
-          "translation": "SuperRate"
+          "translation": "Super-Drehrate"
         },
         "yaw": {
           "english": "Yaw",

--- a/src/rfsuite/i18n/de.json
+++ b/src/rfsuite/i18n/de.json
@@ -6031,6 +6031,11 @@
           "needs_translation": false,
           "translation": "Governor-Status"
         },
+        "help_modelAnnouncement": {
+          "english": "Model announcement requires a .wav file in the 'sounds' folder matching the model name (e.g. 'racer.wav' for model 'racer').",
+          "needs_translation": false,
+          "translation": "Für die Modellansage wird eine .wav-Datei im Ordner 'sounds' benötigt, die dem Modellnamen entspricht (z. B. 'racer.wav' für das Modell 'racer')."
+        },
         "loader_style_large": {
           "english": "LARGE",
           "needs_translation": false,
@@ -6056,6 +6061,11 @@
           "needs_translation": false,
           "translation": "Meter"
         },
+        "modelAnnouncement": {
+          "english": "Model announcement",
+          "needs_translation": false,
+          "translation": "Modellansage"
+        },
         "name": {
           "english": "Settings",
           "needs_translation": false,
@@ -6065,6 +6075,11 @@
           "english": "No configurable themes installed on this device",
           "needs_translation": false,
           "translation": "Keine konfigurierbaren Designs auf dem Gerät installiert."
+        },
+        "otherSoundSettings": {
+          "english": "Other",
+          "needs_translation": false,
+          "translation": "Sonstiges"
         },
         "pid_profile": {
           "english": "PID Profile",

--- a/src/rfsuite/i18n/de.json
+++ b/src/rfsuite/i18n/de.json
@@ -2033,6 +2033,11 @@
       "needs_translation": false,
       "translation": "Konfiguration"
     },
+    "header_help": {
+      "english": "Help",
+      "needs_translation": false,
+      "translation": "Hilfe"
+    },
     "header_system": {
       "english": "System",
       "needs_translation": false,
@@ -6047,9 +6052,9 @@
           "translation": "Governor-Status"
         },
         "help_modelAnnouncement": {
-          "english": "Model announcement requires a .wav file in the 'sounds' folder matching the model name (e.g. 'racer.wav' for model 'racer').",
+          "english": "Model announcement requires a .wav file in the 'audio' folder matching the model name (e.g. 'racer.wav' for model 'racer').",
           "needs_translation": false,
-          "translation": "Für die Modellansage wird eine .wav-Datei im Ordner 'sounds' benötigt, die dem Modellnamen entspricht (z. B. 'racer.wav' für das Modell 'racer')."
+          "translation": "Für die Modellansage wird eine .wav-Datei im Ordner 'audio' benötigt, die dem Modellnamen entspricht (z. B. 'racer.wav' für das Modell 'racer')."
         },
         "loader_style_large": {
           "english": "LARGE",

--- a/src/rfsuite/i18n/en.json
+++ b/src/rfsuite/i18n/en.json
@@ -6031,6 +6031,11 @@
           "needs_translation": false,
           "translation": "Governor State"
         },
+        "help_modelAnnouncement": {
+          "english": "Model announcement requires a .wav file in the 'sounds' folder matching the model name (e.g. 'racer.wav' for model 'racer').",
+          "needs_translation": false,
+          "translation": "Model announcement requires a .wav file in the 'sounds' folder matching the model name (e.g. 'racer.wav' for model 'racer')."
+        },
         "loader_style_large": {
           "english": "LARGE",
           "needs_translation": false,
@@ -6056,6 +6061,11 @@
           "needs_translation": false,
           "translation": "Meters"
         },
+        "modelAnnouncement": {
+          "english": "Model announcement",
+          "needs_translation": false,
+          "translation": "Model announcement"
+        },
         "name": {
           "english": "Settings",
           "needs_translation": false,
@@ -6065,6 +6075,11 @@
           "english": "No configurable themes installed on this device",
           "needs_translation": false,
           "translation": "No configurable themes installed on this device"
+        },
+        "otherSoundSettings": {
+          "english": "Other",
+          "needs_translation": false,
+          "translation": "Other"
         },
         "pid_profile": {
           "english": "PID Profile",

--- a/src/rfsuite/i18n/en.json
+++ b/src/rfsuite/i18n/en.json
@@ -5186,6 +5186,21 @@
           "needs_translation": false,
           "translation": "Expo: Reduces sensitivity near the stick's center where fine controls are needed."
         },
+        "help_table_6_p1": {
+          "english": "Rate: Maximum rotation rate at full stick deflection in degrees per second.",
+          "needs_translation": false,
+          "translation": "Rate: Maximum rotation rate at full stick deflection in degrees per second."
+        },
+        "help_table_6_p2": {
+          "english": "Shape: Shifts the vertex of the control curve. Up to this point, the signal translation is linear. This defines how far the stick travel remains proportional before the curve becomes progressive.",
+          "needs_translation": false,
+          "translation": "Shape: Shifts the vertex of the control curve. Up to this point, the signal translation is linear. This defines how far the stick travel remains proportional before the curve becomes progressive."
+        },
+        "help_table_6_p3": {
+          "english": "Expo: Reduces sensitivity near the stick's center where fine controls are needed.",
+          "needs_translation": false,
+          "translation": "Expo: Reduces sensitivity near the stick's center where fine controls are needed."
+        },
         "kiss": {
           "english": "KISS",
           "needs_translation": false,

--- a/src/rfsuite/i18n/en.json
+++ b/src/rfsuite/i18n/en.json
@@ -2033,6 +2033,11 @@
       "needs_translation": false,
       "translation": "Configuration"
     },
+    "header_help": {
+      "english": "Help",
+      "needs_translation": false,
+      "translation": "Help"
+    },
     "header_system": {
       "english": "System",
       "needs_translation": false,
@@ -6047,9 +6052,9 @@
           "translation": "Governor State"
         },
         "help_modelAnnouncement": {
-          "english": "Model announcement requires a .wav file in the 'sounds' folder matching the model name (e.g. 'racer.wav' for model 'racer').",
+          "english": "Model announcement requires a .wav file in the 'audio' folder matching the model name (e.g. 'racer.wav' for model 'racer').",
           "needs_translation": false,
-          "translation": "Model announcement requires a .wav file in the 'sounds' folder matching the model name (e.g. 'racer.wav' for model 'racer')."
+          "translation": "Model announcement requires a .wav file in the 'audio' folder matching the model name (e.g. 'racer.wav' for model 'racer')."
         },
         "loader_style_large": {
           "english": "LARGE",

--- a/src/rfsuite/i18n/es.json
+++ b/src/rfsuite/i18n/es.json
@@ -6031,6 +6031,11 @@
           "needs_translation": false,
           "translation": "Estado del Governor"
         },
+        "help_modelAnnouncement": {
+          "english": "Model announcement requires a .wav file in the 'sounds' folder matching the model name (e.g. 'racer.wav' for model 'racer').",
+          "needs_translation": false,
+          "translation": "El anuncio del modelo requiere un archivo .wav en la carpeta 'sounds' que coincida con el nombre del modelo (por ejemplo, 'racer.wav' para el modelo 'racer')."
+        },
         "loader_style_large": {
           "english": "LARGE",
           "needs_translation": true,
@@ -6056,6 +6061,11 @@
           "needs_translation": false,
           "translation": "Metros"
         },
+        "modelAnnouncement": {
+          "english": "Model announcement",
+          "needs_translation": false,
+          "translation": "Anuncio de modelo"
+        },
         "name": {
           "english": "Settings",
           "needs_translation": false,
@@ -6065,6 +6075,11 @@
           "english": "No configurable themes installed on this device",
           "needs_translation": false,
           "translation": "No hay temas configurables instalados en este dispositivo"
+        },
+        "otherSoundSettings": {
+          "english": "Other",
+          "needs_translation": false,
+          "translation": "Otros"
         },
         "pid_profile": {
           "english": "PID Profile",

--- a/src/rfsuite/i18n/es.json
+++ b/src/rfsuite/i18n/es.json
@@ -5186,6 +5186,21 @@
           "needs_translation": false,
           "translation": "Expo: Reduce la sensibilidad cerca del centro del joystick donde hacen falta controles finos."
         },
+        "help_table_6_p1": {
+          "english": "Rate: Maximum rotation rate at full stick deflection in degrees per second.",
+          "needs_translation": false,
+          "translation": "Tasa: Tasa máxima de rotación durante el desplazamiento máximo del joystick en grados por segundo."
+        },
+        "help_table_6_p2": {
+          "english": "Shape: Shifts the vertex of the control curve. Up to this point, the signal translation is linear. This defines how far the stick travel remains proportional before the curve becomes progressive.",
+          "needs_translation": false,
+          "translation": "Forma: Desplaza el vértice de la curva de mando. Hasta este punto, la conversión de la señal es lineal. Esto define hasta qué punto el recorrido del stick se mantiene proporcional antes de que la curva se vuelva progresiva."
+        },
+        "help_table_6_p3": {
+          "english": "Expo: Reduces sensitivity near the stick's center where fine controls are needed.",
+          "needs_translation": false,
+          "translation": "Expo: Reduce la sensibilidad cerca del centro del joystick donde hacen falta controles finos."
+        },
         "kiss": {
           "english": "KISS",
           "needs_translation": false,

--- a/src/rfsuite/i18n/es.json
+++ b/src/rfsuite/i18n/es.json
@@ -2033,6 +2033,11 @@
       "needs_translation": true,
       "translation": "Configuración"
     },
+    "header_help": {
+      "english": "Help",
+      "needs_translation": false,
+      "translation": "Ayuda"
+    },
     "header_system": {
       "english": "System",
       "needs_translation": true,
@@ -6047,9 +6052,9 @@
           "translation": "Estado del Governor"
         },
         "help_modelAnnouncement": {
-          "english": "Model announcement requires a .wav file in the 'sounds' folder matching the model name (e.g. 'racer.wav' for model 'racer').",
+          "english": "Model announcement requires a .wav file in the 'audio' folder matching the model name (e.g. 'racer.wav' for model 'racer').",
           "needs_translation": false,
-          "translation": "El anuncio del modelo requiere un archivo .wav en la carpeta 'sounds' que coincida con el nombre del modelo (por ejemplo, 'racer.wav' para el modelo 'racer')."
+          "translation": "El anuncio del modelo requiere un archivo .wav en la carpeta 'audio' que coincida con el nombre del modelo (por ejemplo, 'racer.wav' para el modelo 'racer')."
         },
         "loader_style_large": {
           "english": "LARGE",

--- a/src/rfsuite/i18n/fr.json
+++ b/src/rfsuite/i18n/fr.json
@@ -5186,6 +5186,21 @@
           "needs_translation": false,
           "translation": "Expo : Reduit la sensibilite pres du centre du manche ou des controles fins sont necessaires."
         },
+        "help_table_6_p1": {
+          "english": "Rate: Maximum rotation rate at full stick deflection in degrees per second.",
+          "needs_translation": false,
+          "translation": "Taux : Taux de rotation maximal a pleine deviation du manche en degres par seconde."
+        },
+        "help_table_6_p2": {
+          "english": "Shape: Shifts the vertex of the control curve. Up to this point, the signal translation is linear. This defines how far the stick travel remains proportional before the curve becomes progressive.",
+          "needs_translation": false,
+          "translation": "Forme: Déplace le sommet de la courbe de contrôle. Jusqu'à ce point, la conversion du signal est linéaire. Cela définit jusqu'où la course du manche reste proportionnelle avant que la courbe ne devienne progressive."
+        },
+        "help_table_6_p3": {
+          "english": "Expo: Reduces sensitivity near the stick's center where fine controls are needed.",
+          "needs_translation": false,
+          "translation": "Expo : Reduit la sensibilite pres du centre du manche ou des controles fins sont necessaires."
+        },
         "kiss": {
           "english": "KISS",
           "needs_translation": false,

--- a/src/rfsuite/i18n/fr.json
+++ b/src/rfsuite/i18n/fr.json
@@ -2033,6 +2033,11 @@
       "needs_translation": true,
       "translation": "Configuration"
     },
+    "header_help": {
+      "english": "Help",
+      "needs_translation": false,
+      "translation": "Aide"
+    },
     "header_system": {
       "english": "System",
       "needs_translation": true,
@@ -6047,9 +6052,9 @@
           "translation": "Etat du regulateur"
         },
         "help_modelAnnouncement": {
-          "english": "Model announcement requires a .wav file in the 'sounds' folder matching the model name (e.g. 'racer.wav' for model 'racer').",
+          "english": "Model announcement requires a .wav file in the 'audio' folder matching the model name (e.g. 'racer.wav' for model 'racer').",
           "needs_translation": false,
-          "translation": "L'annonce du modèle nécessite un fichier .wav dans le dossier 'sounds' correspondant au nom du modèle (par ex. 'racer.wav' pour le modèle 'racer')."
+          "translation": "L'annonce du modèle nécessite un fichier .wav dans le dossier 'audio' correspondant au nom du modèle (par ex. 'racer.wav' pour le modèle 'racer')."
         },
         "loader_style_large": {
           "english": "LARGE",

--- a/src/rfsuite/i18n/fr.json
+++ b/src/rfsuite/i18n/fr.json
@@ -6031,6 +6031,11 @@
           "needs_translation": false,
           "translation": "Etat du regulateur"
         },
+        "help_modelAnnouncement": {
+          "english": "Model announcement requires a .wav file in the 'sounds' folder matching the model name (e.g. 'racer.wav' for model 'racer').",
+          "needs_translation": false,
+          "translation": "L'annonce du modèle nécessite un fichier .wav dans le dossier 'sounds' correspondant au nom du modèle (par ex. 'racer.wav' pour le modèle 'racer')."
+        },
         "loader_style_large": {
           "english": "LARGE",
           "needs_translation": true,
@@ -6056,6 +6061,11 @@
           "needs_translation": false,
           "translation": "Metres"
         },
+        "modelAnnouncement": {
+          "english": "Model announcement",
+          "needs_translation": false,
+          "translation": "Annonce du modèle"
+        },
         "name": {
           "english": "Settings",
           "needs_translation": false,
@@ -6065,6 +6075,11 @@
           "english": "No configurable themes installed on this device",
           "needs_translation": false,
           "translation": "Aucun theme configurable n'est installe sur cet appareil"
+        },
+        "otherSoundSettings": {
+          "english": "Other",
+          "needs_translation": false,
+          "translation": "Autre"
         },
         "pid_profile": {
           "english": "PID Profile",

--- a/src/rfsuite/i18n/it.json
+++ b/src/rfsuite/i18n/it.json
@@ -5144,7 +5144,7 @@
         "help_table_3_p1": {
           "english": "RC Rate: Maximum rotation rate at full stick deflection.",
           "needs_translation": false,
-          "translation": "RC Rate: Velocita' di rotazione massima a piena deflessione dello Stick."
+          "translation": "RC Rate: Velocita' di rotazione massima a piena deflessione dello stick."
         },
         "help_table_3_p2": {
           "english": "Rate: Increases maximum rotation rate while reducing sensitivity around half stick.",
@@ -5185,6 +5185,21 @@
           "english": "Expo: Reduces sensitivity near the stick's center where fine controls are needed.",
           "needs_translation": false,
           "translation": "Expo: Riduce la sensibilita' vicino al centro del joystick, dove sono necessari controlli precisi."
+        },
+        "help_table_6_p1": {
+          "english": "Rate: Maximum rotation rate at full stick deflection in degrees per second.",
+          "needs_translation": true,
+          "translation": "Rate: Maximum rotation rate at full stick deflection in degrees per second."
+        },
+        "help_table_6_p2": {
+          "english": "Shape: Shifts the vertex of the control curve. Up to this point, the signal translation is linear. This defines how far the stick travel remains proportional before the curve becomes progressive.",
+          "needs_translation": false,
+          "translation": "Forma: Sposta il vertice della curva di controllo. Fino a questo punto, la conversione del segnale è lineare. Questo definisce quanto il movimento dello stick rimanga proporzionale prima che la curva diventi progressiva."
+        },
+        "help_table_6_p3": {
+          "english": "Expo: Reduces sensitivity near the stick's center where fine controls are needed.",
+          "needs_translation": false,
+          "translation": "Expo: Riduce la sensibilità vicino al centro dello stick dove sono necessari controlli precisi."
         },
         "kiss": {
           "english": "KISS",

--- a/src/rfsuite/i18n/it.json
+++ b/src/rfsuite/i18n/it.json
@@ -6031,6 +6031,11 @@
           "needs_translation": false,
           "translation": "Stato Governor"
         },
+        "help_modelAnnouncement": {
+          "english": "Model announcement requires a .wav file in the 'sounds' folder matching the model name (e.g. 'racer.wav' for model 'racer').",
+          "needs_translation": false,
+          "translation": "L'annuncio del modello richiede un file .wav nella cartella 'sounds' corrispondente al nome del modello (ad es. 'racer.wav' per il modello 'racer')."
+        },
         "loader_style_large": {
           "english": "LARGE",
           "needs_translation": true,
@@ -6056,6 +6061,11 @@
           "needs_translation": false,
           "translation": "Metri"
         },
+        "modelAnnouncement": {
+          "english": "Model announcement",
+          "needs_translation": false,
+          "translation": "Annuncio modello"
+        },
         "name": {
           "english": "Settings",
           "needs_translation": false,
@@ -6065,6 +6075,11 @@
           "english": "No configurable themes installed on this device",
           "needs_translation": false,
           "translation": "Nessun tema disponibile configurabile"
+        },
+        "otherSoundSettings": {
+          "english": "Other",
+          "needs_translation": false,
+          "translation": "Altro"
         },
         "pid_profile": {
           "english": "PID Profile",

--- a/src/rfsuite/i18n/it.json
+++ b/src/rfsuite/i18n/it.json
@@ -2033,6 +2033,11 @@
       "needs_translation": true,
       "translation": "Configurazione"
     },
+    "header_help": {
+      "english": "Help",
+      "needs_translation": true,
+      "translation": "Help"
+    },
     "header_system": {
       "english": "System",
       "needs_translation": true,
@@ -6047,9 +6052,9 @@
           "translation": "Stato Governor"
         },
         "help_modelAnnouncement": {
-          "english": "Model announcement requires a .wav file in the 'sounds' folder matching the model name (e.g. 'racer.wav' for model 'racer').",
+          "english": "Model announcement requires a .wav file in the 'audio' folder matching the model name (e.g. 'racer.wav' for model 'racer').",
           "needs_translation": false,
-          "translation": "L'annuncio del modello richiede un file .wav nella cartella 'sounds' corrispondente al nome del modello (ad es. 'racer.wav' per il modello 'racer')."
+          "translation": "L'annuncio del modello richiede un file .wav nella cartella 'audio' corrispondente al nome del modello (ad es. 'racer.wav' per il modello 'racer')."
         },
         "loader_style_large": {
           "english": "LARGE",

--- a/src/rfsuite/i18n/nl.json
+++ b/src/rfsuite/i18n/nl.json
@@ -6031,6 +6031,11 @@
           "needs_translation": false,
           "translation": "Governor Status"
         },
+        "help_modelAnnouncement": {
+          "english": "Model announcement requires a .wav file in the 'sounds' folder matching the model name (e.g. 'racer.wav' for model 'racer').",
+          "needs_translation": false,
+          "translation": "Model aankondiging vereist een .wav bestand in de 'sounds' map dat overeenkomt met de modelnaam (bijv. 'racer.wav' voor model 'racer')."
+        },
         "loader_style_large": {
           "english": "LARGE",
           "needs_translation": true,
@@ -6056,6 +6061,11 @@
           "needs_translation": false,
           "translation": "Meters"
         },
+        "modelAnnouncement": {
+          "english": "Model announcement",
+          "needs_translation": false,
+          "translation": "Model aankondiging"
+        },
         "name": {
           "english": "Settings",
           "needs_translation": false,
@@ -6065,6 +6075,11 @@
           "english": "No configurable themes installed on this device",
           "needs_translation": false,
           "translation": "Geen themes beschikbaar om in te stellen"
+        },
+        "otherSoundSettings": {
+          "english": "Other",
+          "needs_translation": false,
+          "translation": "Overige"
         },
         "pid_profile": {
           "english": "PID Profile",

--- a/src/rfsuite/i18n/nl.json
+++ b/src/rfsuite/i18n/nl.json
@@ -2033,6 +2033,11 @@
       "needs_translation": true,
       "translation": "Configuratie"
     },
+    "header_help": {
+      "english": "Help",
+      "needs_translation": true,
+      "translation": "Help"
+    },
     "header_system": {
       "english": "System",
       "needs_translation": true,
@@ -6047,9 +6052,9 @@
           "translation": "Governor Status"
         },
         "help_modelAnnouncement": {
-          "english": "Model announcement requires a .wav file in the 'sounds' folder matching the model name (e.g. 'racer.wav' for model 'racer').",
+          "english": "Model announcement requires a .wav file in the 'audio' folder matching the model name (e.g. 'racer.wav' for model 'racer').",
           "needs_translation": false,
-          "translation": "Model aankondiging vereist een .wav bestand in de 'sounds' map dat overeenkomt met de modelnaam (bijv. 'racer.wav' voor model 'racer')."
+          "translation": "Model aankondiging vereist een .wav bestand in de 'audio' map dat overeenkomt met de modelnaam (bijv. 'racer.wav' voor model 'racer')."
         },
         "loader_style_large": {
           "english": "LARGE",

--- a/src/rfsuite/i18n/nl.json
+++ b/src/rfsuite/i18n/nl.json
@@ -5186,6 +5186,21 @@
           "needs_translation": false,
           "translation": "Expo: Vermindert de gevoeligheid in het midden van de stick, waar nauwkeurige bediening nodig is.\n\n"
         },
+        "help_table_6_p1": {
+          "english": "Rate: Maximum rotation rate at full stick deflection in degrees per second.",
+          "needs_translation": false,
+          "translation": "Rate: Maximale rotatiesnelheid bij volledige stickuitslag in graden per seconde."
+        },
+        "help_table_6_p2": {
+          "english": "Shape: Shifts the vertex of the control curve. Up to this point, the signal translation is linear. This defines how far the stick travel remains proportional before the curve becomes progressive.",
+          "needs_translation": false,
+          "translation": "Vorm: Verschuift de vertex van de controle curve. Tot dit punt is de signaalvertaling lineair. Dit bepaalt hoe ver de stick travel proportioneel blijft voordat de curve progressief wordt."
+        },
+        "help_table_6_p3": {
+          "english": "Expo: Reduces sensitivity near the stick's center where fine controls are needed.",
+          "needs_translation": false,
+          "translation": "Expo: Vermindert de gevoeligheid in het midden van de stick, waar nauwkeurige bediening nodig is."
+        },
         "kiss": {
           "english": "KISS",
           "needs_translation": false,

--- a/src/rfsuite/main.lua
+++ b/src/rfsuite/main.lua
@@ -78,7 +78,9 @@ local userpref_defaults = {
         smartfuelrepeats = 1,
         smartfuelhaptic = false,
         adj_v = false,
-        adj_f = false
+        adj_f = false,
+        otherSoundCfg = true,
+        otherModelAnnounce = false
     },
     switches = {},
     developer = {

--- a/src/rfsuite/tasks/events/postconnect/manifest.lua
+++ b/src/rfsuite/tasks/events/postconnect/manifest.lua
@@ -9,6 +9,7 @@
 return {
     { name = "clocksync" },  
     { name = "craftname" },
+    { name = "announceCraftname" },
     { name = "rxmap" },    
     { name = "syncstats" },    
 }

--- a/src/rfsuite/tasks/events/postconnect/tasks/announceCraftname.lua
+++ b/src/rfsuite/tasks/events/postconnect/tasks/announceCraftname.lua
@@ -1,0 +1,48 @@
+--[[
+    Copyright (C) 2026 Rotorflight Project
+    GPLv3 — https://www.gnu.org/licenses/gpl-3.0.en.html
+]] --
+
+local rfsuite = require("rfsuite")
+
+local announceCraftname = {}
+
+local taskComplete = false
+
+function announceCraftname.wakeup()
+
+    if taskComplete then return end
+
+    taskComplete = true
+
+    if not (rfsuite.preferences.events and rfsuite.preferences.events.otherModelAnnounce) then
+        return
+    end
+
+    local craftName = rfsuite.session.craftName
+    if not craftName or craftName == "" then return end
+
+    -- Try exact match and underscore replacement for spaces
+    local candidates = {"/audio/" .. craftName .. ".wav", "/audio/" .. string.gsub(craftName, " ", "_") .. ".wav"}
+
+    for _, filename in ipairs(candidates) do
+        local f = io.open(filename, "r")
+        if f then
+            io.close(f)
+            system.playFile(filename)
+            rfsuite.utils.log("Announcing craft name: " .. filename, "info")
+            return
+        end
+    end
+    rfsuite.utils.log("Craft announcement file not found for: " .. craftName, "info")
+end
+
+function announceCraftname.reset()
+    taskComplete = false
+end
+
+function announceCraftname.isComplete()
+    return taskComplete
+end
+
+return announceCraftname


### PR DESCRIPTION
- Add help for new rate profile Rotorflight
- Model audio announcement / Can be enabled in audio events.
   - Model announcement requires a .wav file in the 'audio' folder matching the model name (e.g. 'racer.wav' for model 'racer').