### PR TITLE
Adjustment Functions - Improvements

### DIFF
--- a/src/rfsuite/app/modules/adjustments/adjustments.lua
+++ b/src/rfsuite/app/modules/adjustments/adjustments.lua
@@ -1155,11 +1155,9 @@ local function updateLiveFields()
 
     if state.liveFields.preview and state.liveFields.preview.value then
         local preview = calcPreview(adjRange, getAdjustmentType(adjRange), enaUs, adjUs)
-        if preview.active then
-            state.liveFields.preview:value(preview.text .. " *")
-        else
-            state.liveFields.preview:value(preview.text)
-        end
+        local valueText = preview.text
+        if preview.active then valueText = valueText .. "*" end
+        state.liveFields.preview:value("Output: " .. valueText)
     end
 end
 
@@ -1216,9 +1214,12 @@ local function render()
 
     local activeCount = countActiveRanges()
     local infoLine = form.addLine("@i18n(app.modules.adjustments.active_ranges)@ " .. tostring(activeCount) .. " / " .. tostring(#state.adjustmentRanges))
+    local previewW = math.max(48, math.floor(width * 0.16))
+    local previewX = width - rightPadding - previewW
+
     if state.dirty then
-        local statusW = math.floor(width * 0.32)
-        local statusX = width - rightPadding - statusW
+        local statusW = math.max(76, math.floor(width * 0.22))
+        local statusX = previewX - gap - statusW
         local statusBtn = form.addButton(infoLine, {x = statusX, y = y, w = statusW, h = h}, {
             text = "@i18n(app.modules.adjustments.unsaved_changes)@",
             icon = nil,
@@ -1228,6 +1229,8 @@ local function render()
         })
         if statusBtn and statusBtn.enable then statusBtn:enable(false) end
     end
+    local preview = form.addStaticText(infoLine, {x = previewX, y = y, w = previewW, h = h}, "Output: -")
+    if preview and preview.value then state.liveFields.preview = preview end
 
     if hasActiveAutoDetect() then form.addLine("@i18n(app.modules.adjustments.auto_detect_active_toggle)@") end
     if state.saveError then form.addLine("@i18n(app.modules.adjustments.save_error)@ " .. tostring(state.saveError)) end
@@ -1564,10 +1567,6 @@ local function render()
         if valStart and valStart.enable then valStart:enable(false) end
         if valEnd and valEnd.enable then valEnd:enable(false) end
     end
-
-    local previewLine = form.addLine("@i18n(app.modules.adjustments.current_output)@")
-    local preview = form.addStaticText(previewLine, {x = width - rightPadding - math.floor(width * 0.45), y = y, w = math.floor(width * 0.45), h = h}, "-")
-    if preview and preview.value then state.liveFields.preview = preview end
 
     restorePendingFocus(focusTargets)
 end

--- a/src/rfsuite/app/modules/adjustments/adjustments.lua
+++ b/src/rfsuite/app/modules/adjustments/adjustments.lua
@@ -27,7 +27,7 @@ local ADJUSTMENT_RANGE_DEFAULT_COUNT = 42
 local MSP_FUNCTION_NAME_PREFETCH_MIN_API = "12.09"
 
 -- gate the prefetch call until its in the firmware
-local USE_MSP_FUNCTION_NAME_PREFETCH = true 
+local USE_MSP_FUNCTION_NAME_PREFETCH = false
 
 local ADJUST_FUNCTIONS = {
     {id = 0, name = "None", min = 0, max = 100},

--- a/src/rfsuite/app/modules/adjustments/adjustments.lua
+++ b/src/rfsuite/app/modules/adjustments/adjustments.lua
@@ -1165,6 +1165,12 @@ local function updateLiveFields()
         if preview.active then valueText = valueText .. "*" end
         state.liveFields.preview:value("Output: " .. valueText)
     end
+    if state.liveFields.previewCompact and state.liveFields.previewCompact.value then
+        local preview = calcPreview(adjRange, getAdjustmentType(adjRange), enaUs, adjUs)
+        local valueText = preview.text
+        if preview.active then valueText = valueText .. "*" end
+        state.liveFields.previewCompact:value("O:" .. valueText)
+    end
 end
 
 local function render()
@@ -1584,6 +1590,8 @@ local function render()
     registerFocus("valEnd", valEnd)
     state.liveFields.valStart = valStart
     state.liveFields.valEnd = valEnd
+    local previewCompact = form.addStaticText(valRangeLine, {x = xSet, y = y, w = wSet, h = h}, "O:-")
+    if previewCompact and previewCompact.value then state.liveFields.previewCompact = previewCompact end
     if adjType == 0 then
         if valStart and valStart.enable then valStart:enable(false) end
         if valEnd and valEnd.enable then valEnd:enable(false) end

--- a/src/rfsuite/tasks/scheduler/msp/api/ADJUSTMENT_FUNCTIONS.lua
+++ b/src/rfsuite/tasks/scheduler/msp/api/ADJUSTMENT_FUNCTIONS.lua
@@ -1,0 +1,77 @@
+--[[
+  Copyright (C) 2026 Rotorflight Project
+  GPLv3 -- https://www.gnu.org/licenses/gpl-3.0.en.html
+]] --
+
+local rfsuite = require("rfsuite")
+local core = assert(loadfile("SCRIPTS:/" .. rfsuite.config.baseDir .. "/tasks/scheduler/msp/api_core.lua"))()
+
+local API_NAME = "ADJUSTMENT_FUNCTIONS"
+local MSP_API_CMD_READ = 167
+local MSP_MIN_BYTES = 0
+local ADJUSTMENT_RANGE_MAX = 42
+
+local mspData = nil
+local handlers = core.createHandlers()
+
+local MSP_API_UUID
+local MSP_API_MSG_TIMEOUT
+
+local function parseAdjustmentFunctions(buf)
+    local parsed = {}
+    local functions = {}
+    buf.offset = 1
+
+    for i = 1, ADJUSTMENT_RANGE_MAX do
+        local fn = rfsuite.tasks.msp.mspHelper.readU8(buf)
+        if fn == nil then break end
+        functions[i] = fn
+    end
+
+    parsed.adjustment_functions = functions
+    return {parsed = parsed, buffer = buf}
+end
+
+local function read()
+    local message = {
+        command = MSP_API_CMD_READ,
+        apiname = API_NAME,
+        processReply = function(self, buf)
+            mspData = parseAdjustmentFunctions(buf)
+            local completeHandler = handlers.getCompleteHandler()
+            if completeHandler then completeHandler(self, buf) end
+        end,
+        errorHandler = function(self, buf)
+            local errorHandler = handlers.getErrorHandler()
+            if errorHandler then errorHandler(self, buf) end
+        end,
+        simulatorResponse = {},
+        uuid = MSP_API_UUID,
+        timeout = MSP_API_MSG_TIMEOUT
+    }
+
+    return rfsuite.tasks.msp.mspQueue:add(message)
+end
+
+local function readValue(fieldName)
+    if mspData and mspData.parsed then return mspData.parsed[fieldName] end
+    return nil
+end
+
+local function readComplete() return mspData ~= nil and #mspData.buffer >= MSP_MIN_BYTES end
+local function data() return mspData end
+local function setUUID(uuid) MSP_API_UUID = uuid end
+local function setTimeout(timeout) MSP_API_MSG_TIMEOUT = timeout end
+local function setRebuildOnWrite(_) end
+
+return {
+    read = read,
+    setRebuildOnWrite = setRebuildOnWrite,
+    readComplete = readComplete,
+    readValue = readValue,
+    setCompleteHandler = handlers.setCompleteHandler,
+    setErrorHandler = handlers.setErrorHandler,
+    data = data,
+    setUUID = setUUID,
+    setTimeout = setTimeout
+}

--- a/src/rfsuite/tasks/scheduler/msp/api/ADJUSTMENT_FUNCTIONS.lua
+++ b/src/rfsuite/tasks/scheduler/msp/api/ADJUSTMENT_FUNCTIONS.lua
@@ -16,6 +16,10 @@ local handlers = core.createHandlers()
 
 local MSP_API_UUID
 local MSP_API_MSG_TIMEOUT
+local SIMULATOR_RESPONSE = {
+    1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+}
 
 local function parseAdjustmentFunctions(buf)
     local parsed = {}
@@ -45,7 +49,7 @@ local function read()
             local errorHandler = handlers.getErrorHandler()
             if errorHandler then errorHandler(self, buf) end
         end,
-        simulatorResponse = {},
+        simulatorResponse = SIMULATOR_RESPONSE,
         uuid = MSP_API_UUID,
         timeout = MSP_API_MSG_TIMEOUT
     }

--- a/src/rfsuite/tasks/scheduler/msp/api/BOXIDS.lua
+++ b/src/rfsuite/tasks/scheduler/msp/api/BOXIDS.lua
@@ -15,6 +15,7 @@ local handlers = core.createHandlers()
 
 local MSP_API_UUID
 local MSP_API_MSG_TIMEOUT
+local SIMULATOR_RESPONSE = {0, 1, 2, 53, 27, 36, 45, 13, 52, 19, 20, 26, 31, 51, 55, 56, 57}
 
 local function parseBoxIds(buf)
     local parsed = {}
@@ -42,7 +43,7 @@ local function read()
             local errorHandler = handlers.getErrorHandler()
             if errorHandler then errorHandler(self, buf) end
         end,
-        simulatorResponse = {},
+        simulatorResponse = SIMULATOR_RESPONSE,
         uuid = MSP_API_UUID,
         timeout = MSP_API_MSG_TIMEOUT
     }


### PR DESCRIPTION
This uses a new api call to lazy enable efficient lazy loading of adjustment functions.

There is a depenancy on this PR.

https://github.com/rotorflight/rotorflight-firmware/pull/398

The use of it is gated by 

```
-- gate the prefetch call until its in the firmware
local USE_MSP_FUNCTION_NAME_PREFETCH = false
```

Once the firmware pr merges we will need to revisit the code and switch the flag