### PR TITLE
 i18n placeholder for armed and disarmed

### DIFF
--- a/src/rfsuite/widgets/dashboard/objects/text/armflags.lua
+++ b/src/rfsuite/widgets/dashboard/objects/text/armflags.lua
@@ -121,9 +121,9 @@ function render.wakeup(box)
     if not showReason then
         if value ~= nil then
             if value == 1 or value == 3 then
-                displayValue = "@i18n(ARMED)@"
+                displayValue = "@i18n(widgets.governor.ARMED)@"
             else
-                displayValue = "@i18n(DISARMED)@"
+                displayValue = "@i18n(widgets.governor.DISARMED)@"
             end
         end
     end


### PR DESCRIPTION
Noticed when build the dashboard that the name translation was not working correctly when using armflags.lua object. I found an appropriate mapping in the namespace files under widgets.governor and used that as to avoid having to add it to each of the  json files. Not sure what your preference is. 