### PR TITLE
reduce gc thrashing for blackbox and bar objects in dashboard

### DIFF
--- a/src/rfsuite/widgets/dashboard/lib/utils.lua
+++ b/src/rfsuite/widgets/dashboard/lib/utils.lua
@@ -83,6 +83,7 @@ local NAMED_COLORS = {
 }
 
 local resolveColorCache = {}
+local resolveColorTableCache = setmetatable({}, {__mode = "k"})
 local themeFallbackPaletteCache = {dark = nil, light = nil}
 
 local function clampColorByte(v) return max(0, min(255, floor(v + 0.5))) end
@@ -462,8 +463,11 @@ function utils.resolveColor(value, variantFactor)
         end
 
     elseif type(value) == "table" and #value >= 3 then
-
-        return lcd.RGB(value[1], value[2], value[3], 1)
+        local cached = resolveColorTableCache[value]
+        if cached ~= nil then return cached end
+        local color = lcd.RGB(value[1], value[2], value[3], 1)
+        resolveColorTableCache[value] = color
+        return color
     end
 
     return nil


### PR DESCRIPTION
Added table-keyed weak cache for resolveColor table inputs to stop repeated lcd.RGB(...) allocation on the type(value) == "table" path: utils.lua (line 86), utils.lua (line 465)
Replaced loading dots rep() with prebuilt frames in bar wakeup: bar.lua (line 102), bar.lua (line 393)
Reduced bar format() churn by only rebuilding battery info strings when displayed values actually change at shown precision: bar.lua (line 407)
Replaced loading dots rep() in blackbox and cached formatted display string; only recompute when usedSize/totalSize (or format spec) changes: blackbox.lua (line 49), blackbox.lua (line 149), blackbox.lua (line 183)