### PR TITLE
Update battery profile translations and lengths across multiple langu…

### DIFF
--- a/bin/i18n/json/cs.json
+++ b/bin/i18n/json/cs.json
@@ -32,11 +32,11 @@
         "reverse_text": false
       },
       "batteryProfile": {
-        "english": "Selected battery profile (0-5)",
+        "english": "Selected battery profile (1-6)",
         "translation": "Selected battery profile (0-5)",
         "needs_translation": true,
         "reverse_text": false,
-        "max_length": 27
+        "max_length": 30
       },
       "source_adc": {
         "english": "Battery ADC",
@@ -8077,176 +8077,6 @@
           "max_length": 11
         }
       },
-      "power": {
-        "alert_name": {
-          "english": "Alerts",
-          "translation": "Alerts",
-          "needs_translation": true,
-          "max_length": 6,
-          "reverse_text": false
-        },
-        "alert_type": {
-          "english": "Rx Voltage Alert",
-          "translation": "Rx Voltage Alert",
-          "needs_translation": true,
-          "max_length": 16,
-          "reverse_text": false
-        },
-        "battery_capacity": {
-          "english": "Battery Capacity",
-          "translation": "Battery Capacity",
-          "needs_translation": true,
-          "max_length": 16,
-          "reverse_text": false
-        },
-        "battery_name": {
-          "english": "Battery",
-          "translation": "Battery",
-          "needs_translation": true,
-          "max_length": 7,
-          "reverse_text": false
-        },
-        "bec_voltage_alert": {
-          "english": "BEC Alert Value",
-          "translation": "BEC Alert Value",
-          "needs_translation": true,
-          "max_length": 15,
-          "reverse_text": false
-        },
-        "calcfuel_local": {
-          "english": "Calculate Fuel Using",
-          "translation": "Calculate Fuel Using",
-          "needs_translation": true,
-          "max_length": 20,
-          "reverse_text": false
-        },
-        "capacity": {
-          "english": "Capacity",
-          "translation": "Capacity",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 8
-        },
-        "cell_count": {
-          "english": "Cell Count",
-          "translation": "Cell Count",
-          "needs_translation": true,
-          "max_length": 10,
-          "reverse_text": false
-        },
-        "consumption_warning_percentage": {
-          "english": "Consumption Warning %",
-          "translation": "Spotreba Varovani %",
-          "needs_translation": false,
-          "max_length": 21,
-          "reverse_text": false
-        },
-        "current_meter_source": {
-          "english": "Current Source",
-          "translation": "Current Source",
-          "needs_translation": true,
-          "max_length": 14,
-          "reverse_text": false
-        },
-        "full_cell_voltage": {
-          "english": "Full Cell Voltage",
-          "translation": "Plny Cell Voltage",
-          "needs_translation": false,
-          "max_length": 17,
-          "reverse_text": false
-        },
-        "help_p1": {
-          "english": "The battery settings are used to configure the flight controller to monitor the battery voltage and provide warnings when the voltage drops below a certain level.",
-          "translation": "The battery Nastaveni are Pouzito to configure the flight controller to monitor the battery voltage and provide warnings when the voltage drops Pod a certain level.",
-          "needs_translation": false,
-          "max_length": 162,
-          "reverse_text": false
-        },
-        "max_cell_voltage": {
-          "english": "Max Cell Voltage",
-          "translation": "Max Cell Voltage",
-          "needs_translation": true,
-          "max_length": 16,
-          "reverse_text": false
-        },
-        "min_cell_voltage": {
-          "english": "Min Cell Voltage",
-          "translation": "Min Cell Voltage",
-          "needs_translation": true,
-          "max_length": 16,
-          "reverse_text": false
-        },
-        "name": {
-          "english": "Power",
-          "translation": "Power",
-          "needs_translation": true,
-          "max_length": 5,
-          "reverse_text": false
-        },
-        "rx_voltage_alert": {
-          "english": "RxBatt Alert Value",
-          "translation": "RxBatt Alert Value",
-          "needs_translation": true,
-          "max_length": 18,
-          "reverse_text": false
-        },
-        "selected": {
-          "english": "Selected",
-          "translation": "Selected",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 8
-        },
-        "show_battery_profile_startup": {
-          "english": "Show battery type choose (startup)",
-          "translation": "Show battery type choose (startup)",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 34
-        },
-        "show_confirmation_dialog": {
-          "english": "Show confirmation dialog",
-          "translation": "Show confirmation dialog",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 24
-        },
-        "source_name": {
-          "english": "Sources",
-          "translation": "Sources",
-          "needs_translation": true,
-          "max_length": 7,
-          "reverse_text": false
-        },
-        "timer": {
-          "english": "Flight Time Alarm",
-          "translation": "Flight Cas Alarm",
-          "needs_translation": false,
-          "max_length": 17,
-          "reverse_text": false
-        },
-        "voltage_meter_source": {
-          "english": "Voltage Source",
-          "translation": "Voltage Source",
-          "needs_translation": true,
-          "max_length": 14,
-          "reverse_text": false
-        },
-        "voltage_multiplier": {
-          "english": "Sag Compensation",
-          "translation": "Sag Compensation",
-          "needs_translation": true,
-          "max_length": 16,
-          "reverse_text": false
-        },
-        "warn_cell_voltage": {
-          "english": "Warn Cell Voltage",
-          "translation": "Warn Cell Voltage",
-          "needs_translation": true,
-          "max_length": 17,
-          "reverse_text": false
-        }
-      },
       "profile_autolevel": {
         "acro_trainer": {
           "english": "Acro trainer",
@@ -11289,7 +11119,7 @@
       "translation": "Battery Profile",
       "needs_translation": true,
       "reverse_text": false,
-      "max_length": 12
+      "max_length": 15
     },
     "bec_voltage": {
       "english": "Bec voltage",
@@ -11603,7 +11433,7 @@
         "translation": "Battery Profile",
         "needs_translation": true,
         "reverse_text": false,
-        "max_length": 12
+        "max_length": 15
       },
       "bec_voltage": {
         "english": "BEC Voltage",

--- a/bin/i18n/json/de.json
+++ b/bin/i18n/json/de.json
@@ -5,15 +5,15 @@
         "english": "Use to trim if the heli drifts in one of the stabilized modes (angle, horizon, etc.).",
         "translation": "Verwenden Sie diese Einstellung, um den Heli zu trimmen, falls er in einem der stabilisierten Modi (Angle, Horizon usw.) driftet.",
         "needs_translation": false,
-        "max_length": 85,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 85
       },
       "roll": {
         "english": "Use to trim if the heli drifts in one of the stabilized modes (angle, horizon, etc.).",
         "translation": "Verwenden Sie diese Einstellung, um den Heli zu trimmen, falls er in einem der stabilisierten Modi (Angle, Horizon usw.) driftet.",
         "needs_translation": false,
-        "max_length": 85,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 85
       }
     },
     "BATTERY_CONFIG": {
@@ -21,122 +21,122 @@
         "english": "The milliamp hour capacity of your battery.",
         "translation": "Die Kapazitaet Ihrer Batterie in Milliamperestunden.",
         "needs_translation": false,
-        "max_length": 43,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 43
       },
       "batteryCellCount": {
         "english": "The number of cells in your battery.",
         "translation": "Zellenanzahl des Akkus.",
         "needs_translation": false,
-        "max_length": 36,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 36
       },
       "batteryProfile": {
-        "english": "Selected battery profile (0-5)",
-        "translation": "Selected battery profile (0-5)",
-        "needs_translation": true,
+        "english": "Selected battery profile (1-6)",
+        "translation": "Batterie auswählen (1-6)",
+        "needs_translation": false,
         "reverse_text": false,
-        "max_length": 27
+        "max_length": 30
       },
       "source_adc": {
         "english": "Battery ADC",
         "translation": "Akku ADC",
         "needs_translation": false,
-        "max_length": 11,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 11
       },
       "source_esc": {
         "english": "ESC Telemetry",
         "translation": "ESC-Telemetrie",
         "needs_translation": false,
-        "max_length": 13,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 13
       },
       "source_none": {
         "english": "None",
         "translation": "Keine",
         "needs_translation": false,
-        "max_length": 4,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 4
       },
       "vbatfullcellvoltage": {
         "english": "The nominal voltage of a fully charged cell.",
         "translation": "Die Nennspannung einer vollstaendig geladenen Zelle.",
         "needs_translation": false,
-        "max_length": 44,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 44
       },
       "vbatmaxcellvoltage": {
         "english": "The maximum voltage per cell before the high voltage alarm is triggered.",
         "translation": "Die maximale Spannung pro Zelle, bevor der Hochspannungsalarm ausgeloest wird.",
         "needs_translation": false,
-        "max_length": 72,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 72
       },
       "vbatmincellvoltage": {
         "english": "The minimum voltage per cell before the low voltage alarm is triggered.",
         "translation": "Die minimale Spannung pro Zelle, bevor der Niederspannungsalarm ausgeloest wird.",
         "needs_translation": false,
-        "max_length": 71,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 71
       },
       "vbatwarningcellvoltage": {
         "english": "The voltage per cell at which the low voltage alarm will start to sound.",
         "translation": "Die Spannung pro Zelle, bei der der Niederspannungsalarm ausgeloest wird.",
         "needs_translation": false,
-        "max_length": 72,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 72
       }
     },
     "BATTERY_INI": {
       "alert_bec": {
         "english": "BEC",
         "translation": "BEC",
-        "needs_translation": true,
-        "max_length": 3,
-        "reverse_text": false
+        "needs_translation": false,
+        "reverse_text": false,
+        "max_length": 3
       },
       "alert_off": {
         "english": "Off",
         "translation": "Aus",
         "needs_translation": false,
-        "max_length": 3,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 3
       },
       "alert_rxbatt": {
         "english": "RxBatt",
         "translation": "Empfaengerakku",
         "needs_translation": false,
-        "max_length": 6,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 6
       },
       "calcfuel_local": {
         "english": "Calculate Fuel Using",
         "translation": "Kraftstoff berechnen mit",
         "needs_translation": false,
-        "max_length": 20,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 20
       },
       "sag_multiplier": {
         "english": "Raise or lower to adjust for the amount of voltage sag you see in flight.",
         "translation": "Erhoehen oder verringern, um den Spannungseinbruch im Flug anzupassen.",
         "needs_translation": false,
-        "max_length": 73,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 73
       },
       "tbl_off": {
         "english": "Current Sensor",
         "translation": "Stromsensor",
         "needs_translation": false,
-        "max_length": 14,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 14
       },
       "tbl_on": {
         "english": "Voltage Sensor",
         "translation": "Spannungssensor",
         "needs_translation": false,
-        "max_length": 14,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 14
       }
     },
     "ESC_PARAMETERS_FLYROTOR": {
@@ -144,183 +144,183 @@
         "english": "Beeper volume",
         "translation": "Summerlautstaerke",
         "needs_translation": false,
-        "max_length": 13,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 13
       },
       "cell_count": {
         "english": "Number of cells in the battery",
         "translation": "Anzahl der Zellen in der Batterie",
         "needs_translation": false,
-        "max_length": 30,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 30
       },
       "current_gain": {
         "english": "Gain value for the current sensor",
         "translation": "Verstaerkungswert fuer den Stromsensor",
         "needs_translation": false,
-        "max_length": 33,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 33
       },
       "drive_freq": {
         "english": "PWM drive frequency",
         "translation": "PWM-Antriebsfrequenz",
         "needs_translation": false,
-        "max_length": 19,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 19
       },
       "electrical_angle": {
         "english": "Electrical angle for the motor",
         "translation": "Timing-Winkel fuer den Motor",
         "needs_translation": false,
-        "max_length": 30,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 30
       },
       "gov_i": {
         "english": "Integral value for the governor",
         "translation": "Integralwert fuer den Governor",
         "needs_translation": false,
-        "max_length": 31,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 31
       },
       "gov_p": {
         "english": "Proportional value for the governor",
         "translation": "Proportionalwert fuer den Governor",
         "needs_translation": false,
-        "max_length": 35,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 35
       },
       "low_voltage_protection": {
         "english": "Voltage at which we cut power by 50%",
         "translation": "Spannung, bei der die Leistung um 50 % reduziert wird",
         "needs_translation": false,
-        "max_length": 36,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 36
       },
       "motor_erpm_max": {
         "english": "Maximum motor electrical rpm",
         "translation": "Maximale RPM",
         "needs_translation": false,
-        "max_length": 28,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 28
       },
       "response_speed": {
         "english": "Response speed for the motor",
         "translation": "Reaktionsgeschwindigkeit des Motors",
         "needs_translation": false,
-        "max_length": 28,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 28
       },
       "soft_start": {
         "english": "Soft start time",
         "translation": "Wert fuer sanftes Anlaufen",
         "needs_translation": false,
-        "max_length": 15,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 15
       },
       "starting_torque": {
         "english": "Starting power for the motor",
         "translation": "Anlaufmoment fuer den Motor",
         "needs_translation": false,
-        "max_length": 28,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 28
       },
       "tbl_alwaysoff": {
         "english": "Always Off",
         "translation": "Immer aus",
         "needs_translation": false,
-        "max_length": 10,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 10
       },
       "tbl_alwayson": {
         "english": "Always On",
         "translation": "Immer an",
         "needs_translation": false,
-        "max_length": 9,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 9
       },
       "tbl_auto": {
         "english": "Automatic",
         "translation": "Auto",
         "needs_translation": false,
-        "max_length": 9,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 9
       },
       "tbl_automatic": {
         "english": "Temp Control",
         "translation": "Automatisch",
         "needs_translation": false,
-        "max_length": 12,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 12
       },
       "tbl_ccw": {
         "english": "Reversed",
         "translation": "CCW",
         "needs_translation": false,
-        "max_length": 8,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 8
       },
       "tbl_cw": {
         "english": "Normal",
         "translation": "CW",
         "needs_translation": false,
-        "max_length": 6,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 6
       },
       "tbl_disabled": {
         "english": "Disabled",
         "translation": "Deaktiviert",
         "needs_translation": false,
-        "max_length": 8,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 8
       },
       "tbl_enabled": {
         "english": "Enabled",
         "translation": "Aktiviert",
         "needs_translation": false,
-        "max_length": 7,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 7
       },
       "tbl_escgov": {
         "english": "ESC Governor",
         "translation": "ESC-Governor",
-        "needs_translation": true,
-        "max_length": 12,
-        "reverse_text": false
+        "needs_translation": false,
+        "reverse_text": false,
+        "max_length": 12
       },
       "tbl_linear_thr": {
         "english": "Linear Throttle",
         "translation": "Lineares Gas",
         "needs_translation": false,
-        "max_length": 15,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 15
       },
       "tbl_rf_gov": {
         "english": "RF Gyro Governor",
         "translation": "RF Gyro-Governor",
-        "needs_translation": true,
-        "max_length": 16,
-        "reverse_text": false
+        "needs_translation": false,
+        "reverse_text": false,
+        "max_length": 16
       },
       "temperature_protection": {
         "english": "Temperature at which we cut power by 50%",
         "translation": "Temperatur, bei der die Leistung um 50 % reduziert wird",
         "needs_translation": false,
-        "max_length": 40,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 40
       },
       "throttle_max": {
         "english": "Maximum throttle calibration value",
         "translation": "Maximaler Gaswert",
         "needs_translation": false,
-        "max_length": 34,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 34
       },
       "throttle_min": {
         "english": "Minimum throttle calibration value",
         "translation": "Minimaler Gaswert",
         "needs_translation": false,
-        "max_length": 34,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 34
       }
     },
     "ESC_PARAMETERS_HW5": {
@@ -328,99 +328,99 @@
         "english": "Auto Calculate",
         "translation": "Automatische Berechnung",
         "needs_translation": false,
-        "max_length": 14,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 14
       },
       "tbl_ccw": {
         "english": "CCW",
         "translation": "CCW",
         "needs_translation": true,
-        "max_length": 3,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 3
       },
       "tbl_cw": {
         "english": "CW",
         "translation": "CW",
         "needs_translation": true,
-        "max_length": 2,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 2
       },
       "tbl_disabled": {
         "english": "Disabled",
         "translation": "Deaktiviert",
         "needs_translation": false,
-        "max_length": 8,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 8
       },
       "tbl_enabled": {
         "english": "Enabled",
         "translation": "Aktiviert",
         "needs_translation": false,
-        "max_length": 7,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 7
       },
       "tbl_fixedwing": {
         "english": "Fixed Wing",
         "translation": "Flaechenflugzeug",
         "needs_translation": false,
-        "max_length": 10,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 10
       },
       "tbl_hardcutoff": {
         "english": "Hard Cutoff",
         "translation": "Harte Abschaltung",
         "needs_translation": false,
-        "max_length": 11,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 11
       },
       "tbl_heliext": {
         "english": "Heli Ext Governor",
         "translation": "Heli Externer Governor",
         "needs_translation": false,
-        "max_length": 17,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 17
       },
       "tbl_heligov": {
         "english": "Heli Governor",
         "translation": "Heli Governor",
         "needs_translation": true,
-        "max_length": 13,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 13
       },
       "tbl_helistore": {
         "english": "Heli Governor Store",
         "translation": "Heli Governor Speicher",
         "needs_translation": false,
-        "max_length": 19,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 19
       },
       "tbl_normal": {
         "english": "Normal",
         "translation": "Normal",
-        "needs_translation": true,
-        "max_length": 6,
-        "reverse_text": false
+        "needs_translation": false,
+        "reverse_text": false,
+        "max_length": 6
       },
       "tbl_proportional": {
         "english": "Proportional",
         "translation": "Proportional",
-        "needs_translation": true,
-        "max_length": 12,
-        "reverse_text": false
+        "needs_translation": false,
+        "reverse_text": false,
+        "max_length": 12
       },
       "tbl_reverse": {
         "english": "Reverse",
         "translation": "Umgekehrt",
         "needs_translation": false,
-        "max_length": 7,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 7
       },
       "tbl_softcutoff": {
         "english": "Soft Cutoff",
         "translation": "Sanfte Abschaltung",
         "needs_translation": false,
-        "max_length": 11,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 11
       }
     },
     "ESC_PARAMETERS_OMP": {
@@ -428,197 +428,197 @@
         "english": "Auto",
         "translation": "Automatisch",
         "needs_translation": false,
-        "max_length": 4,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 4
       },
       "tbl_blue": {
         "english": "BLUE",
         "translation": "Blau",
         "needs_translation": false,
-        "max_length": 4,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 4
       },
       "tbl_ccw": {
         "english": "CCW",
         "translation": "CCW",
         "needs_translation": true,
-        "max_length": 3,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 3
       },
       "tbl_cw": {
         "english": "CW",
         "translation": "CW",
         "needs_translation": true,
-        "max_length": 2,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 2
       },
       "tbl_cyan": {
         "english": "CYAN",
         "translation": "Cyan",
         "needs_translation": true,
-        "max_length": 4,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 4
       },
       "tbl_escgov": {
         "english": "ESC Governor",
         "translation": "ESC-Governor",
         "needs_translation": true,
-        "max_length": 12,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 12
       },
       "tbl_extgov": {
         "english": "External Governor",
         "translation": "Externer Governor",
         "needs_translation": false,
-        "max_length": 17,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 17
       },
       "tbl_fast": {
         "english": "Fast",
         "translation": "Schnell",
         "needs_translation": false,
-        "max_length": 4,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 4
       },
       "tbl_fmfw": {
         "english": "Fixed Wing",
         "translation": "Flaechenflugzeug",
         "needs_translation": false,
-        "max_length": 10,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 10
       },
       "tbl_fmheli": {
         "english": "Helicopter",
         "translation": "Helikopter",
         "needs_translation": false,
-        "max_length": 10,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 10
       },
       "tbl_fwgov": {
         "english": "Fixed Wing",
         "translation": "Flaechenflugzeug",
         "needs_translation": false,
-        "max_length": 10,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 10
       },
       "tbl_green": {
         "english": "GREEN",
         "translation": "Gruen",
         "needs_translation": false,
-        "max_length": 5,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 5
       },
       "tbl_high": {
         "english": "High",
         "translation": "Hoch",
         "needs_translation": false,
-        "max_length": 4,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 4
       },
       "tbl_jadegreen": {
         "english": "JADE GREEN",
         "translation": "Jadegruen",
         "needs_translation": false,
-        "max_length": 10,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 10
       },
       "tbl_low": {
         "english": "Low",
         "translation": "Niedrig",
         "needs_translation": false,
-        "max_length": 3,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 3
       },
       "tbl_medium": {
         "english": "Medium",
         "translation": "Mittel",
         "needs_translation": false,
-        "max_length": 6,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 6
       },
       "tbl_normal": {
         "english": "Normal",
         "translation": "Normal",
         "needs_translation": true,
-        "max_length": 6,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 6
       },
       "tbl_off": {
         "english": "Off",
         "translation": "Aus",
         "needs_translation": false,
-        "max_length": 3,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 3
       },
       "tbl_on": {
         "english": "On",
         "translation": "An",
         "needs_translation": false,
-        "max_length": 2,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 2
       },
       "tbl_orange": {
         "english": "ORANGE",
         "translation": "Orange",
-        "needs_translation": true,
-        "max_length": 6,
-        "reverse_text": false
+        "needs_translation": false,
+        "reverse_text": false,
+        "max_length": 6
       },
       "tbl_pink": {
         "english": "PINK",
         "translation": "Pink",
-        "needs_translation": true,
-        "max_length": 4,
-        "reverse_text": false
+        "needs_translation": false,
+        "reverse_text": false,
+        "max_length": 4
       },
       "tbl_purple": {
         "english": "PURPLE",
         "translation": "Lila",
         "needs_translation": false,
-        "max_length": 6,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 6
       },
       "tbl_red": {
         "english": "Red",
         "translation": "Rot",
         "needs_translation": false,
-        "max_length": 3,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 3
       },
       "tbl_reverse": {
         "english": "Reverse",
         "translation": "Umgekehrt",
         "needs_translation": false,
-        "max_length": 7,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 7
       },
       "tbl_slow": {
         "english": "Slow",
         "translation": "Langsam",
         "needs_translation": false,
-        "max_length": 4,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 4
       },
       "tbl_vslow": {
         "english": "Very Slow",
         "translation": "Sehr langsam",
         "needs_translation": false,
-        "max_length": 9,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 9
       },
       "tbl_white": {
         "english": "WHITE",
         "translation": "Weiß",
         "needs_translation": false,
-        "max_length": 5,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 5
       },
       "tbl_yellow": {
         "english": "YELLOW",
         "translation": "Gelb",
         "needs_translation": false,
-        "max_length": 6,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 6
       }
     },
     "ESC_PARAMETERS_SCORPION": {
@@ -626,113 +626,113 @@
         "english": "Airplane mode",
         "translation": "Flugzeugmodus",
         "needs_translation": false,
-        "max_length": 13,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 13
       },
       "tbl_boat": {
         "english": "Boat mode",
         "translation": "Bootmodus",
         "needs_translation": false,
-        "max_length": 9,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 9
       },
       "tbl_ccw": {
         "english": "CCW",
         "translation": "CCW",
         "needs_translation": true,
-        "max_length": 3,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 3
       },
       "tbl_cw": {
         "english": "CW",
         "translation": "CW",
         "needs_translation": true,
-        "max_length": 2,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 2
       },
       "tbl_exbus": {
         "english": "Jeti Exbus",
         "translation": "Jeti Exbus",
-        "needs_translation": true,
-        "max_length": 10,
-        "reverse_text": false
+        "needs_translation": false,
+        "reverse_text": false,
+        "max_length": 10
       },
       "tbl_extgov": {
         "english": "External Governor",
         "translation": "Externer Governor",
         "needs_translation": false,
-        "max_length": 17,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 17
       },
       "tbl_futsbus": {
         "english": "Futaba SBUS",
         "translation": "Futaba SBUS",
-        "needs_translation": true,
-        "max_length": 11,
-        "reverse_text": false
+        "needs_translation": false,
+        "reverse_text": false,
+        "max_length": 11
       },
       "tbl_heligov": {
         "english": "Heli Governor",
         "translation": "Heli Governor",
-        "needs_translation": true,
-        "max_length": 13,
-        "reverse_text": false
+        "needs_translation": false,
+        "reverse_text": false,
+        "max_length": 13
       },
       "tbl_helistore": {
         "english": "Heli Governor (stored)",
         "translation": "Heli Governor (gespeichert)",
         "needs_translation": false,
-        "max_length": 22,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 22
       },
       "tbl_off": {
         "english": "Off",
         "translation": "Aus",
         "needs_translation": false,
-        "max_length": 3,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 3
       },
       "tbl_on": {
         "english": "On",
         "translation": "An",
         "needs_translation": false,
-        "max_length": 2,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 2
       },
       "tbl_quad": {
         "english": "Quad mode",
         "translation": "Quadmodus",
         "needs_translation": false,
-        "max_length": 9,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 9
       },
       "tbl_standard": {
         "english": "Standard",
         "translation": "Standard",
-        "needs_translation": true,
-        "max_length": 8,
-        "reverse_text": false
+        "needs_translation": false,
+        "reverse_text": false,
+        "max_length": 8
       },
       "tbl_unsolicited": {
         "english": "Unsolicited",
         "translation": "Unaufgefordert",
         "needs_translation": false,
-        "max_length": 11,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 11
       },
       "tbl_vbar": {
         "english": "VBar",
         "translation": "VBar",
-        "needs_translation": true,
-        "max_length": 4,
-        "reverse_text": false
+        "needs_translation": false,
+        "reverse_text": false,
+        "max_length": 4
       },
       "tbl_vbargov": {
         "english": "VBar Governor",
         "translation": "VBar Governor",
-        "needs_translation": true,
-        "max_length": 13,
-        "reverse_text": false
+        "needs_translation": false,
+        "reverse_text": false,
+        "max_length": 13
       }
     },
     "ESC_PARAMETERS_XDFLY": {
@@ -740,197 +740,197 @@
         "english": "Auto",
         "translation": "Automatisch",
         "needs_translation": false,
-        "max_length": 4,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 4
       },
       "tbl_blue": {
         "english": "BLUE",
         "translation": "Blau",
         "needs_translation": false,
-        "max_length": 4,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 4
       },
       "tbl_ccw": {
         "english": "CCW",
         "translation": "CCW",
         "needs_translation": true,
-        "max_length": 3,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 3
       },
       "tbl_cw": {
         "english": "CW",
         "translation": "CW",
         "needs_translation": true,
-        "max_length": 2,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 2
       },
       "tbl_cyan": {
         "english": "CYAN",
         "translation": "Cyan",
         "needs_translation": true,
-        "max_length": 4,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 4
       },
       "tbl_escgov": {
         "english": "ESC Governor",
         "translation": "ESC-Governor",
         "needs_translation": true,
-        "max_length": 12,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 12
       },
       "tbl_extgov": {
         "english": "External Governor",
         "translation": "Externer Governor",
         "needs_translation": false,
-        "max_length": 17,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 17
       },
       "tbl_fast": {
         "english": "Fast",
         "translation": "Schnell",
         "needs_translation": false,
-        "max_length": 4,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 4
       },
       "tbl_fmfw": {
         "english": "Fixed Wing",
         "translation": "Flaechenflugzeug",
         "needs_translation": false,
-        "max_length": 10,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 10
       },
       "tbl_fmheli": {
         "english": "Helicopter",
         "translation": "Helikopter",
         "needs_translation": false,
-        "max_length": 10,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 10
       },
       "tbl_fwgov": {
         "english": "Fixed Wing",
         "translation": "Flaechenflugzeug",
         "needs_translation": false,
-        "max_length": 10,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 10
       },
       "tbl_green": {
         "english": "GREEN",
         "translation": "Gruen",
         "needs_translation": false,
-        "max_length": 5,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 5
       },
       "tbl_high": {
         "english": "High",
         "translation": "Hoch",
         "needs_translation": false,
-        "max_length": 4,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 4
       },
       "tbl_jadegreen": {
         "english": "JADE GREEN",
         "translation": "Jadegruen",
         "needs_translation": false,
-        "max_length": 10,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 10
       },
       "tbl_low": {
         "english": "Low",
         "translation": "Niedrig",
         "needs_translation": false,
-        "max_length": 3,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 3
       },
       "tbl_medium": {
         "english": "Medium",
         "translation": "Mittel",
         "needs_translation": false,
-        "max_length": 6,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 6
       },
       "tbl_normal": {
         "english": "Normal",
         "translation": "Normal",
-        "needs_translation": true,
-        "max_length": 6,
-        "reverse_text": false
+        "needs_translation": false,
+        "reverse_text": false,
+        "max_length": 6
       },
       "tbl_off": {
         "english": "Off",
         "translation": "Aus",
         "needs_translation": false,
-        "max_length": 3,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 3
       },
       "tbl_on": {
         "english": "On",
         "translation": "An",
         "needs_translation": false,
-        "max_length": 2,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 2
       },
       "tbl_orange": {
         "english": "ORANGE",
         "translation": "Orange",
-        "needs_translation": true,
-        "max_length": 6,
-        "reverse_text": false
+        "needs_translation": false,
+        "reverse_text": false,
+        "max_length": 6
       },
       "tbl_pink": {
         "english": "PINK",
         "translation": "Pink",
-        "needs_translation": true,
-        "max_length": 4,
-        "reverse_text": false
+        "needs_translation": false,
+        "reverse_text": false,
+        "max_length": 4
       },
       "tbl_purple": {
         "english": "PURPLE",
         "translation": "Lila",
         "needs_translation": false,
-        "max_length": 6,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 6
       },
       "tbl_red": {
         "english": "Red",
         "translation": "Rot",
         "needs_translation": false,
-        "max_length": 3,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 3
       },
       "tbl_reverse": {
         "english": "Reverse",
         "translation": "Umgekehrt",
         "needs_translation": false,
-        "max_length": 7,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 7
       },
       "tbl_slow": {
         "english": "Slow",
         "translation": "Langsam",
         "needs_translation": false,
-        "max_length": 4,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 4
       },
       "tbl_vslow": {
         "english": "Very Slow",
         "translation": "Sehr langsam",
         "needs_translation": false,
-        "max_length": 9,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 9
       },
       "tbl_white": {
         "english": "WHITE",
         "translation": "Weiß",
         "needs_translation": false,
-        "max_length": 5,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 5
       },
       "tbl_yellow": {
         "english": "YELLOW",
         "translation": "Gelb",
         "needs_translation": false,
-        "max_length": 6,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 6
       }
     },
     "ESC_PARAMETERS_YGE": {
@@ -938,176 +938,176 @@
         "english": "Always On",
         "translation": "Immer an",
         "needs_translation": false,
-        "max_length": 9,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 9
       },
       "tbl_auto": {
         "english": "Auto",
         "translation": "Automatisch",
         "needs_translation": false,
-        "max_length": 4,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 4
       },
       "tbl_autoefficient": {
         "english": "Auto Efficient",
         "translation": "Automatisch Effizient",
         "needs_translation": false,
-        "max_length": 14,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 14
       },
       "tbl_autoextreme": {
         "english": "Auto Extreme",
         "translation": "Automatisch Extrem",
         "needs_translation": false,
-        "max_length": 12,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 12
       },
       "tbl_autonorm": {
         "english": "Auto Normal",
         "translation": "Auto Normal",
-        "needs_translation": true,
-        "max_length": 11,
-        "reverse_text": false
+        "needs_translation": false,
+        "reverse_text": false,
+        "max_length": 11
       },
       "tbl_autopower": {
         "english": "Auto Power",
         "translation": "Automatische Leistung",
         "needs_translation": false,
-        "max_length": 10,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 10
       },
       "tbl_custom": {
         "english": "Custom (PC Defined)",
         "translation": "Benutzerdefiniert (PC-Definiert)",
         "needs_translation": false,
-        "max_length": 19,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 19
       },
       "tbl_cutoff": {
         "english": "Cutoff",
         "translation": "Abschaltung",
         "needs_translation": false,
-        "max_length": 6,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 6
       },
       "tbl_fast": {
         "english": "Fast",
         "translation": "Schnell",
         "needs_translation": false,
-        "max_length": 4,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 4
       },
       "tbl_medium": {
         "english": "Medium",
         "translation": "Mittel",
         "needs_translation": false,
-        "max_length": 6,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 6
       },
       "tbl_modeair": {
         "english": "Aero Motor",
         "translation": "Luftfahrtmotor",
         "needs_translation": false,
-        "max_length": 10,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 10
       },
       "tbl_modeext": {
         "english": "Heli Ext Governor",
         "translation": "Heli ext. Governor",
         "needs_translation": true,
-        "max_length": 17,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 17
       },
       "tbl_modef3a": {
         "english": "Aero F3A",
         "translation": "Luftfahrt F3A",
         "needs_translation": false,
-        "max_length": 8,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 8
       },
       "tbl_modefree": {
         "english": "Free (Attention!)",
         "translation": "Frei (Achtung!)",
         "needs_translation": false,
-        "max_length": 17,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 17
       },
       "tbl_modeglider": {
         "english": "Aero Glider",
         "translation": "Segelflugzeug",
         "needs_translation": false,
-        "max_length": 11,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 11
       },
       "tbl_modeheli": {
         "english": "Heli Governor",
         "translation": "Heli Governor",
         "needs_translation": true,
-        "max_length": 13,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 13
       },
       "tbl_modestore": {
         "english": "Heli Governor Store",
         "translation": "Heli Governor (gespeichert)",
         "needs_translation": false,
-        "max_length": 19,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 19
       },
       "tbl_normal": {
         "english": "Normal",
         "translation": "Normal",
-        "needs_translation": true,
-        "max_length": 6,
-        "reverse_text": false
+        "needs_translation": false,
+        "reverse_text": false,
+        "max_length": 6
       },
       "tbl_off": {
         "english": "Off",
         "translation": "Aus",
         "needs_translation": false,
-        "max_length": 3,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 3
       },
       "tbl_on": {
         "english": "On",
         "translation": "An",
         "needs_translation": false,
-        "max_length": 2,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 2
       },
       "tbl_reverse": {
         "english": "Reverse",
         "translation": "Umgekehrt",
         "needs_translation": false,
-        "max_length": 7,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 7
       },
       "tbl_slow": {
         "english": "Slow",
         "translation": "Langsam",
         "needs_translation": false,
-        "max_length": 4,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 4
       },
       "tbl_slowdown": {
         "english": "Slowdown",
         "translation": "Verlangsamen",
         "needs_translation": false,
-        "max_length": 8,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 8
       },
       "tbl_smooth": {
         "english": "Smooth",
         "translation": "Sanft",
         "needs_translation": false,
-        "max_length": 6,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 6
       },
       "tbl_unused": {
         "english": "*Unused*",
         "translation": "*Nicht verwendet*",
         "needs_translation": false,
-        "max_length": 8,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 8
       }
     },
     "ESC_PARAMETERS_ZTW": {
@@ -1115,197 +1115,197 @@
         "english": "Auto",
         "translation": "Automatisch",
         "needs_translation": false,
-        "max_length": 4,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 4
       },
       "tbl_blue": {
         "english": "BLUE",
         "translation": "Blau",
         "needs_translation": false,
-        "max_length": 4,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 4
       },
       "tbl_ccw": {
         "english": "CCW",
         "translation": "CCW",
         "needs_translation": true,
-        "max_length": 3,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 3
       },
       "tbl_cw": {
         "english": "CW",
         "translation": "CW",
         "needs_translation": true,
-        "max_length": 2,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 2
       },
       "tbl_cyan": {
         "english": "CYAN",
         "translation": "Cyan",
         "needs_translation": true,
-        "max_length": 4,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 4
       },
       "tbl_escgov": {
         "english": "ESC Governor",
         "translation": "ESC-Governor",
         "needs_translation": true,
-        "max_length": 12,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 12
       },
       "tbl_extgov": {
         "english": "External Governor",
         "translation": "Externer Governor",
         "needs_translation": false,
-        "max_length": 17,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 17
       },
       "tbl_fast": {
         "english": "Fast",
         "translation": "Schnell",
         "needs_translation": false,
-        "max_length": 4,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 4
       },
       "tbl_fmfw": {
         "english": "Fixed Wing",
         "translation": "Flaechenflugzeug",
         "needs_translation": false,
-        "max_length": 10,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 10
       },
       "tbl_fmheli": {
         "english": "Helicopter",
         "translation": "Helikopter",
         "needs_translation": false,
-        "max_length": 10,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 10
       },
       "tbl_fwgov": {
         "english": "Fixed Wing",
         "translation": "Flaechenflugzeug",
         "needs_translation": false,
-        "max_length": 10,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 10
       },
       "tbl_green": {
         "english": "GREEN",
         "translation": "Gruen",
         "needs_translation": false,
-        "max_length": 5,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 5
       },
       "tbl_high": {
         "english": "High",
         "translation": "Hoch",
         "needs_translation": false,
-        "max_length": 4,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 4
       },
       "tbl_jadegreen": {
         "english": "JADE GREEN",
         "translation": "Jadegruen",
         "needs_translation": false,
-        "max_length": 10,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 10
       },
       "tbl_low": {
         "english": "Low",
         "translation": "Niedrig",
         "needs_translation": false,
-        "max_length": 3,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 3
       },
       "tbl_medium": {
         "english": "Medium",
         "translation": "Mittel",
         "needs_translation": false,
-        "max_length": 6,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 6
       },
       "tbl_normal": {
         "english": "Normal",
         "translation": "Normal",
-        "needs_translation": true,
-        "max_length": 6,
-        "reverse_text": false
+        "needs_translation": false,
+        "reverse_text": false,
+        "max_length": 6
       },
       "tbl_off": {
         "english": "Off",
         "translation": "Aus",
         "needs_translation": false,
-        "max_length": 3,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 3
       },
       "tbl_on": {
         "english": "On",
         "translation": "An",
         "needs_translation": false,
-        "max_length": 2,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 2
       },
       "tbl_orange": {
         "english": "ORANGE",
         "translation": "Orange",
-        "needs_translation": true,
-        "max_length": 6,
-        "reverse_text": false
+        "needs_translation": false,
+        "reverse_text": false,
+        "max_length": 6
       },
       "tbl_pink": {
         "english": "PINK",
         "translation": "Pink",
         "needs_translation": true,
-        "max_length": 4,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 4
       },
       "tbl_purple": {
         "english": "PURPLE",
         "translation": "Lila",
         "needs_translation": false,
-        "max_length": 6,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 6
       },
       "tbl_red": {
         "english": "Red",
         "translation": "Rot",
         "needs_translation": false,
-        "max_length": 3,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 3
       },
       "tbl_reverse": {
         "english": "Reverse",
         "translation": "Umgekehrt",
         "needs_translation": false,
-        "max_length": 7,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 7
       },
       "tbl_slow": {
         "english": "Slow",
         "translation": "Langsam",
         "needs_translation": false,
-        "max_length": 4,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 4
       },
       "tbl_vslow": {
         "english": "Very Slow",
         "translation": "Sehr langsam",
         "needs_translation": false,
-        "max_length": 9,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 9
       },
       "tbl_white": {
         "english": "WHITE",
         "translation": "Weiß",
         "needs_translation": false,
-        "max_length": 5,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 5
       },
       "tbl_yellow": {
         "english": "YELLOW",
         "translation": "Gelb",
         "needs_translation": false,
-        "max_length": 6,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 6
       }
     },
     "ESC_SENSOR_CONFIG": {
@@ -1313,85 +1313,85 @@
         "english": "Adjust the consumption correction",
         "translation": "Anpassen der Verbrauchskorrektur",
         "needs_translation": false,
-        "max_length": 33,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 33
       },
       "current_correction": {
         "english": "Adjust current correction",
         "translation": "Anpassen der Stromkorrektur",
         "needs_translation": false,
-        "max_length": 25,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 25
       },
       "current_offset": {
         "english": "Current sensor offset adjustment",
         "translation": "Stromsensor-Offset-Anpassung",
         "needs_translation": false,
-        "max_length": 32,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 32
       },
       "half_duplex": {
         "english": "Half duplex mode for ESC telemetry",
         "translation": "Halbduplex-Modus fuer ESC-Telemetrie",
         "needs_translation": false,
-        "max_length": 34,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 34
       },
       "hw4_current_gain": {
         "english": "Hobbywing v4 current gain adjustment",
         "translation": "Hobbywing v4 Stromverstaerkung-Anpassung",
         "needs_translation": false,
-        "max_length": 36,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 36
       },
       "hw4_current_offset": {
         "english": "Hobbywing v4 current offset adjustment",
         "translation": "Hobbywing v4 Strom-Offset-Anpassung",
         "needs_translation": false,
-        "max_length": 38,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 38
       },
       "hw4_voltage_gain": {
         "english": "Hobbywing v4 voltage gain adjustment",
         "translation": "Hobbywing v4 Spannungsverstaerkung-Anpassung",
         "needs_translation": false,
-        "max_length": 36,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 36
       },
       "pin_swap": {
         "english": "Swap the TX and RX pins for the ESC telemetry",
         "translation": "Tauschen der TX- und RX-Pins fuer die ESC-Telemetrie",
         "needs_translation": false,
-        "max_length": 45,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 45
       },
       "tbl_off": {
         "english": "Off",
         "translation": "Aus",
         "needs_translation": false,
-        "max_length": 3,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 3
       },
       "tbl_on": {
         "english": "On",
         "translation": "Ein",
         "needs_translation": false,
-        "max_length": 2,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 2
       },
       "update_hz": {
         "english": "ESC telemetry update rate",
         "translation": "ESC-Telemetrie-Aktualisierungsrate",
         "needs_translation": false,
-        "max_length": 25,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 25
       },
       "voltage_correction": {
         "english": "Adjust the voltage correction",
         "translation": "Anpassen der Spannungskorrektur",
         "needs_translation": false,
-        "max_length": 29,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 29
       }
     },
     "FILTER_CONFIG": {
@@ -1399,141 +1399,141 @@
         "english": "Number of notches to apply.",
         "translation": "Anzahl der Notches.",
         "needs_translation": false,
-        "max_length": 27,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 27
       },
       "dyn_notch_max_hz": {
         "english": "Maximum frequency to which the notch is applied.",
         "translation": "Maximale Frequenz, auf die der Notch-Filter angewendet wird.",
         "needs_translation": false,
-        "max_length": 48,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 48
       },
       "dyn_notch_min_hz": {
         "english": "Minimum frequency to which the notch is applied.",
         "translation": "Minimale Frequenz, auf die der Notch-Filter angewendet wird.",
         "needs_translation": false,
-        "max_length": 48,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 48
       },
       "dyn_notch_q": {
         "english": "Quality factor of the notch filter.",
         "translation": "Qualitaetsfaktor des dynamischen Notch-Filters.",
         "needs_translation": false,
-        "max_length": 35,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 35
       },
       "gyro_lpf1_dyn_max_hz": {
         "english": "Dynamic filter max cutoff in Hz.",
         "translation": "Dynamischer Filter - maximale Grenzfrequenz in Hz.",
         "needs_translation": false,
-        "max_length": 32,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 32
       },
       "gyro_lpf1_dyn_min_hz": {
         "english": "Dynamic filter min cutoff in Hz.",
         "translation": "Dynamischer Filter - minimale Grenzfrequenz in Hz.",
         "needs_translation": false,
-        "max_length": 32,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 32
       },
       "gyro_lpf1_static_hz": {
         "english": "Lowpass filter cutoff frequency in Hz.",
         "translation": "Tiefpassfilter-Grenzfrequenz in Hz.",
         "needs_translation": false,
-        "max_length": 38,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 38
       },
       "gyro_lpf2_static_hz": {
         "english": "Lowpass filter cutoff frequency in Hz.",
         "translation": "Tiefpassfilter-Grenzfrequenz in Hz.",
         "needs_translation": false,
-        "max_length": 38,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 38
       },
       "gyro_soft_notch_cutoff_1": {
         "english": "Width of the notch filter in Hz.",
         "translation": "Breite des Notch-Filters in Hz.",
         "needs_translation": false,
-        "max_length": 32,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 32
       },
       "gyro_soft_notch_cutoff_2": {
         "english": "Width of the notch filter in Hz.",
         "translation": "Breite des Notch-Filters in Hz.",
         "needs_translation": false,
-        "max_length": 32,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 32
       },
       "gyro_soft_notch_hz_1": {
         "english": "Center frequency to which the notch is applied.",
         "translation": "Zentralfrequenz, auf die der Notch-Filter angewendet wird.",
         "needs_translation": false,
-        "max_length": 47,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 47
       },
       "gyro_soft_notch_hz_2": {
         "english": "Center frequency to which the notch is applied.",
         "translation": "Zentralfrequenz, auf die der Notch-Filter angewendet wird.",
         "needs_translation": false,
-        "max_length": 47,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 47
       },
       "rpm_min_hz": {
         "english": "Minimum frequency for the RPM filter.",
         "translation": "Minimale Frequenz des Drehzahlfilters.",
         "needs_translation": false,
-        "max_length": 37,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 37
       },
       "tbl_1st": {
         "english": "1ST",
         "translation": "1.",
         "needs_translation": false,
-        "max_length": 3,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 3
       },
       "tbl_2nd": {
         "english": "2ND",
         "translation": "2.",
         "needs_translation": false,
-        "max_length": 3,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 3
       },
       "tbl_custom": {
         "english": "CUSTOM",
         "translation": "BENUTZERDEF.",
         "needs_translation": false,
-        "max_length": 6,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 6
       },
       "tbl_high": {
         "english": "HIGH",
         "translation": "HOCH",
         "needs_translation": false,
-        "max_length": 4,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 4
       },
       "tbl_low": {
         "english": "LOW",
         "translation": "NIEDRIG",
         "needs_translation": false,
-        "max_length": 3,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 3
       },
       "tbl_medium": {
         "english": "MEDIUM",
         "translation": "MITTEL",
         "needs_translation": false,
-        "max_length": 6,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 6
       },
       "tbl_none": {
         "english": "NONE",
         "translation": "KEINE",
         "needs_translation": false,
-        "max_length": 4,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 4
       }
     },
     "GOVERNOR_CONFIG": {
@@ -1541,141 +1541,141 @@
         "english": "Governor activates above this %. Below this the input throttle is passed to the ESC.",
         "translation": "Der Governor aktiviert sich ueber diesem Wert in %. Darunter wird das Eingangs-Gas an den ESC weitergegeben.",
         "needs_translation": false,
-        "max_length": 84,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 84
       },
       "gov_recovery_time": {
         "english": "Time constant for recovery spoolup, in seconds, measuring the time from zero to full headspeed.",
         "translation": "Zeitkonstante fuer die Wiederherstellung des Hochfahrens in Sekunden, gemessen von null bis zur vollen Drehzahl.",
         "needs_translation": false,
-        "max_length": 95,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 95
       },
       "gov_spoolup_min_throttle": {
         "english": "Minimum throttle to use for slow spoolup, in percent. For electric motors the default is 5%, for nitro this should be set so the clutch starts to engage for a smooth spoolup 10-15%.",
         "translation": "Minimaler Gaswert fuer langsames Hochfahren in Prozent. Bei Elektromotoren ist der Standardwert 5 %, bei Nitro sollte der Wert so eingestellt werden, dass die Kupplung fuer ein sanftes Hochfahren zu greifen beginnt (10-15 %).",
         "needs_translation": false,
-        "max_length": 181,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 181
       },
       "gov_spoolup_time": {
         "english": "Time constant for slow spoolup, in seconds, measuring the time from zero to full headspeed.",
         "translation": "Zeitkonstante fuer das langsame Hochfahren in Sekunden, gemessen von null bis zur vollen Drehzahl.",
         "needs_translation": false,
-        "max_length": 91,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 91
       },
       "gov_startup_time": {
         "english": "Time constant for slow startup, in seconds, measuring the time from zero to full headspeed.",
         "translation": "Zeitkonstante fuer den langsamen Start in Sekunden, gemessen von null bis zur vollen Drehzahl.",
         "needs_translation": false,
-        "max_length": 91,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 91
       },
       "gov_tracking_time": {
         "english": "Time constant for headspeed changes, in seconds, measuring the time from zero to full headspeed.",
         "translation": "Zeitkonstante fuer Drehzahlaenderungen in Sekunden, gemessen von null bis zur vollen Drehzahl.",
         "needs_translation": false,
-        "max_length": 96,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 96
       },
       "governor_auto_throttle": {
         "english": "Auto throttle",
         "translation": "Automatikgas",
         "needs_translation": false,
-        "max_length": 13,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 13
       },
       "governor_idle_throttle": {
         "english": "Idle throttle",
         "translation": "Leerlaufgas",
         "needs_translation": false,
-        "max_length": 13,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 13
       },
       "tbl_govmode_direct": {
         "english": "DIRECT",
         "translation": "DIREKT",
         "needs_translation": false,
-        "max_length": 6,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 6
       },
       "tbl_govmode_electric": {
         "english": "ELECTRIC",
         "translation": "ELEKTRISCH",
         "needs_translation": false,
-        "max_length": 8,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 8
       },
       "tbl_govmode_limit": {
         "english": "LIMIT",
         "translation": "LIMIT",
         "needs_translation": true,
-        "max_length": 5,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 5
       },
       "tbl_govmode_mode1": {
         "english": "MODE1",
         "translation": "MODUS1",
         "needs_translation": false,
-        "max_length": 5,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 5
       },
       "tbl_govmode_mode2": {
         "english": "MODE2",
         "translation": "MODUS2",
         "needs_translation": false,
-        "max_length": 5,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 5
       },
       "tbl_govmode_nitro": {
         "english": "NITRO",
         "translation": "NITRO",
         "needs_translation": true,
-        "max_length": 5,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 5
       },
       "tbl_govmode_off": {
         "english": "OFF",
         "translation": "AUS",
         "needs_translation": false,
-        "max_length": 3,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 3
       },
       "tbl_govmode_passthrough": {
         "english": "PASSTHROUGH",
         "translation": "DURCHSCHLEIFEN",
         "needs_translation": false,
-        "max_length": 11,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 11
       },
       "tbl_govmode_standard": {
         "english": "STANDARD",
         "translation": "STANDARD",
         "needs_translation": true,
-        "max_length": 8,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 8
       },
       "tbl_throttle_type_function": {
         "english": "FUNCTION",
         "translation": "FUNKTION",
         "needs_translation": false,
-        "max_length": 8,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 8
       },
       "tbl_throttle_type_normal": {
         "english": "NORMAL",
         "translation": "NORMAL",
         "needs_translation": true,
-        "max_length": 6,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 6
       },
       "tbl_throttle_type_switch": {
         "english": "SWITCH",
         "translation": "SCHALTER",
         "needs_translation": false,
-        "max_length": 6,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 6
       }
     },
     "GOVERNOR_PROFILE": {
@@ -1683,106 +1683,106 @@
         "english": "Collective precompensation weight - how much collective is mixed into the feedforward.",
         "translation": "Kollektive Vorkompensationsgewichtung - wie stark kollektiv in das Feedforward gemischt wird.",
         "needs_translation": false,
-        "max_length": 86,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 86
       },
       "governor_cyclic_ff_weight": {
         "english": "Cyclic precompensation weight - how much cyclic is mixed into the feedforward.",
         "translation": "Zyklische Vorkompensationsgewichtung - wie stark zyklisch in das Feedforward gemischt wird.",
         "needs_translation": false,
-        "max_length": 78,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 78
       },
       "governor_d_gain": {
         "english": "PID loop D-term gain.",
         "translation": "D-Term-Verstaerkung der PID-Regler.",
         "needs_translation": false,
-        "max_length": 21,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 21
       },
       "governor_f_gain": {
         "english": "Feedforward gain.",
         "translation": "Feedforward-Verstaerkung.",
         "needs_translation": false,
-        "max_length": 17,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 17
       },
       "governor_gain": {
         "english": "Master PID loop gain.",
         "translation": "Master-Verstaerkung der PID-Regler.",
         "needs_translation": false,
-        "max_length": 21,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 21
       },
       "governor_headspeed": {
         "english": "Target headspeed for the current profile.",
         "translation": "Ziel-Drehzahl fuer das aktuelle Profil.",
         "needs_translation": false,
-        "max_length": 41,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 41
       },
       "governor_i_gain": {
         "english": "PID loop I-term gain.",
         "translation": "I-Term-Verstärkung der PID-Regler.",
         "needs_translation": false,
-        "max_length": 21,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 21
       },
       "governor_max_throttle": {
         "english": "Maximum output throttle the governor is allowed to use.",
         "translation": "Maximales Ausgangs-Gas, das der Governor verwenden darf.",
         "needs_translation": false,
-        "max_length": 55,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 55
       },
       "governor_min_throttle": {
         "english": "Minimum output throttle the governor is allowed to use.",
         "translation": "Minimales Ausgangs-Gas, das der Governor verwenden darf.",
         "needs_translation": false,
-        "max_length": 55,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 55
       },
       "governor_p_gain": {
         "english": "PID loop P-term gain.",
         "translation": "P-Term-Verstaerkung der PID-Regler.",
         "needs_translation": false,
-        "max_length": 21,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 21
       },
       "governor_tta_gain": {
         "english": "TTA gain applied to increase headspeed to control the tail in the negative direction (e.g. motorised tail less than idle speed).",
         "translation": "TTA-Verstaerkung zur Erhoehung der Drehzahl zur Steuerung des Hecks in die negative Richtung (z. B. motorisiertes Heck unter Leerlaufdrehzahl).",
         "needs_translation": false,
-        "max_length": 128,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 128
       },
       "governor_tta_limit": {
         "english": "TTA max headspeed increase over full headspeed.",
         "translation": "Maximale TTA-Drehzahlerhoehung ueber die volle Drehzahl hinaus.",
         "needs_translation": false,
-        "max_length": 47,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 47
       },
       "governor_yaw_ff_weight": {
         "english": "Yaw precompensation weight - how much yaw is mixed into the feedforward.",
         "translation": "Gier-Vorkompensationsgewicht - wie stark Gier in das Feedforward gemischt wird.",
         "needs_translation": false,
-        "max_length": 72,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 72
       },
       "tbl_off": {
         "english": "OFF",
         "translation": "AUS",
         "needs_translation": false,
-        "max_length": 3,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 3
       },
       "tbl_on": {
         "english": "ON",
         "translation": "EIN",
         "needs_translation": false,
-        "max_length": 2,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 2
       }
     },
     "MIXER_CONFIG": {
@@ -1790,113 +1790,113 @@
         "english": "Adjust the collective tilt correction scaling for negative collective pitch.",
         "translation": "Skalierung der Kollektiv-Neigungskorrektur fuer negativen Pitch.",
         "needs_translation": false,
-        "max_length": 76,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 76
       },
       "collective_tilt_correction_pos": {
         "english": "Adjust the collective tilt correction scaling for positive collective pitch.",
         "translation": "Skalierung der Kollektiv-Neigungskorrektur fuer positiven Pitch.",
         "needs_translation": false,
-        "max_length": 76,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 76
       },
       "swash_geo_correction": {
         "english": "Adjust if there is too much negative collective or too much positive collective.",
         "translation": "Anpassen, falls zu viel negativer oder positiver Kollektivpitch vorhanden ist.",
         "needs_translation": false,
-        "max_length": 80,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 80
       },
       "swash_phase": {
         "english": "Phase offset for the swashplate controls.",
         "translation": "Phasenversatz fuer die Taumelscheibensteuerung.",
         "needs_translation": false,
-        "max_length": 41,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 41
       },
       "swash_pitch_limit": {
         "english": "Maximum amount of combined cyclic and collective blade pitch.",
         "translation": "Maximale kombinierte zyklische und kollektive Blattverstellung.",
         "needs_translation": false,
-        "max_length": 61,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 61
       },
       "swash_trim_0": {
         "english": "Swash trim to level the swash plate when using fixed links.",
         "translation": "Taumelscheiben-Trimmung zur Nivellierung bei festen Gestaengen.",
         "needs_translation": false,
-        "max_length": 59,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 59
       },
       "swash_trim_1": {
         "english": "Swash trim to level the swash plate when using fixed links.",
         "translation": "Taumelscheiben-Trimmung zur Nivellierung bei festen Gestaengen.",
         "needs_translation": false,
-        "max_length": 59,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 59
       },
       "swash_trim_2": {
         "english": "Swash trim to level the swash plate when using fixed links.",
         "translation": "Taumelscheiben-Trimmung zur Nivellierung bei festen Gestaengen.",
         "needs_translation": false,
-        "max_length": 59,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 59
       },
       "swash_tta_precomp": {
         "english": "Mixer precomp for 0 yaw.",
         "translation": "Mischer-Vorkompensation fuer 0 Gier.",
         "needs_translation": false,
-        "max_length": 24,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 24
       },
       "tail_center_trim": {
         "english": "Sets tail rotor trim for 0 yaw for variable pitch, or tail motor throttle for 0 yaw for motorized.",
         "translation": "Heckrotor-Trimmung fuer 0 Gier bei variablem Pitch oder Heckmotor-Gas fuer 0 Gier bei motorisiertem Heck.",
         "needs_translation": false,
-        "max_length": 98,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 98
       },
       "tail_motor_idle": {
         "english": "Minimum throttle signal sent to the tail motor. This should be set just high enough that the motor does not stop.",
         "translation": "Minimales Gas-Signal, das an den Heckmotor gesendet wird. Sollte so eingestellt sein, dass der Motor nicht stoppt.",
         "needs_translation": false,
-        "max_length": 113,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 113
       },
       "tbl_ccw": {
         "english": "CCW",
         "translation": "CCW",
         "needs_translation": true,
-        "max_length": 3,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 3
       },
       "tbl_cw": {
         "english": "CW",
         "translation": "CW",
         "needs_translation": true,
-        "max_length": 2,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 2
       },
       "tbl_tail_bidirectional": {
         "english": "Bidirectional",
         "translation": "Bidirektional",
         "needs_translation": false,
-        "max_length": 13,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 13
       },
       "tbl_tail_motororized_tail": {
         "english": "Motorized Tail",
         "translation": "Motorisiertes Heck",
         "needs_translation": false,
-        "max_length": 14,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 14
       },
       "tbl_tail_variable_pitch": {
         "english": "Variable Pitch",
         "translation": "Variabler Pitch",
         "needs_translation": false,
-        "max_length": 14,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 14
       }
     },
     "MIXER_INPUT": {
@@ -1904,15 +1904,15 @@
         "english": "Normal",
         "translation": "Normal",
         "needs_translation": true,
-        "max_length": 6,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 6
       },
       "tbl_reversed": {
         "english": "Reversed",
         "translation": "Umgekehrt",
         "needs_translation": false,
-        "max_length": 8,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 8
       }
     },
     "MOTOR_CONFIG": {
@@ -1920,85 +1920,85 @@
         "english": "Motor Pinion Gear Tooth Count",
         "translation": "Zahnzahl des Motorritzels.",
         "needs_translation": false,
-        "max_length": 29,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 29
       },
       "main_rotor_gear_ratio_1": {
         "english": "Main Gear Tooth Count",
         "translation": "Zahnzahl des Hauptzahnrads.",
         "needs_translation": false,
-        "max_length": 21,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 21
       },
       "maxthrottle": {
         "english": "This PWM value is sent to the ESC/Servo at full throttle",
         "translation": "Dieser PWM-Wert wird an den ESC/Servo bei vollem Gas gesendet.",
         "needs_translation": false,
-        "max_length": 56,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 56
       },
       "mincommand": {
         "english": "This PWM value is sent when the motor is stopped",
         "translation": "Dieser PWM-Wert wird gesendet, wenn der Motor gestoppt ist.",
         "needs_translation": false,
-        "max_length": 48,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 48
       },
       "minthrottle": {
         "english": "This PWM value is sent to the ESC/Servo at low throttle",
         "translation": "Dieser PWM-Wert wird an den ESC/Servo bei minimalem Gas gesendet.",
         "needs_translation": false,
-        "max_length": 55,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 55
       },
       "motor_pole_count_0": {
         "english": "The number of magnets on the motor bell.",
         "translation": "Die Anzahl der Magnete an der Motor-Glocke.",
         "needs_translation": false,
-        "max_length": 40,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 40
       },
       "motor_pwm_protocol": {
         "english": "The protocol used to communicate with the ESC",
         "translation": "Das Protokoll zur Kommunikation mit dem ESC.",
         "needs_translation": false,
-        "max_length": 45,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 45
       },
       "motor_pwm_rate": {
         "english": "The frequency at which the ESC sends PWM signals to the motor",
         "translation": "Die Frequenz, mit der der ESC PWM-Signale an den Motor sendet.",
         "needs_translation": false,
-        "max_length": 61,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 61
       },
       "tail_rotor_gear_ratio_0": {
         "english": "Tail Gear Tooth Count",
         "translation": "Zahnzahl des Heckzahnrads.",
         "needs_translation": false,
-        "max_length": 21,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 21
       },
       "tail_rotor_gear_ratio_1": {
         "english": "Autorotation Gear Tooth Count",
         "translation": "Zahnzahl des Autorotationszahnrads.",
         "needs_translation": false,
-        "max_length": 29,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 29
       },
       "tbl_off": {
         "english": "OFF",
         "translation": "AUS",
         "needs_translation": false,
-        "max_length": 3,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 3
       },
       "tbl_on": {
         "english": "ON",
         "translation": "EIN",
         "needs_translation": false,
-        "max_length": 2,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 2
       }
     },
     "PID_PROFILE": {
@@ -2006,309 +2006,309 @@
         "english": "Limit the maximum angle the helicopter will pitch/roll to while in Angle mode.",
         "translation": "Begrenzt den maximalen Pitch/Roll-Winkel im Winkelmodus.",
         "needs_translation": false,
-        "max_length": 78,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 78
       },
       "angle_level_strength": {
         "english": "Determines how aggressively the helicopter tilts back to level while in Angle Mode.",
         "translation": "Bestimmt, wie stark der Heli im Winkelmodus zur Horizontalen zurueckkippt.",
         "needs_translation": false,
-        "max_length": 83,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 83
       },
       "bterm_cutoff_0": {
         "english": "B-term cutoff in Hz.",
         "translation": "B-Term-Grenzfrequenz in Hz.",
         "needs_translation": false,
-        "max_length": 20,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 20
       },
       "bterm_cutoff_1": {
         "english": "B-term cutoff in Hz.",
         "translation": "B-Term-Grenzfrequenz in Hz.",
         "needs_translation": false,
-        "max_length": 20,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 20
       },
       "bterm_cutoff_2": {
         "english": "B-term cutoff in Hz.",
         "translation": "B-Term-Grenzfrequenz in Hz.",
         "needs_translation": false,
-        "max_length": 20,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 20
       },
       "cyclic_cross_coupling_cutoff": {
         "english": "Frequency limit for the compensation. Higher value will make the compensation action faster.",
         "translation": "Frequenzgrenze fuer die Kompensation. Hoeher bedeutet schnellere Korrektur.",
         "needs_translation": false,
-        "max_length": 92,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 92
       },
       "cyclic_cross_coupling_gain": {
         "english": "Amount of compensation applied for pitch-to-roll decoupling.",
         "translation": "Menge der angewendeten Kompensation fuer Pitch-Roll-Entkopplung.",
         "needs_translation": false,
-        "max_length": 60,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 60
       },
       "cyclic_cross_coupling_ratio": {
         "english": "Amount of roll-to-pitch compensation needed, vs. pitch-to-roll.",
         "translation": "Menge der Roll-zu-Pitch-Kompensation vs. Pitch-zu-Roll.",
         "needs_translation": false,
-        "max_length": 63,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 63
       },
       "dterm_cutoff_0": {
         "english": "D-term cutoff in Hz.",
         "translation": "D-Term-Grenzfrequenz in Hz.",
         "needs_translation": false,
-        "max_length": 20,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 20
       },
       "dterm_cutoff_1": {
         "english": "D-term cutoff in Hz.",
         "translation": "D-Term-Grenzfrequenz in Hz.",
         "needs_translation": false,
-        "max_length": 20,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 20
       },
       "dterm_cutoff_2": {
         "english": "D-term cutoff in Hz.",
         "translation": "D-Term-Grenzfrequenz in Hz.",
         "needs_translation": false,
-        "max_length": 20,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 20
       },
       "error_decay_limit_cyclic": {
         "english": "Maximum bleed-off speed for cyclic I-term.",
         "translation": "Maximale Geschwindigkeit fuer das Reduzieren des zyklischen I-Terms.",
         "needs_translation": false,
-        "max_length": 42,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 42
       },
       "error_decay_time_cyclic": {
         "english": "Time constant for bleeding off cyclic I-term. Higher will stabilize hover, lower will drift.",
         "translation": "Zeitkonstante fuer das allmaehliche Reduzieren des zyklischen I-Terms. Hoeher stabilisiert den Schwebeflug, niedriger fuehrt zu mehr Drift.",
         "needs_translation": false,
-        "max_length": 92,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 92
       },
       "error_decay_time_ground": {
         "english": "Bleeds off the current controller error when the craft is not airborne to stop the craft tipping over.",
         "translation": "Reduziert den aktuellen Reglerfehler, wenn das Modell nicht in der Luft ist, um ein Umkippen zu verhindern.",
         "needs_translation": false,
-        "max_length": 102,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 102
       },
       "error_limit_0": {
         "english": "Hard limit for the angle error in the PID loop. The absolute error and thus the I-term will never go above these limits.",
         "translation": "Harte Begrenzung fuer den Winkel-Fehler im PID-Regler. Der absolute Fehler und damit der I-Term werden nie ueber diese Grenzen hinausgehen.",
         "needs_translation": false,
-        "max_length": 120,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 120
       },
       "error_limit_1": {
         "english": "Hard limit for the angle error in the PID loop. The absolute error and thus the I-term will never go above these limits.",
         "translation": "Harte Begrenzung fuer den Winkel-Fehler im PID-Regler.",
         "needs_translation": false,
-        "max_length": 120,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 120
       },
       "error_limit_2": {
         "english": "Hard limit for the angle error in the PID loop. The absolute error and thus the I-term will never go above these limits.",
         "translation": "Harte Begrenzung fuer den Winkel-Fehler im PID-Regler.",
         "needs_translation": false,
-        "max_length": 120,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 120
       },
       "error_rotation": {
         "english": "Rotates the current roll and pitch error terms around yaw when the craft rotates. This is sometimes called Piro Compensation.",
         "translation": "Dreht die aktuellen Roll- und Nick-Fehlerwerte um die Gierachse, wenn sich das Modell dreht. Auch als Piro-Kompensation bekannt.",
         "needs_translation": false,
-        "max_length": 125,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 125
       },
       "gyro_cutoff_0": {
         "english": "PID loop overall bandwidth in Hz.",
         "translation": "Gesamtbandbreite des PID-Reglers in Hz.",
         "needs_translation": false,
-        "max_length": 33,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 33
       },
       "gyro_cutoff_1": {
         "english": "PID loop overall bandwidth in Hz.",
         "translation": "Gesamtbandbreite des PID-Reglers in Hz.",
         "needs_translation": false,
-        "max_length": 33,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 33
       },
       "gyro_cutoff_2": {
         "english": "PID loop overall bandwidth in Hz.",
         "translation": "Gesamtbandbreite des PID-Reglers in Hz.",
         "needs_translation": false,
-        "max_length": 33,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 33
       },
       "horizon_level_strength": {
         "english": "Determines how aggressively the helicopter tilts back to level while in Horizon Mode.",
         "translation": "Bestimmt, wie stark der Heli im Horizontmodus zur Horizontalen zurueckkippt.",
         "needs_translation": false,
-        "max_length": 85,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 85
       },
       "iterm_relax_cutoff_0": {
         "english": "Helps reduce bounce back after fast stick movements. Can cause inconsistency in small stick movements if too low.",
         "translation": "Hilft, das Nachschwingen nach schnellen Knueppelbewegungen zu reduzieren. Kann zu Inkonsistenzen bei kleinen Knueppelbewegungen fuehren, wenn zu niedrig.",
         "needs_translation": false,
-        "max_length": 113,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 113
       },
       "iterm_relax_cutoff_1": {
         "english": "Helps reduce bounce back after fast stick movements. Can cause inconsistency in small stick movements if too low.",
         "translation": "Hilft, das Nachschwingen zu reduzieren.",
         "needs_translation": false,
-        "max_length": 113,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 113
       },
       "iterm_relax_cutoff_2": {
         "english": "Helps reduce bounce back after fast stick movements. Can cause inconsistency in small stick movements if too low.",
         "translation": "Hilft, das Nachschwingen zu reduzieren.",
         "needs_translation": false,
-        "max_length": 113,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 113
       },
       "iterm_relax_type": {
         "english": "Choose the axes in which this is active. RP: Roll, Pitch. RPY: Roll, Pitch, Yaw.",
         "translation": "Waehlen Sie die Achsen, auf denen dies aktiv ist. RP: Roll, Nick. RPY: Roll, Nick, Gier.",
         "needs_translation": false,
-        "max_length": 80,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 80
       },
       "offset_limit_0": {
         "english": "Hard limit for the High Speed Integral offset angle in the PID loop. The O-term will never go over these limits.",
         "translation": "Harte Begrenzung fuer den High Speed Integral Offset-Winkel in der PID-Schleife. Der O-Term wird nie ueber diese Grenzen hinausgehen.",
         "needs_translation": false,
-        "max_length": 112,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 112
       },
       "offset_limit_1": {
         "english": "Hard limit for the High Speed Integral offset angle in the PID loop. The O-term will never go over these limits.",
         "translation": "Harte Begrenzung fuer den High Speed Integral Offset-Winkel.",
         "needs_translation": false,
-        "max_length": 112,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 112
       },
       "pitch_collective_ff_gain": {
         "english": "Increasing will compensate for the pitching up motion caused by tail drag when climbing.",
         "translation": "Erhoehen, um das Nick-Aufrichten durch Heckwiderstand beim Steigen auszugleichen.",
         "needs_translation": false,
-        "max_length": 88,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 88
       },
       "tbl_off": {
         "english": "OFF",
         "translation": "AUS",
         "needs_translation": false,
-        "max_length": 3,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 3
       },
       "tbl_on": {
         "english": "ON",
         "translation": "EIN",
         "needs_translation": false,
-        "max_length": 2,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 2
       },
       "tbl_rp": {
         "english": "RP",
         "translation": "RP",
         "needs_translation": true,
-        "max_length": 2,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 2
       },
       "tbl_rpy": {
         "english": "RPY",
         "translation": "RPY",
         "needs_translation": true,
-        "max_length": 3,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 3
       },
       "trainer_angle_limit": {
         "english": "Limit the maximum angle the helicopter will pitch/roll to while in Acro Trainer Mode.",
         "translation": "Begrenzt den maximalen Pitch/Roll-Winkel im Acro-Trainer-Modus.",
         "needs_translation": false,
-        "max_length": 85,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 85
       },
       "trainer_gain": {
         "english": "Determines how aggressively the helicopter tilts back to the maximum angle (if exceeded) while in Acro Trainer Mode.",
         "translation": "Bestimmt, wie stark der Heli im Acro-Trainer-Modus zurueckkippt, wenn der Maximalwinkel ueberschritten wird.",
         "needs_translation": false,
-        "max_length": 116,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 116
       },
       "yaw_ccw_stop_gain": {
         "english": "Stop gain (PD) for counter-clockwise rotation.",
         "translation": "Stopp-Verstaerkung (PD) fuer die Drehung gegen den Uhrzeigersinn.",
         "needs_translation": false,
-        "max_length": 46,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 46
       },
       "yaw_collective_dynamic_decay": {
         "english": "Decay time for the extra yaw precomp on collective input.",
         "translation": "Abfallzeit fuer die zusaetzliche Gier-Vorkompensation bei kollektiven Eingaben.",
         "needs_translation": false,
-        "max_length": 57,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 57
       },
       "yaw_collective_dynamic_gain": {
         "english": "An extra boost of yaw precomp on collective input.",
         "translation": "Zusaetzlicher Gier-Vorkompensations-Boost bei kollektiven Eingaben.",
         "needs_translation": false,
-        "max_length": 50,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 50
       },
       "yaw_collective_ff_gain": {
         "english": "Collective feedforward mixed into yaw (collective-to-yaw precomp).",
         "translation": "Kollektive Feedforward-Mischung in Gier (kollektiv-zu-Gier Vorkompensation).",
         "needs_translation": false,
-        "max_length": 66,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 66
       },
       "yaw_cw_stop_gain": {
         "english": "Stop gain (PD) for clockwise rotation.",
         "translation": "Stopp-Verstaerkung (PD) fuer die Drehung im Uhrzeigersinn.",
         "needs_translation": false,
-        "max_length": 38,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 38
       },
       "yaw_cyclic_ff_gain": {
         "english": "Cyclic feedforward mixed into yaw (cyclic-to-yaw precomp).",
         "translation": "Zyklische Feedforward-Mischung in Gier (zyklisch-zu-Gier Vorkompensation).",
         "needs_translation": false,
-        "max_length": 58,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 58
       },
       "yaw_inertia_precomp_cutoff": {
         "english": "Cutoff. Derivative cutoff frequency in 1/10Hz steps. Controls how sharp the precomp is. Higher value is sharper.",
         "translation": "Grenzfrequenz der Ableitung in 1/10Hz-Schritten. Hoeher bedeutet schaerfere Vorkompensation.",
         "needs_translation": false,
-        "max_length": 112,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 112
       },
       "yaw_inertia_precomp_gain": {
         "english": "Scalar gain. The strength of the main rotor inertia. Higher value means more precomp is applied to yaw control.",
         "translation": "Staerke der Hauptrotor-Traegheit. Hoeher bedeutet mehr Vorkompensation in der Giersteuerung.",
         "needs_translation": false,
-        "max_length": 111,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 111
       },
       "yaw_precomp_cutoff": {
         "english": "Frequency limit for all yaw precompensation actions.",
         "translation": "Frequenzgrenze fuer alle Gier-Vorkompensationen.",
         "needs_translation": false,
-        "max_length": 52,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 52
       }
     },
     "PID_TUNING": {
@@ -2316,120 +2316,120 @@
         "english": "Additional boost on the feedforward to make the heli react more to quick stick movements.",
         "translation": "Zusaetzlicher Feedforward-Boost, um das System reaktionsschneller auf schnelle Knueppelbewegungen zu machen.",
         "needs_translation": false,
-        "max_length": 89,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 89
       },
       "pid_0_D": {
         "english": "Strength of dampening to any motion on the system, including external influences. Also reduces overshoot.",
         "translation": "Staerke der Daempfung gegen jede Bewegung des Systems, einschliesslich aeusserer Einfluesse. Reduziert auch das Ueberschwingen.",
         "needs_translation": false,
-        "max_length": 105,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 105
       },
       "pid_0_F": {
         "english": "Helps push P-term based on stick input. Increasing will make response more sharp, but can cause overshoot.",
         "translation": "Hilft, den P-Term basierend auf Knueppelbewegungen zu verstaerken. Erhoehen macht die Reaktion schaerfer, kann aber zu Ueberschwingern fuehren.",
         "needs_translation": false,
-        "max_length": 106,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 106
       },
       "pid_0_I": {
         "english": "How tightly the system holds its position.",
         "translation": "Wie genau das System seine Position haelt.",
         "needs_translation": false,
-        "max_length": 42,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 42
       },
       "pid_0_O": {
         "english": "Used to prevent the craft from rolling when using high collective.",
         "translation": "Verhindert das Rollen des Modells bei hoher Kollektivleistung.",
         "needs_translation": false,
-        "max_length": 66,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 66
       },
       "pid_0_P": {
         "english": "How tightly the system tracks the desired setpoint.",
         "translation": "Wie genau das System dem gewuenschten Sollwert folgt.",
         "needs_translation": false,
-        "max_length": 51,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 51
       },
       "pid_1_B": {
         "english": "Additional boost on the feedforward to make the heli react more to quick stick movements.",
         "translation": "Zusaetzlicher Feedforward-Boost, um das System reaktionsschneller auf schnelle Knueppelbewegungen zu machen.",
         "needs_translation": false,
-        "max_length": 89,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 89
       },
       "pid_1_D": {
         "english": "Strength of dampening to any motion on the system, including external influences. Also reduces overshoot.",
         "translation": "Staerke der Daempfung gegen jede Bewegung des Systems, einschliesslich aeusserer Einfluesse. Reduziert auch das Ueberschwingen.",
         "needs_translation": false,
-        "max_length": 105,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 105
       },
       "pid_1_F": {
         "english": "Helps push P-term based on stick input. Increasing will make response more sharp, but can cause overshoot.",
         "translation": "Hilft, den P-Term basierend auf Knueppelbewegungen zu verstaerken. Erhoehen macht die Reaktion schaerfer, kann aber zu Ueberschwingern fuehren.",
         "needs_translation": false,
-        "max_length": 106,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 106
       },
       "pid_1_I": {
         "english": "How tightly the system holds its position.",
         "translation": "Wie genau das System seine Position haelt.",
         "needs_translation": false,
-        "max_length": 42,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 42
       },
       "pid_1_O": {
         "english": "Used to prevent the craft from pitching when using high collective.",
         "translation": "Verhindert das Nicken des Modells bei hoher Kollektivleistung.",
         "needs_translation": false,
-        "max_length": 67,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 67
       },
       "pid_1_P": {
         "english": "How tightly the system tracks the desired setpoint.",
         "translation": "Wie genau das System dem gewuenschten Sollwert folgt.",
         "needs_translation": false,
-        "max_length": 51,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 51
       },
       "pid_2_B": {
         "english": "Additional boost on the feedforward to make the heli react more to quick stick movements.",
         "translation": "Zusaetzlicher Feedforward-Boost, um das System reaktionsschneller auf schnelle Knueppelbewegungen zu machen.",
         "needs_translation": false,
-        "max_length": 89,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 89
       },
       "pid_2_D": {
         "english": "Strength of dampening to any motion on the system, including external influences. Also reduces overshoot.",
         "translation": "Staerke der Daempfung gegen jede Bewegung des Systems, einschliesslich aeusserer Einfluesse. Reduziert auch das Ueberschwingen.",
         "needs_translation": false,
-        "max_length": 105,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 105
       },
       "pid_2_F": {
         "english": "Helps push P-term based on stick input. Increasing will make response more sharp, but can cause overshoot.",
         "translation": "Hilft, den P-Term basierend auf Knueppelbewegungen zu verstaerken. Erhoehen macht die Reaktion schaerfer, kann aber zu Ueberschwingern fuehren.",
         "needs_translation": false,
-        "max_length": 106,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 106
       },
       "pid_2_I": {
         "english": "How tightly the system holds its position.",
         "translation": "Wie genau das System seine Position haelt.",
         "needs_translation": false,
-        "max_length": 42,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 42
       },
       "pid_2_P": {
         "english": "How tightly the system tracks the desired setpoint.",
         "translation": "Wie genau das System dem gewuenschten Sollwert folgt.",
         "needs_translation": false,
-        "max_length": 51,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 51
       }
     },
     "PILOT_CONFIG": {
@@ -2437,8 +2437,8 @@
         "english": "Set this to the expected flight time in seconds.  The transmitter will beep when the flight time is reached.",
         "translation": "Setzen Sie die erwartete Flugzeit in Sekunden. Die Fernsteuerung piept, sobald die Flugzeit erreicht wurde.",
         "needs_translation": false,
-        "max_length": 108,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 108
       }
     },
     "RC_CONFIG": {
@@ -2446,50 +2446,50 @@
         "english": "Throttle must be at or below this value in microseconds (us) to allow arming. Must be at least 10us lower than minimum throttle.",
         "translation": "Das Gas muss bei diesem Wert oder darunter liegen (in µs), um das Schaerfen zu ermoeglichen. Muss mindestens 10 µs unter dem Mindestgaswert liegen.",
         "needs_translation": false,
-        "max_length": 128,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 128
       },
       "rc_center": {
         "english": "Stick center in microseconds (us).",
         "translation": "Knueppelmittelpunkt in Mikrosekunden (µs).",
         "needs_translation": false,
-        "max_length": 34,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 34
       },
       "rc_deadband": {
         "english": "Deadband for cyclic control in microseconds (us).",
         "translation": "Totzone fuer die zyklische Steuerung in Mikrosekunden (µs).",
         "needs_translation": false,
-        "max_length": 49,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 49
       },
       "rc_deflection": {
         "english": "Stick deflection from center in microseconds (us).",
         "translation": "Knueppelausschlag vom Mittelpunkt in Mikrosekunden (µs).",
         "needs_translation": false,
-        "max_length": 50,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 50
       },
       "rc_max_throttle": {
         "english": "Maximum throttle (100% throttle output) expected from radio, in microseconds (us).",
         "translation": "Maximales Gas (100 % Gasausgabe), das von der Fernsteuerung erwartet wird, in Mikrosekunden (µs).",
         "needs_translation": false,
-        "max_length": 82,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 82
       },
       "rc_min_throttle": {
         "english": "Minimum throttle (0% throttle output) expected from radio, in microseconds (us).",
         "translation": "Minimales Gas (0 % Gasausgabe), das von der Fernsteuerung erwartet wird, in Mikrosekunden (µs).",
         "needs_translation": false,
-        "max_length": 80,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 80
       },
       "rc_yaw_deadband": {
         "english": "Deadband for yaw control in microseconds (us).",
         "translation": "Totzone fuer die Giersteuerung in Mikrosekunden (µs).",
         "needs_translation": false,
-        "max_length": 46,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 46
       }
     },
     "RC_TUNING": {
@@ -2497,134 +2497,134 @@
         "english": "Maximum acceleration of the craft in response to a stick movement.",
         "translation": "Maximale Beschleunigung des Modells als Reaktion auf eine Knüppelbewegung.",
         "needs_translation": false,
-        "max_length": 66,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 66
       },
       "accel_limit_2": {
         "english": "Maximum acceleration of the craft in response to a stick movement.",
         "translation": "Maximale Beschleunigung des Modells als Reaktion auf eine Knüppelbewegung.",
         "needs_translation": false,
-        "max_length": 66,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 66
       },
       "accel_limit_3": {
         "english": "Maximum acceleration of the craft in response to a stick movement.",
         "translation": "Maximale Beschleunigung des Modells als Reaktion auf eine Knüppelbewegung.",
         "needs_translation": false,
-        "max_length": 66,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 66
       },
       "accel_limit_4": {
         "english": "Maximum acceleration of the craft in response to a stick movement.",
         "translation": "Maximale Beschleunigung des Modells als Reaktion auf eine Knüppelbewegung.",
         "needs_translation": false,
-        "max_length": 66,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 66
       },
       "response_time_1": {
         "english": "Increase or decrease the response time of the rate to smooth heli movements.",
         "translation": "Erhoeht oder verringert die Reaktionszeit der Rate, um die Heli-Bewegungen zu glaetten.",
         "needs_translation": false,
-        "max_length": 76,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 76
       },
       "response_time_2": {
         "english": "Increase or decrease the response time of the rate to smooth heli movements.",
         "translation": "Erhoeht oder verringert die Reaktionszeit der Rate, um die Heli-Bewegungen zu glaetten.",
         "needs_translation": false,
-        "max_length": 76,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 76
       },
       "response_time_3": {
         "english": "Increase or decrease the response time of the rate to smooth heli movements.",
         "translation": "Erhoeht oder verringert die Reaktionszeit der Rate, um die Heli-Bewegungen zu glaetten.",
         "needs_translation": false,
-        "max_length": 76,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 76
       },
       "response_time_4": {
         "english": "Increase or decrease the response time of the rate to smooth heli movements.",
         "translation": "Erhoeht oder verringert die Reaktionszeit der Rate, um die Heli-Bewegungen zu glaetten.",
         "needs_translation": false,
-        "max_length": 76,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 76
       },
       "setpoint_boost_cutoff_1": {
         "english": "Boost cutoff for the setpoint.",
         "translation": "Boost-Grenzwert fuer den Sollwert.",
         "needs_translation": false,
-        "max_length": 30,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 30
       },
       "setpoint_boost_cutoff_2": {
         "english": "Boost cutoff for the setpoint.",
         "translation": "Boost-Grenzwert fuer den Sollwert.",
         "needs_translation": false,
-        "max_length": 30,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 30
       },
       "setpoint_boost_cutoff_3": {
         "english": "Boost cutoff for the setpoint.",
         "translation": "Boost-Grenzwert fuer den Sollwert.",
         "needs_translation": false,
-        "max_length": 30,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 30
       },
       "setpoint_boost_cutoff_4": {
         "english": "Boost cutoff for the setpoint.",
         "translation": "Boost-Grenzwert fuer den Sollwert.",
         "needs_translation": false,
-        "max_length": 30,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 30
       },
       "setpoint_boost_gain_1": {
         "english": "Boost gain for the setpoint.",
         "translation": "Boost-Verstaerkung fuer den Sollwert.",
         "needs_translation": false,
-        "max_length": 28,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 28
       },
       "setpoint_boost_gain_2": {
         "english": "Boost gain for the setpoint.",
         "translation": "Boost-Verstaerkung fuer den Sollwert.",
         "needs_translation": false,
-        "max_length": 28,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 28
       },
       "setpoint_boost_gain_3": {
         "english": "Boost gain for the setpoint.",
         "translation": "Boost-Verstaerkung fuer den Sollwert.",
         "needs_translation": false,
-        "max_length": 28,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 28
       },
       "setpoint_boost_gain_4": {
         "english": "Boost gain for the setpoint.",
         "translation": "Boost-Verstaerkung fuer den Sollwert.",
         "needs_translation": false,
-        "max_length": 28,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 28
       },
       "yaw_dynamic_ceiling_gain": {
         "english": "The maximum gain applied to the yaw dynamic ceiling.",
         "translation": "Der maximale Gewinn, der auf die dynamische Yaw-Obergrenze angewendet wird.",
         "needs_translation": false,
-        "max_length": 52,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 52
       },
       "yaw_dynamic_deadband_filter": {
         "english": "The maximum filter applied to the yaw dynamic deadband.",
         "translation": "Der maximale Filter, der auf die dynamische Yaw-Totzone angewendet wird.",
         "needs_translation": false,
-        "max_length": 55,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 55
       },
       "yaw_dynamic_deadband_gain": {
         "english": "The maximum gain applied to the yaw dynamic deadband.",
         "translation": "Der maximale Gewinn, der auf die dynamische Yaw-Totzone angewendet wird.",
         "needs_translation": false,
-        "max_length": 53,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 53
       }
     },
     "RESCUE_PROFILE": {
@@ -2632,134 +2632,134 @@
         "english": "Collective value for rescue climb.",
         "translation": "Kollektivwert fuer den Steigflug waehrend der Rettung.",
         "needs_translation": false,
-        "max_length": 34,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 34
       },
       "rescue_climb_time": {
         "english": "Length of time the climb collective is applied before switching to hover.",
         "translation": "Dauer des Steigflugs, bevor in den Schwebezustand gewechselt wird.",
         "needs_translation": false,
-        "max_length": 73,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 73
       },
       "rescue_exit_time": {
         "english": "This limits rapid application of negative collective if the helicopter has rolled during rescue.",
         "translation": "Begrenzt die schnelle Anwendung von negativem Kollektiv, falls der Heli sich während der Rettung gedreht hat.",
         "needs_translation": false,
-        "max_length": 96,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 96
       },
       "rescue_flip_gain": {
         "english": "Determine how aggressively the heli flips during inverted rescue.",
         "translation": "Bestimmt, wie aggressiv der Heli während der invertierten Rettung flippt.",
         "needs_translation": false,
-        "max_length": 65,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 65
       },
       "rescue_flip_mode": {
         "english": "If rescue is activated while inverted, flip to upright - or remain inverted.",
         "translation": "Falls die Rettung im invertierten Zustand aktiviert wird: Aufrichten oder invertiert bleiben.",
         "needs_translation": false,
-        "max_length": 76,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 76
       },
       "rescue_flip_time": {
         "english": "If the helicopter is in rescue and is trying to flip to upright and does not within this time, rescue will be aborted.",
         "translation": "Falls der Heli in der Rettung nicht innerhalb dieser Zeit aufrichtet, wird die Rettung abgebrochen.",
         "needs_translation": false,
-        "max_length": 118,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 118
       },
       "rescue_hover_collective": {
         "english": "Collective value for hover.",
         "translation": "Kollektivwert fuer das Schweben.",
         "needs_translation": false,
-        "max_length": 27,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 27
       },
       "rescue_level_gain": {
         "english": "Determine how aggressively the heli levels during rescue.",
         "translation": "Bestimmt, wie aggressiv der Heli sich während der Rettung ausrichtet.",
         "needs_translation": false,
-        "max_length": 57,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 57
       },
       "rescue_max_setpoint_accel": {
         "english": "Limit how fast the helicopter accelerates into a roll/pitch. Larger helicopters may need slower acceleration.",
         "translation": "Begrenzt, wie schnell der Heli in eine Roll-/Nick-Bewegung beschleunigt. Groessere Helis benoetigen moeglicherweise langsamere Beschleunigungswerte.",
         "needs_translation": false,
-        "max_length": 109,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 109
       },
       "rescue_max_setpoint_rate": {
         "english": "Limit rescue roll/pitch rate. Larger helicopters may need slower rotation rates.",
         "translation": "Begrenzt die Roll-/Nick-Rate waehrend der Rettung. Groessere Helis benoetigen moeglicherweise langsamere Drehgeschwindigkeiten.",
         "needs_translation": false,
-        "max_length": 80,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 80
       },
       "rescue_pull_up_collective": {
         "english": "Collective value for pull-up climb.",
         "translation": "Kollektivwert fuer das Hochziehen.",
         "needs_translation": false,
-        "max_length": 35,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 35
       },
       "rescue_pull_up_time": {
         "english": "When rescue is activated, helicopter will apply pull-up collective for this time period before moving to flip or climb stage.",
         "translation": "Wenn die Rettung aktiviert wird, wird fuer diese Dauer kollektives Steigen angewendet, bevor zum Flip- oder Steigstadium uebergegangen wird.",
         "needs_translation": false,
-        "max_length": 125,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 125
       },
       "tbl_flip": {
         "english": "FLIP",
         "translation": "FLIP",
         "needs_translation": true,
-        "max_length": 4,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 4
       },
       "tbl_noflip": {
         "english": "NO FLIP",
         "translation": "KEIN FLIP",
         "needs_translation": false,
-        "max_length": 7,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 7
       },
       "tbl_off": {
         "english": "OFF",
         "translation": "AUS",
         "needs_translation": false,
-        "max_length": 3,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 3
       },
       "tbl_on": {
         "english": "ON",
         "translation": "EIN",
         "needs_translation": false,
-        "max_length": 2,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 2
       }
     },
     "RXFAIL_CONFIG": {
       "channel_mode": {
         "english": "Select how each channel behaves when signal is lost: Auto, Hold, or Set.",
-        "translation": "Select how each channel behaves when signal is lost: Auto, Hold, or Set.",
-        "needs_translation": true,
+        "translation": "Kanalverhalten bei Signalverlust wählen: Auto, Hold oder Set.",
+        "needs_translation": false,
         "reverse_text": false,
         "max_length": 72
       },
       "channel_value": {
         "english": "Channel value used only when mode is Set.",
-        "translation": "Channel value used only when mode is Set.",
-        "needs_translation": true,
+        "translation": "Kanalwert wird nur im Modus 'Set' verwendet.",
+        "needs_translation": false,
         "reverse_text": false,
         "max_length": 41
       },
       "tbl_auto": {
         "english": "Auto",
         "translation": "Auto",
-        "needs_translation": true,
+        "needs_translation": false,
         "reverse_text": false,
         "max_length": 4
       },
@@ -2784,78 +2784,78 @@
       "english": "CANCEL",
       "translation": "ABBRECHEN",
       "needs_translation": false,
-      "max_length": 6,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 6
     },
     "btn_close": {
       "english": "CLOSE",
       "translation": "SCHLIESSEN",
       "needs_translation": false,
-      "max_length": 5,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 5
     },
     "btn_ok": {
       "english": "          OK           ",
       "translation": "          OK           ",
       "needs_translation": true,
-      "max_length": 23,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 23
     },
     "btn_ok_long": {
       "english": "                OK                ",
       "translation": "                OK                ",
       "needs_translation": true,
-      "max_length": 34,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 34
     },
     "check_bg_task": {
       "english": "Please enable the background task.",
       "translation": "Bitte aktivieren Sie die Hintergrund-Task.",
       "needs_translation": false,
-      "max_length": 34,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 34
     },
     "error_timed_out": {
       "english": "Error: timed out",
       "translation": "Fehler: Zeitüberschreitung",
       "needs_translation": false,
-      "max_length": 16,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 16
     },
     "header_configuration": {
       "english": "Configuration",
       "translation": "Konfiguration",
       "needs_translation": false,
-      "max_length": 13,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 13
     },
     "header_help": {
       "english": "Help",
       "translation": "Hilfe",
       "needs_translation": false,
-      "max_length": 4,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 4
     },
     "header_shortcuts": {
       "english": "Shortcuts",
-      "max_length": 9,
+      "translation": "Shortcuts",
       "needs_translation": true,
       "reverse_text": false,
-      "translation": "Shortcuts"
+      "max_length": 9
     },
     "header_system": {
       "english": "System",
       "translation": "System",
       "needs_translation": true,
-      "max_length": 6,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 6
     },
     "menu_section_advanced": {
       "english": "Advanced",
       "translation": "Erweitert",
       "needs_translation": false,
-      "max_length": 8,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 8
     },
     "menu_section_controls": {
       "english": "Controls",
@@ -2875,20 +2875,20 @@
       "english": "Hardware",
       "translation": "Hardware",
       "needs_translation": true,
-      "max_length": 8,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 8
     },
     "menu_section_mechanics": {
       "english": "Mechanics",
-      "translation": "Mechanics",
-      "needs_translation": true,
+      "translation": "Mechanik",
+      "needs_translation": false,
       "reverse_text": false,
       "max_length": 9
     },
     "menu_section_profiles": {
       "english": "Profiles",
-      "translation": "Profiles",
-      "needs_translation": true,
+      "translation": "Profile",
+      "needs_translation": false,
       "reverse_text": false,
       "max_length": 8
     },
@@ -2901,17 +2901,17 @@
     },
     "menu_section_shortcuts": {
       "english": "Shortcuts",
-      "max_length": 9,
+      "translation": "Shortcuts",
       "needs_translation": true,
       "reverse_text": false,
-      "translation": "Shortcuts"
+      "max_length": 9
     },
     "menu_section_tools": {
       "english": "Tools",
       "translation": "Werkzeuge",
       "needs_translation": false,
-      "max_length": 5,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 5
     },
     "modules": {
       "accelerometer": {
@@ -2919,36 +2919,36 @@
           "english": "The accelerometer is used to measure the angle of the flight controller in relation to the horizon. This data is used to stabilize the aircraft and provide self-leveling functionality.",
           "translation": "Der Beschleunigungssensor wird verwendet, um den Winkel des Flugcontrollers in Bezug auf den Horizont zu messen. Diese Daten werden zur Stabilisierung des Fluggeräts und zur Bereitstellung der Selbstnivellierungsfunktion verwendet.",
           "needs_translation": false,
-          "max_length": 184,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 184
         },
         "msg_calibrate": {
           "english": "Calibrate the accelerometer?",
           "translation": "Beschleunigungssensor kalibrieren?",
           "needs_translation": false,
-          "max_length": 28,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 28
         },
         "name": {
           "english": "Accelerometer",
           "translation": "Beschleunigungssensor",
           "needs_translation": false,
-          "max_length": 13,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 13
         },
         "pitch": {
           "english": "Pitch",
           "translation": "Nick",
           "needs_translation": false,
-          "max_length": 5,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 5
         },
         "roll": {
           "english": "Roll",
           "translation": "Roll",
           "needs_translation": true,
-          "max_length": 4,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 4
         }
       },
       "adjustments": {
@@ -2982,8 +2982,8 @@
         },
         "channel_always": {
           "english": "Always",
-          "translation": "Always",
-          "needs_translation": true,
+          "translation": "Immer",
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 6
         },
@@ -3010,15 +3010,15 @@
         },
         "confirm_use_current": {
           "english": "Use current value",
-          "translation": "Use current value",
-          "needs_translation": true,
+          "translation": "Aktuellen Wert verwenden",
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 17
         },
         "current_output": {
           "english": "Current Output",
           "translation": "Current Output",
-          "needs_translation": true,
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 14
         },
@@ -3248,22 +3248,22 @@
         },
         "type_off": {
           "english": "OFF",
-          "translation": "OFF",
-          "needs_translation": true,
+          "translation": "AUS",
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 3
         },
         "type_stepped": {
           "english": "STEPPED",
           "translation": "STEPPED",
-          "needs_translation": true,
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 7
         },
         "unsaved_changes": {
           "english": "Unsaved changes",
           "translation": "Unsaved changes",
-          "needs_translation": true,
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 15
         },
@@ -3404,8 +3404,8 @@
         },
         "msg_reset_tail_view": {
           "english": "Reset view yaw so the tail faces you?",
-          "translation": "Reset view yaw so the tail faces you?",
-          "needs_translation": true,
+          "translation": "Blickwinkel resetten: Heck zeigt zum Nutzer?",
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 37
         },
@@ -3419,7 +3419,7 @@
         "nose_direction": {
           "english": "Nose Direction",
           "translation": "Nose Direction",
-          "needs_translation": true,
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 14
         },
@@ -3688,29 +3688,29 @@
         },
         "field_bat_crit_low": {
           "english": "Battery critical low",
-          "translation": "Battery critical low",
-          "needs_translation": true,
+          "translation": "Akku kritisch niedrig",
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 20
         },
         "field_bat_low": {
           "english": "Battery low",
-          "translation": "Battery low",
-          "needs_translation": true,
+          "translation": "Akku schwach",
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 11
         },
         "field_blackbox_erase": {
           "english": "Blackbox erase",
-          "translation": "Blackbox erase",
-          "needs_translation": true,
+          "translation": "Blackbox löschen",
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 14
         },
         "field_disarm_repeat": {
           "english": "Disarm repeat",
           "translation": "Disarm repeat",
-          "needs_translation": true,
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 13
         },
@@ -3779,8 +3779,8 @@
         },
         "help_p1": {
           "english": "Configure analog beeper conditions and DShot beacon behavior.",
-          "translation": "Configure analog beeper conditions and DShot beacon behavior.",
-          "needs_translation": true,
+          "translation": "Konfiguriere Analog-Beeper und DShot-Beacon-Verhalten.",
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 61
         },
@@ -3800,15 +3800,15 @@
         },
         "menu_configuration": {
           "english": "Configuration",
-          "translation": "Configuration",
-          "needs_translation": true,
+          "translation": "Konfiguration",
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 13
         },
         "menu_dshot": {
           "english": "ESC Beacon",
           "translation": "DShot",
-          "needs_translation": true,
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 10
         },
@@ -3851,8 +3851,8 @@
         },
         "device_disabled": {
           "english": "Disabled",
-          "translation": "Disabled",
-          "needs_translation": true,
+          "translation": "Ausgeschaltet",
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 8
         },
@@ -3865,8 +3865,8 @@
         },
         "device_sdcard": {
           "english": "SD Card",
-          "translation": "SD Card",
-          "needs_translation": true,
+          "translation": "SD Karte",
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 7
         },
@@ -3991,15 +3991,15 @@
         },
         "log_battery": {
           "english": "Battery",
-          "translation": "Battery",
-          "needs_translation": true,
+          "translation": "Akku",
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 7
         },
         "log_bec": {
           "english": "BEC",
           "translation": "BEC",
-          "needs_translation": true,
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 3
         },
@@ -4013,14 +4013,14 @@
         "log_esc": {
           "english": "ESC",
           "translation": "ESC",
-          "needs_translation": true,
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 3
         },
         "log_esc2": {
           "english": "ESC2",
           "translation": "ESC2",
-          "needs_translation": true,
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 4
         },
@@ -4034,21 +4034,21 @@
         "log_gps": {
           "english": "GPS",
           "translation": "GPS",
-          "needs_translation": true,
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 3
         },
         "log_gyro": {
           "english": "Gyro",
           "translation": "Gyro",
-          "needs_translation": true,
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 4
         },
         "log_gyro_raw": {
           "english": "Gyro Raw",
           "translation": "Gyro Raw",
-          "needs_translation": true,
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 8
         },
@@ -4180,8 +4180,8 @@
         },
         "mode_off": {
           "english": "Off",
-          "translation": "Off",
-          "needs_translation": true,
+          "translation": "Aus",
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 3
         },
@@ -4215,15 +4215,15 @@
         },
         "off": {
           "english": "Off",
-          "translation": "Off",
-          "needs_translation": true,
+          "translation": "Aus",
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 3
         },
         "on": {
           "english": "On",
-          "translation": "On",
-          "needs_translation": true,
+          "translation": "An",
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 2
         },
@@ -4250,8 +4250,8 @@
         },
         "sdcard": {
           "english": "SD Card",
-          "translation": "SD Card",
-          "needs_translation": true,
+          "translation": "SD Karte",
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 7
         },
@@ -4280,8 +4280,8 @@
       "configuration": {
         "craft_name": {
           "english": "Craft name",
-          "translation": "Craft name",
-          "needs_translation": true,
+          "translation": "Modellname",
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 10
         },
@@ -4364,22 +4364,22 @@
         },
         "error_save_failed": {
           "english": "Save failed",
-          "translation": "Save failed",
-          "needs_translation": true,
+          "translation": "Speichern fehlgeschlagen",
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 11
         },
         "feature_cms": {
           "english": "CMS",
           "translation": "CMS",
-          "needs_translation": true,
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 3
         },
         "feature_gps": {
           "english": "GPS",
           "translation": "GPS",
-          "needs_translation": true,
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 3
         },
@@ -4427,8 +4427,8 @@
         },
         "name": {
           "english": "Configuration",
-          "translation": "Configuration",
-          "needs_translation": true,
+          "translation": "Konfiguration",
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 13
         },
@@ -4449,28 +4449,28 @@
         "pid_loop_16": {
           "english": "1:16",
           "translation": "1:16",
-          "needs_translation": true,
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 4
         },
         "pid_loop_2": {
           "english": "1:2",
           "translation": "1:2",
-          "needs_translation": true,
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 3
         },
         "pid_loop_4": {
           "english": "1:4",
           "translation": "1:4",
-          "needs_translation": true,
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 3
         },
         "pid_loop_8": {
           "english": "1:8",
           "translation": "1:8",
-          "needs_translation": true,
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 3
         },
@@ -4522,71 +4522,71 @@
           "english": "Dest. Profile",
           "translation": "Zielprofil",
           "needs_translation": false,
-          "max_length": 13,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 13
         },
         "help_p1": {
           "english": "Copy PID profile or Rate profile from Source to Destination.",
           "translation": "PID-Profil oder Rate-Profil von der Quelle zum Ziel kopieren.",
           "needs_translation": false,
-          "max_length": 60,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 60
         },
         "help_p2": {
           "english": "Choose the source and destinations and save to copy the profile.",
           "translation": "Wählen Sie die Quelle und das Ziel aus und speichern Sie, um das Profil zu kopieren.",
           "needs_translation": false,
-          "max_length": 64,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 64
         },
         "msgbox_msg": {
           "english": "Save current page to flight controller?",
           "translation": "Aktuelle Seite auf dem Flugcontroller speichern?",
           "needs_translation": false,
-          "max_length": 39,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 39
         },
         "msgbox_save": {
           "english": "Save settings",
           "translation": "Einstellungen speichern",
           "needs_translation": false,
-          "max_length": 13,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 13
         },
         "name": {
           "english": "Copy Profiles",
           "translation": "Profile kopieren",
           "needs_translation": false,
-          "max_length": 13,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 13
         },
         "profile_type": {
           "english": "Profile Type",
           "translation": "Profiltyp",
           "needs_translation": false,
-          "max_length": 12,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 12
         },
         "profile_type_pid": {
           "english": "PID",
           "translation": "PID",
           "needs_translation": true,
-          "max_length": 3,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 3
         },
         "profile_type_rate": {
           "english": "Rate",
           "translation": "Rate",
           "needs_translation": true,
-          "max_length": 4,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 4
         },
         "source_profile": {
           "english": "Source Profile",
           "translation": "Quellprofil",
           "needs_translation": false,
-          "max_length": 14,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 14
         }
       },
       "diagnostics": {
@@ -4594,8 +4594,8 @@
           "english": "Diagnostics",
           "translation": "Diagnose",
           "needs_translation": false,
-          "max_length": 11,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 11
         }
       },
       "esc_motors": {
@@ -4603,183 +4603,183 @@
           "english": "Consumption Correction",
           "translation": "Verbrauchskorrektur",
           "needs_translation": false,
-          "max_length": 22,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 22
         },
         "current_correction": {
           "english": "Current Correction",
           "translation": "Stromkorrektur",
           "needs_translation": false,
-          "max_length": 18,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 18
         },
         "front": {
           "english": "Front",
           "translation": "Vorne",
           "needs_translation": false,
-          "max_length": 5,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 5
         },
         "half_duplex": {
           "english": "Half Duplex",
           "translation": "Halbduplex",
           "needs_translation": false,
-          "max_length": 11,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 11
         },
         "help_p1": {
           "english": "Configure the motor and speed controller features.",
           "translation": "Konfigurieren Sie die Motor- und Governor-Einstellungen.",
           "needs_translation": false,
-          "max_length": 50,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 50
         },
         "main": {
           "english": "Main",
           "translation": "Haupt",
           "needs_translation": false,
-          "max_length": 4,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 4
         },
         "main_motor_ratio": {
           "english": "Main Motor Ratio",
           "translation": "Hauptübersetzung",
           "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 16
         },
         "max_throttle": {
           "english": "100% Throttle PWM value",
           "translation": "100% Gas PWM-Wert",
           "needs_translation": false,
-          "max_length": 23,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 23
         },
         "min_throttle": {
           "english": "0% Throttle PWM Value",
           "translation": "0% Gas PWM-Wert",
           "needs_translation": false,
-          "max_length": 21,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 21
         },
         "mincommand": {
           "english": "Motor Stop PWM Value",
           "translation": "Motor-Stopp PWM-Wert",
           "needs_translation": false,
-          "max_length": 20,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 20
         },
         "motor_pole_count": {
           "english": "Motor Pole Count",
           "translation": "Anzahl der Motorpole",
           "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 16
         },
         "motor_pwm_rate": {
           "english": "Update frequency",
           "translation": "Aktualisierungsrate",
           "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 16
         },
         "name": {
           "english": "ESC & Motors",
           "translation": "ESC/Motoren",
           "needs_translation": false,
-          "max_length": 12,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 12
         },
         "pin_swap": {
           "english": "Pin Swap",
           "translation": "Pin-Tausch",
           "needs_translation": false,
-          "max_length": 8,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 8
         },
         "pinion": {
           "english": "Pinion",
           "translation": "Ritzel",
           "needs_translation": false,
-          "max_length": 6,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 6
         },
         "rear": {
           "english": "Rear",
           "translation": "Hinten",
           "needs_translation": false,
-          "max_length": 4,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 4
         },
         "rpm": {
           "english": "RPM",
           "translation": "RPM",
           "needs_translation": true,
-          "max_length": 3,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 3
         },
         "rpm_sensor_source": {
           "english": "RPM Sensor",
           "translation": "RPM-Sensor",
           "needs_translation": true,
-          "max_length": 10,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 10
         },
         "tail_motor_ratio": {
           "english": "Tail Motor Ratio",
           "translation": "Heckübersetzung",
           "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 16
         },
         "telemetry": {
           "english": "Telemetry",
           "translation": "Telemetrie",
           "needs_translation": false,
-          "max_length": 9,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 9
         },
         "telemetry_protocol": {
           "english": "Telemetry Protocol",
           "translation": "Telemetrieprotokoll",
           "needs_translation": false,
-          "max_length": 18,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 18
         },
         "throttle": {
           "english": "Throttle",
           "translation": "Gas",
           "needs_translation": false,
-          "max_length": 8,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 8
         },
         "throttle_protocol": {
           "english": "Throttle Protocol",
           "translation": "Gasprotokoll",
           "needs_translation": false,
-          "max_length": 17,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 17
         },
         "unsynced": {
           "english": "Unsynced ESC Update",
           "translation": "Nicht synchr. ESC-Update",
           "needs_translation": false,
-          "max_length": 19,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 19
         },
         "use_dshot_telemetry": {
           "english": "DShot RPM Telemetry",
           "translation": "DShot RPM-Telemetrie",
           "needs_translation": false,
-          "max_length": 19,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 19
         },
         "voltage_correction": {
           "english": "Voltage Correction",
           "translation": "Spannungskorrektur",
           "needs_translation": false,
-          "max_length": 18,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 18
         }
       },
       "esc_tools": {
@@ -4879,7 +4879,7 @@
             "name": {
               "english": "AM32",
               "translation": "AM32",
-              "needs_translation": true,
+              "needs_translation": false,
               "reverse_text": false,
               "max_length": 4
             },
@@ -5099,218 +5099,218 @@
               "english": "Active Freewheeling",
               "translation": "Aktiver Freilauf",
               "needs_translation": false,
-              "max_length": 19,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 19
             },
             "advanced": {
               "english": "Advanced",
               "translation": "Erweitert",
               "needs_translation": false,
-              "max_length": 8,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 8
             },
             "auto_restart_time": {
               "english": "Auto Bailout Time",
               "translation": "Auto Restart Zeit",
               "needs_translation": false,
-              "max_length": 17,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 17
             },
             "basic": {
               "english": "General",
               "translation": "Grundlegend",
               "needs_translation": false,
-              "max_length": 7,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 7
             },
             "battery_capacity": {
               "english": "Capacity Limit",
               "translation": "Batteriekapazität",
               "needs_translation": false,
-              "max_length": 14,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 14
             },
             "bec_voltage": {
               "english": "SBEC Voltage",
               "translation": "BEC-Spannung",
               "needs_translation": false,
-              "max_length": 12,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 12
             },
             "buzzer_volume": {
               "english": "Beeper Volume",
               "translation": "Summerlautstärke",
               "needs_translation": false,
-              "max_length": 13,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 13
             },
             "cell_count": {
               "english": "LiPo Cell Count",
               "translation": "Zellenanzahl",
               "needs_translation": false,
-              "max_length": 15,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 15
             },
             "current_gain": {
               "english": "Current Gain",
               "translation": "Verstärkungswert für den Stromsensor",
               "needs_translation": false,
-              "max_length": 12,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 12
             },
             "drive_freq": {
               "english": "Drive Frequency",
               "translation": "Ansteuerfrequenz",
               "needs_translation": false,
-              "max_length": 15,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 15
             },
             "electrical_angle": {
               "english": "Electrical Angle",
               "translation": "Timing-Winkel",
               "needs_translation": false,
-              "max_length": 16,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 16
             },
             "esc_mode": {
               "english": "ESC Mode",
               "translation": "ESC-Modus",
               "needs_translation": false,
-              "max_length": 8,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 8
             },
             "fan_control": {
               "english": "Cooling Fan Mode",
               "translation": "Lüftersteuerung",
               "needs_translation": false,
-              "max_length": 16,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 16
             },
             "gov_i": {
               "english": "Governor I",
               "translation": "Integralwert für den Governor",
               "needs_translation": false,
-              "max_length": 10,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 10
             },
             "gov_p": {
               "english": "Governor P",
               "translation": "Gov-P",
               "needs_translation": false,
-              "max_length": 10,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 10
             },
             "governor": {
               "english": "Governor",
               "translation": "Governor",
               "needs_translation": true,
-              "max_length": 8,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 8
             },
             "led_color": {
               "english": "LED Color",
               "translation": "LED-Farbe",
               "needs_translation": false,
-              "max_length": 9,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 9
             },
             "low_voltage_protection": {
               "english": "Low Voltage Limit",
               "translation": "Spannung, bei der die Leistung reduziert wird",
               "needs_translation": false,
-              "max_length": 17,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 17
             },
             "motor_direction": {
               "english": "Motor Direction",
               "translation": "Motordrehrichtung (CCW/CW)",
               "needs_translation": false,
-              "max_length": 15,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 15
             },
             "motor_erpm_max": {
               "english": "Maximum Motor ERPM",
               "translation": "Maximale RPM",
               "needs_translation": false,
-              "max_length": 18,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 18
             },
             "motor_temp": {
               "english": "Motor Temperture Limit",
               "translation": "Motortemperatur",
               "needs_translation": false,
-              "max_length": 22,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 22
             },
             "motor_temp_sensor": {
               "english": "Motor Temperture Sensor",
               "translation": "Motortemperatursensor",
               "needs_translation": false,
-              "max_length": 23,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 23
             },
             "name": {
               "english": "FLYROTOR",
               "translation": "FLYROTOR",
               "needs_translation": true,
-              "max_length": 8,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 8
             },
             "other": {
               "english": "Other",
               "translation": "Sonstiges",
               "needs_translation": false,
-              "max_length": 5,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 5
             },
             "response_speed": {
               "english": "Response Speed",
               "translation": "Reaktionsgeschwindigkeit",
               "needs_translation": false,
-              "max_length": 14,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 14
             },
             "restart_acc": {
               "english": "Auto Bailout Accel",
               "translation": "Neustart-Beschleunigung",
               "needs_translation": false,
-              "max_length": 18,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 18
             },
             "soft_start": {
               "english": "Soft Start Time",
               "translation": "Sanftanlauf",
               "needs_translation": false,
-              "max_length": 15,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 15
             },
             "starting_torque": {
               "english": "Starting Power",
               "translation": "Anlaufmoment",
               "needs_translation": false,
-              "max_length": 14,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 14
             },
             "telemetry_protocol": {
               "english": "Telemetry Protocol",
               "translation": "Telemetrieprotokoll",
               "needs_translation": false,
-              "max_length": 18,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 18
             },
             "temperature_protection": {
               "english": "Temperature Limit",
               "translation": "Temperaturschutz",
               "needs_translation": false,
-              "max_length": 17,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 17
             },
             "throttle_protocol": {
               "english": "Throttle Protocol",
               "translation": "Gasprotokoll",
               "needs_translation": false,
-              "max_length": 17,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 17
             }
           },
           "hw5": {
@@ -5318,183 +5318,183 @@
               "english": "Active Freewheel",
               "translation": "Aktive Freilaufsteuerung",
               "needs_translation": false,
-              "max_length": 16,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 16
             },
             "advanced": {
               "english": "Advanced",
               "translation": "Erweitert",
               "needs_translation": false,
-              "max_length": 8,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 8
             },
             "auto_restart": {
               "english": "Auto Restart",
               "translation": "Automatischer Neustart",
               "needs_translation": false,
-              "max_length": 12,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 12
             },
             "basic": {
               "english": "Basic",
               "translation": "Grundlegend",
               "needs_translation": false,
-              "max_length": 5,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 5
             },
             "bec_voltage": {
               "english": "BEC Voltage",
               "translation": "BEC-Spannung",
               "needs_translation": false,
-              "max_length": 11,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 11
             },
             "brake": {
               "english": "Brake",
               "translation": "Bremse",
               "needs_translation": false,
-              "max_length": 5,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 5
             },
             "brake_force": {
               "english": "Brake Force%",
               "translation": "Bremskraft%",
               "needs_translation": false,
-              "max_length": 12,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 12
             },
             "brake_type": {
               "english": "Brake Type",
               "translation": "Bremstyp",
               "needs_translation": false,
-              "max_length": 10,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 10
             },
             "cutoff_voltage": {
               "english": "Cutoff Voltage",
               "translation": "Abschaltspannung",
               "needs_translation": false,
-              "max_length": 14,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 14
             },
             "esc": {
               "english": "ESC",
               "translation": "ESC",
               "needs_translation": true,
-              "max_length": 3,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 3
             },
             "flight_mode": {
               "english": "Flight Mode",
               "translation": "Flugmodus",
               "needs_translation": false,
-              "max_length": 11,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 11
             },
             "gov_i_gain": {
               "english": "I-Gain",
               "translation": "I-Verst.",
               "needs_translation": false,
-              "max_length": 6,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 6
             },
             "gov_p_gain": {
               "english": "P-Gain",
               "translation": "P-Verst.",
               "needs_translation": false,
-              "max_length": 6,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 6
             },
             "governor": {
               "english": "Governor",
               "translation": "Governor",
               "needs_translation": true,
-              "max_length": 8,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 8
             },
             "limits": {
               "english": "Limits",
               "translation": "Grenzwerte",
               "needs_translation": false,
-              "max_length": 6,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 6
             },
             "lipo_cell_count": {
               "english": "LiPo Cell Count",
               "translation": "LiPo-Zellenanzahl",
               "needs_translation": false,
-              "max_length": 15,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 15
             },
             "motor": {
               "english": "Motor",
               "translation": "Motor",
               "needs_translation": true,
-              "max_length": 5,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 5
             },
             "name": {
               "english": "Hobbywing V5",
               "translation": "Hobbywing V5",
               "needs_translation": true,
-              "max_length": 12,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 12
             },
             "other": {
               "english": "Other",
               "translation": "Sonstiges",
               "needs_translation": false,
-              "max_length": 5,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 5
             },
             "restart_time": {
               "english": "Restart Time",
               "translation": "Neustartzeit",
               "needs_translation": false,
-              "max_length": 12,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 12
             },
             "rotation": {
               "english": "Rotation",
               "translation": "Drehrichtung",
               "needs_translation": false,
-              "max_length": 8,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 8
             },
             "soft_start": {
               "english": "Soft Start",
               "translation": "Sanftanlauf",
               "needs_translation": false,
-              "max_length": 10,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 10
             },
             "startup_power": {
               "english": "Startup Power",
               "translation": "Anlaufleistung",
               "needs_translation": false,
-              "max_length": 13,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 13
             },
             "startup_time": {
               "english": "Startup Time",
               "translation": "Anlaufzeit",
               "needs_translation": false,
-              "max_length": 12,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 12
             },
             "timing": {
               "english": "Timing",
               "translation": "Timing",
               "needs_translation": true,
-              "max_length": 6,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 6
             },
             "volt_cutoff_type": {
               "english": "Volt Cutoff Type",
               "translation": "Spannungsabschaltmodus",
               "needs_translation": false,
-              "max_length": 16,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 16
             }
           },
           "omp": {
@@ -5502,148 +5502,148 @@
               "english": "Acceleration",
               "translation": "Beschleunigung",
               "needs_translation": false,
-              "max_length": 12,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 12
             },
             "advanced": {
               "english": "Advanced",
               "translation": "Erweitert",
               "needs_translation": false,
-              "max_length": 8,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 8
             },
             "auto_restart_time": {
               "english": "Auto Restart Time",
               "translation": "Neustartzeit",
               "needs_translation": false,
-              "max_length": 17,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 17
             },
             "basic": {
               "english": "Basic",
               "translation": "Grundlegend",
               "needs_translation": false,
-              "max_length": 5,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 5
             },
             "brake_force": {
               "english": "Brake Force",
               "translation": "Bremskraft",
               "needs_translation": false,
-              "max_length": 11,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 11
             },
             "capacity_correction": {
               "english": "Capacity Correction",
               "translation": "Kapazitätskorrektur",
               "needs_translation": false,
-              "max_length": 19,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 19
             },
             "cell_cutoff": {
               "english": "Cell Cutoff",
               "translation": "Zellenabschaltung",
               "needs_translation": false,
-              "max_length": 11,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 11
             },
             "gov": {
               "english": "Governor",
               "translation": "Governor",
               "needs_translation": true,
-              "max_length": 8,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 8
             },
             "gov_i": {
               "english": "Gov-I",
               "translation": "Gov-I",
               "needs_translation": true,
-              "max_length": 5,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 5
             },
             "gov_p": {
               "english": "Gov-P",
               "translation": "Gov-P",
               "needs_translation": true,
-              "max_length": 5,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 5
             },
             "governor": {
               "english": "Governor",
               "translation": "Governor",
               "needs_translation": true,
-              "max_length": 8,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 8
             },
             "hv_bec_voltage": {
               "english": "HV BEC Voltage",
               "translation": "HV BEC-Spannung",
               "needs_translation": false,
-              "max_length": 14,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 14
             },
             "led_color": {
               "english": "LED Color",
               "translation": "LED-Farbe",
               "needs_translation": false,
-              "max_length": 9,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 9
             },
             "lv_bec_voltage": {
               "english": "LV BEC Voltage",
               "translation": "LV BEC-Spannung",
               "needs_translation": false,
-              "max_length": 14,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 14
             },
             "motor_direction": {
               "english": "Motor Direction",
               "translation": "Motordrehrichtung (CCW/CW)",
               "needs_translation": false,
-              "max_length": 15,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 15
             },
             "motor_poles": {
               "english": "Motor Poles",
               "translation": "Motorpole",
               "needs_translation": false,
-              "max_length": 11,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 11
             },
             "name": {
               "english": "OMP",
               "translation": "OMP",
               "needs_translation": true,
-              "max_length": 3,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 3
             },
             "smart_fan": {
               "english": "Smart Fan",
               "translation": "Intelligenter Lüfter",
               "needs_translation": false,
-              "max_length": 9,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 9
             },
             "sr_function": {
               "english": "SR Function",
               "translation": "SR-Funktion",
               "needs_translation": false,
-              "max_length": 11,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 11
             },
             "startup_power": {
               "english": "Startup Power",
               "translation": "Anlaufleistung",
               "needs_translation": false,
-              "max_length": 13,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 13
             },
             "timing": {
               "english": "Timing",
               "translation": "Timing",
               "needs_translation": true,
-              "max_length": 6,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 6
             }
           },
           "scorp": {
@@ -5651,141 +5651,141 @@
               "english": "Advanced",
               "translation": "Erweitert",
               "needs_translation": false,
-              "max_length": 8,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 8
             },
             "bailout": {
               "english": "Bailout",
               "translation": "Rettung",
               "needs_translation": false,
-              "max_length": 7,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 7
             },
             "basic": {
               "english": "Basic",
               "translation": "Grundlegend",
               "needs_translation": false,
-              "max_length": 5,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 5
             },
             "bec_voltage": {
               "english": "BEC Voltage",
               "translation": "BEC-Spannung",
               "needs_translation": false,
-              "max_length": 11,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 11
             },
             "cutoff_handling": {
               "english": "Cutoff Handling",
               "translation": "Abschaltverhalten",
               "needs_translation": false,
-              "max_length": 15,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 15
             },
             "esc_mode": {
               "english": "ESC Mode",
               "translation": "ESC-Modus",
               "needs_translation": false,
-              "max_length": 8,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 8
             },
             "extra_msg_save": {
               "english": "Please reboot the ESC to apply the changes",
               "translation": "Bitte starten Sie den ESC neu, um die Änderungen zu übernehmen",
               "needs_translation": false,
-              "max_length": 42,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 42
             },
             "gov_integral": {
               "english": "Gov Integral",
               "translation": "Gov Integral",
               "needs_translation": true,
-              "max_length": 12,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 12
             },
             "gov_proportional": {
               "english": "Gov Proportional",
               "translation": "Gov Proportional",
               "needs_translation": true,
-              "max_length": 16,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 16
             },
             "limits": {
               "english": "Limits",
               "translation": "Grenzwerte",
               "needs_translation": false,
-              "max_length": 6,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 6
             },
             "max_current": {
               "english": "Max Current",
               "translation": "Max. Strom",
               "needs_translation": false,
-              "max_length": 11,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 11
             },
             "max_temperature": {
               "english": "Max Temperature",
               "translation": "Max. Temperatur",
               "needs_translation": false,
-              "max_length": 15,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 15
             },
             "max_used": {
               "english": "Max Used",
               "translation": "Max. Nutzung",
               "needs_translation": false,
-              "max_length": 8,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 8
             },
             "min_voltage": {
               "english": "Min Voltage",
               "translation": "Min. Spannung",
               "needs_translation": false,
-              "max_length": 11,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 11
             },
             "motor_startup_sound": {
               "english": "Motor Startup Sound",
               "translation": "Motor-Startton",
               "needs_translation": false,
-              "max_length": 19,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 19
             },
             "name": {
               "english": "Scorpion",
               "translation": "Scorpion",
               "needs_translation": true,
-              "max_length": 8,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 8
             },
             "protection_delay": {
               "english": "Protection Delay",
               "translation": "Schutzverzögerung",
               "needs_translation": false,
-              "max_length": 16,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 16
             },
             "rotation": {
               "english": "Rotation",
               "translation": "Drehrichtung (CCW/CW)",
               "needs_translation": false,
-              "max_length": 8,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 8
             },
             "runup_time": {
               "english": "Runup Time",
               "translation": "Hochlaufzeit",
               "needs_translation": false,
-              "max_length": 10,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 10
             },
             "soft_start_time": {
               "english": "Soft Start Time",
               "translation": "Sanftanlauf-Zeit",
               "needs_translation": false,
-              "max_length": 15,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 15
             }
           },
           "xdfly": {
@@ -5793,148 +5793,148 @@
               "english": "Acceleration",
               "translation": "Beschleunigung",
               "needs_translation": false,
-              "max_length": 12,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 12
             },
             "advanced": {
               "english": "Advanced",
               "translation": "Erweitert",
               "needs_translation": false,
-              "max_length": 8,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 8
             },
             "auto_restart_time": {
               "english": "Auto Restart Time",
               "translation": "Neustartzeit",
               "needs_translation": false,
-              "max_length": 17,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 17
             },
             "basic": {
               "english": "Basic",
               "translation": "Grundlegend",
               "needs_translation": false,
-              "max_length": 5,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 5
             },
             "brake_force": {
               "english": "Brake Force",
               "translation": "Bremskraft",
               "needs_translation": false,
-              "max_length": 11,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 11
             },
             "capacity_correction": {
               "english": "Capacity Correction",
               "translation": "Kapazitätskorrektur",
               "needs_translation": false,
-              "max_length": 19,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 19
             },
             "cell_cutoff": {
               "english": "Cell Cutoff",
               "translation": "Zellenabschaltung",
               "needs_translation": false,
-              "max_length": 11,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 11
             },
             "gov": {
               "english": "Governor",
               "translation": "Governor",
               "needs_translation": true,
-              "max_length": 8,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 8
             },
             "gov_i": {
               "english": "Gov-I",
               "translation": "Gov-I",
               "needs_translation": true,
-              "max_length": 5,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 5
             },
             "gov_p": {
               "english": "Gov-P",
               "translation": "Gov-P",
               "needs_translation": true,
-              "max_length": 5,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 5
             },
             "governor": {
               "english": "Governor",
               "translation": "Governor",
               "needs_translation": true,
-              "max_length": 8,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 8
             },
             "hv_bec_voltage": {
               "english": "HV BEC Voltage",
               "translation": "HV BEC-Spannung",
               "needs_translation": false,
-              "max_length": 14,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 14
             },
             "led_color": {
               "english": "LED Color",
               "translation": "LED-Farbe",
               "needs_translation": false,
-              "max_length": 9,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 9
             },
             "lv_bec_voltage": {
               "english": "LV BEC Voltage",
               "translation": "LV BEC-Spannung",
               "needs_translation": false,
-              "max_length": 14,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 14
             },
             "motor_direction": {
               "english": "Motor Direction",
               "translation": "Motordrehrichtung (CCW/CW)",
               "needs_translation": false,
-              "max_length": 15,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 15
             },
             "motor_poles": {
               "english": "Motor Poles",
               "translation": "Motorpole",
               "needs_translation": false,
-              "max_length": 11,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 11
             },
             "name": {
               "english": "XDFLY",
               "translation": "XDFLY",
               "needs_translation": true,
-              "max_length": 5,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 5
             },
             "smart_fan": {
               "english": "Smart Fan",
               "translation": "Intelligenter Lüfter",
               "needs_translation": false,
-              "max_length": 9,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 9
             },
             "sr_function": {
               "english": "SR Function",
               "translation": "SR-Funktion",
               "needs_translation": false,
-              "max_length": 11,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 11
             },
             "startup_power": {
               "english": "Startup Power",
               "translation": "Anlaufleistung",
               "needs_translation": false,
-              "max_length": 13,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 13
             },
             "timing": {
               "english": "Timing",
               "translation": "Timing",
               "needs_translation": true,
-              "max_length": 6,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 6
             }
           },
           "yge": {
@@ -5942,176 +5942,176 @@
               "english": "Active Freewheel",
               "translation": "Aktive Freilaufsteuerung",
               "needs_translation": false,
-              "max_length": 16,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 16
             },
             "advanced": {
               "english": "Advanced",
               "translation": "Erweitert",
               "needs_translation": false,
-              "max_length": 8,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 8
             },
             "auto_restart_time": {
               "english": "Auto Restart Time",
               "translation": "Neustartzeit",
               "needs_translation": false,
-              "max_length": 17,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 17
             },
             "basic": {
               "english": "Basic",
               "translation": "Grundlegend",
               "needs_translation": false,
-              "max_length": 5,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 5
             },
             "cell_cutoff": {
               "english": "Cell Cutoff",
               "translation": "Zellenabschaltung",
               "needs_translation": false,
-              "max_length": 11,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 11
             },
             "current_limit": {
               "english": "Current Limit",
               "translation": "Strombegrenzung",
               "needs_translation": false,
-              "max_length": 13,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 13
             },
             "direction": {
               "english": "Direction",
               "translation": "Richtung",
               "needs_translation": false,
-              "max_length": 9,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 9
             },
             "esc": {
               "english": "ESC",
               "translation": "ESC",
               "needs_translation": true,
-              "max_length": 3,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 3
             },
             "esc_mode": {
               "english": "ESC Mode",
               "translation": "ESC-Modus",
               "needs_translation": false,
-              "max_length": 8,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 8
             },
             "f3c_auto": {
               "english": "F3C Autorotation",
               "translation": "F3C-Autorotation",
               "needs_translation": true,
-              "max_length": 16,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 16
             },
             "gov_i": {
               "english": "Gov-I",
               "translation": "Gov-I",
               "needs_translation": true,
-              "max_length": 5,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 5
             },
             "gov_p": {
               "english": "Gov-P",
               "translation": "Proportionalwert für den Governor",
               "needs_translation": false,
-              "max_length": 5,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 5
             },
             "limits": {
               "english": "Limits",
               "translation": "Grenzwerte",
               "needs_translation": false,
-              "max_length": 6,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 6
             },
             "lv_bec_voltage": {
               "english": "BEC",
               "translation": "BEC",
               "needs_translation": true,
-              "max_length": 3,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 3
             },
             "main_teeth": {
               "english": "Main Teeth",
               "translation": "Hauptzahnrad-Zähne",
               "needs_translation": false,
-              "max_length": 10,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 10
             },
             "max_start_power": {
               "english": "Max Start Power",
               "translation": "Maximale Startleistung",
               "needs_translation": false,
-              "max_length": 15,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 15
             },
             "min_start_power": {
               "english": "Min Start Power",
               "translation": "Minimale Startleistung",
               "needs_translation": false,
-              "max_length": 15,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 15
             },
             "motor_pole_pairs": {
               "english": "Motor Pole Pairs",
               "translation": "Motor-Polpaare",
               "needs_translation": false,
-              "max_length": 16,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 16
             },
             "name": {
               "english": "YGE",
               "translation": "YGE",
               "needs_translation": true,
-              "max_length": 3,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 3
             },
             "other": {
               "english": "Other",
               "translation": "Sonstiges",
               "needs_translation": false,
-              "max_length": 5,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 5
             },
             "pinion_teeth": {
               "english": "Pinion Teeth",
               "translation": "Ritzel-Zähne",
               "needs_translation": false,
-              "max_length": 12,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 12
             },
             "stick_range_us": {
               "english": "Stick Range",
               "translation": "Stick-Bereich",
               "needs_translation": false,
-              "max_length": 11,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 11
             },
             "stick_zero_us": {
               "english": "Stick Zero",
               "translation": "Stick-Nullpunkt",
               "needs_translation": false,
-              "max_length": 10,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 10
             },
             "throttle_response": {
               "english": "Throttle Response",
               "translation": "Gasannahme",
               "needs_translation": false,
-              "max_length": 17,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 17
             },
             "timing": {
               "english": "Motor Timing",
               "translation": "Motortiming",
               "needs_translation": true,
-              "max_length": 12,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 12
             }
           },
           "ztw": {
@@ -6119,148 +6119,148 @@
               "english": "Acceleration",
               "translation": "Beschleunigung",
               "needs_translation": false,
-              "max_length": 12,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 12
             },
             "advanced": {
               "english": "Advanced",
               "translation": "Erweitert",
               "needs_translation": false,
-              "max_length": 8,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 8
             },
             "auto_restart_time": {
               "english": "Auto Restart Time",
               "translation": "Neustartzeit",
               "needs_translation": false,
-              "max_length": 17,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 17
             },
             "basic": {
               "english": "Basic",
               "translation": "Grundlegend",
               "needs_translation": false,
-              "max_length": 5,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 5
             },
             "brake_force": {
               "english": "Brake Force",
               "translation": "Bremskraft",
               "needs_translation": false,
-              "max_length": 11,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 11
             },
             "capacity_correction": {
               "english": "Capacity Correction",
               "translation": "Kapazitätskorrektur",
               "needs_translation": false,
-              "max_length": 19,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 19
             },
             "cell_cutoff": {
               "english": "Cell Cutoff",
               "translation": "Zellenabschaltung",
               "needs_translation": false,
-              "max_length": 11,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 11
             },
             "gov": {
               "english": "Governor",
               "translation": "Governor",
               "needs_translation": true,
-              "max_length": 8,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 8
             },
             "gov_i": {
               "english": "Gov-I",
               "translation": "Gov-I",
               "needs_translation": true,
-              "max_length": 5,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 5
             },
             "gov_p": {
               "english": "Gov-P",
               "translation": "Gov-P",
               "needs_translation": true,
-              "max_length": 5,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 5
             },
             "governor": {
               "english": "Governor",
               "translation": "Governor",
               "needs_translation": true,
-              "max_length": 8,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 8
             },
             "hv_bec_voltage": {
               "english": "HV BEC Voltage",
               "translation": "HV BEC-Spannung",
               "needs_translation": false,
-              "max_length": 14,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 14
             },
             "led_color": {
               "english": "LED Color",
               "translation": "LED-Farbe",
               "needs_translation": false,
-              "max_length": 9,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 9
             },
             "lv_bec_voltage": {
               "english": "LV BEC Voltage",
               "translation": "LV BEC-Spannung",
               "needs_translation": false,
-              "max_length": 14,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 14
             },
             "motor_direction": {
               "english": "Motor Direction",
               "translation": "Motordrehrichtung (CCW/CW)",
               "needs_translation": false,
-              "max_length": 15,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 15
             },
             "motor_poles": {
               "english": "Motor Poles",
               "translation": "Motorpole",
               "needs_translation": false,
-              "max_length": 11,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 11
             },
             "name": {
               "english": "ZTW",
               "translation": "ZTW",
               "needs_translation": true,
-              "max_length": 3,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 3
             },
             "smart_fan": {
               "english": "Smart Fan",
               "translation": "Intelligenter Lüfter",
               "needs_translation": false,
-              "max_length": 9,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 9
             },
             "sr_function": {
               "english": "SR Function",
               "translation": "SR-Funktion",
               "needs_translation": false,
-              "max_length": 11,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 11
             },
             "startup_power": {
               "english": "Startup Power",
               "translation": "Anlaufleistung",
               "needs_translation": false,
-              "max_length": 13,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 13
             },
             "timing": {
               "english": "Timing",
               "translation": "Timing",
               "needs_translation": true,
-              "max_length": 6,
-              "reverse_text": false
+              "reverse_text": false,
+              "max_length": 6
             }
           }
         },
@@ -6268,29 +6268,29 @@
           "english": "Esc Programing",
           "translation": "ESC-Werkzeuge",
           "needs_translation": false,
-          "max_length": 14,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 14
         },
         "please_powercycle": {
           "english": "Please power cycle the ESC...",
           "translation": "Bitte schalten Sie den ESC aus und wieder ein...",
           "needs_translation": false,
-          "max_length": 29,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 29
         },
         "searching": {
           "english": "Searching",
           "translation": "Suche...",
           "needs_translation": false,
-          "max_length": 9,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 9
         },
         "unknown": {
           "english": "UNKNOWN",
           "translation": "UNBEKANNT",
           "needs_translation": false,
-          "max_length": 7,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 7
         }
       },
       "failsafe": {
@@ -6449,281 +6449,281 @@
           "english": "No Gyro",
           "translation": "Kein Gyro",
           "needs_translation": false,
-          "max_length": 7,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 7
         },
         "arming_disable_flag_1": {
           "english": "Fail Safe",
           "translation": "Fail Safe",
           "needs_translation": true,
-          "max_length": 9,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 9
         },
         "arming_disable_flag_10": {
           "english": "No Pre Arm",
           "translation": "Kein Pre-Arm",
           "needs_translation": false,
-          "max_length": 10,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 10
         },
         "arming_disable_flag_11": {
           "english": "Load",
           "translation": "Auslastung",
           "needs_translation": false,
-          "max_length": 4,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 4
         },
         "arming_disable_flag_12": {
           "english": "Calibrating",
           "translation": "Kalibrierung",
           "needs_translation": false,
-          "max_length": 11,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 11
         },
         "arming_disable_flag_13": {
           "english": "CLI",
           "translation": "CLI",
           "needs_translation": true,
-          "max_length": 3,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 3
         },
         "arming_disable_flag_14": {
           "english": "CMS Menu",
           "translation": "CMS-Menü",
           "needs_translation": false,
-          "max_length": 8,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 8
         },
         "arming_disable_flag_15": {
           "english": "BST",
           "translation": "BST",
           "needs_translation": true,
-          "max_length": 3,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 3
         },
         "arming_disable_flag_16": {
           "english": "MSP",
           "translation": "MSP",
           "needs_translation": true,
-          "max_length": 3,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 3
         },
         "arming_disable_flag_17": {
           "english": "Paralyze",
           "translation": "Paralyse",
           "needs_translation": false,
-          "max_length": 8,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 8
         },
         "arming_disable_flag_18": {
           "english": "GPS",
           "translation": "GPS",
           "needs_translation": true,
-          "max_length": 3,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 3
         },
         "arming_disable_flag_19": {
           "english": "Resc",
           "translation": "Rettung",
           "needs_translation": false,
-          "max_length": 4,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 4
         },
         "arming_disable_flag_2": {
           "english": "RX Fail Safe",
           "translation": "RX Fail Safe",
           "needs_translation": true,
-          "max_length": 12,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 12
         },
         "arming_disable_flag_20": {
           "english": "RPM Filter",
           "translation": "RPM-Filter",
           "needs_translation": true,
-          "max_length": 10,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 10
         },
         "arming_disable_flag_21": {
           "english": "Reboot Required",
           "translation": "Neustart erforderlich",
           "needs_translation": false,
-          "max_length": 15,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 15
         },
         "arming_disable_flag_22": {
           "english": "DSHOT Bitbang",
           "translation": "DSHOT Bitbang",
           "needs_translation": true,
-          "max_length": 13,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 13
         },
         "arming_disable_flag_23": {
           "english": "Acc Calibration",
           "translation": "ACC-Kalibrierung",
           "needs_translation": false,
-          "max_length": 15,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 15
         },
         "arming_disable_flag_24": {
           "english": "Motor Protocol",
           "translation": "Motor-Protokoll",
           "needs_translation": false,
-          "max_length": 14,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 14
         },
         "arming_disable_flag_25": {
           "english": "Arm Switch",
           "translation": "Arming-Schalter",
           "needs_translation": false,
-          "max_length": 10,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 10
         },
         "arming_disable_flag_3": {
           "english": "Bad RX Recovery",
           "translation": "RX-Wiederherstellung fehlgeschlagen",
           "needs_translation": false,
-          "max_length": 15,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 15
         },
         "arming_disable_flag_4": {
           "english": "Box Fail Safe",
           "translation": "Box Fail Safe",
           "needs_translation": true,
-          "max_length": 13,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 13
         },
         "arming_disable_flag_5": {
           "english": "Governor",
           "translation": "Governor",
           "needs_translation": true,
-          "max_length": 8,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 8
         },
         "arming_disable_flag_6": {
           "english": "RPM Signal",
           "translation": "RPM-Signal",
           "needs_translation": true,
-          "max_length": 10,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 10
         },
         "arming_disable_flag_7": {
           "english": "Throttle",
           "translation": "Gas",
           "needs_translation": false,
-          "max_length": 8,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 8
         },
         "arming_disable_flag_8": {
           "english": "Angle",
           "translation": "Winkel",
           "needs_translation": false,
-          "max_length": 5,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 5
         },
         "arming_disable_flag_9": {
           "english": "Boot Grace Time",
           "translation": "Boot-Grace-Zeit",
           "needs_translation": false,
-          "max_length": 15,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 15
         },
         "arming_flags": {
           "english": "Arming Flags",
           "translation": "Arming-Flags",
           "needs_translation": true,
-          "max_length": 12,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 12
         },
         "cpu_load": {
           "english": "CPU Load",
           "translation": "CPU-Auslastung",
           "needs_translation": false,
-          "max_length": 8,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 8
         },
         "dataflash_free_space": {
           "english": "Dataflash Free Space",
           "translation": "Freier Datenspeicher",
           "needs_translation": false,
-          "max_length": 20,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 20
         },
         "erase": {
           "english": "Erase",
           "translation": "Löschen",
           "needs_translation": false,
-          "max_length": 5,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 5
         },
         "erase_prompt": {
           "english": "Would you like to erase the dataflash?",
           "translation": "Möchten Sie den Datenspeicher löschen?",
           "needs_translation": false,
-          "max_length": 38,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 38
         },
         "erasing": {
           "english": "Erasing",
           "translation": "Löschen",
           "needs_translation": false,
-          "max_length": 7,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 7
         },
         "erasing_dataflash": {
           "english": "Erasing dataflash...",
           "translation": "Datenspeicher wird gelöscht...",
           "needs_translation": false,
-          "max_length": 20,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 20
         },
         "fbl_date": {
           "english": "Date",
           "translation": "Datum",
           "needs_translation": false,
-          "max_length": 4,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 4
         },
         "fbl_time": {
           "english": "Time",
           "translation": "Zeit",
           "needs_translation": false,
-          "max_length": 4,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 4
         },
         "megabyte": {
           "english": "MB",
           "translation": "MB",
           "needs_translation": true,
-          "max_length": 2,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 2
         },
         "name": {
           "english": "FBL Status",
           "translation": "FBL-Status",
           "needs_translation": true,
-          "max_length": 10,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 10
         },
         "ok": {
           "english": "OK",
           "translation": "OK",
           "needs_translation": true,
-          "max_length": 2,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 2
         },
         "real_time_load": {
           "english": "Real-time Load",
           "translation": "Echtzeitauslastung",
           "needs_translation": false,
-          "max_length": 14,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 14
         },
         "unsupported": {
           "english": "Unsupported",
           "translation": "Nicht unterstützt",
           "needs_translation": false,
-          "max_length": 11,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 11
         }
       },
       "filters": {
@@ -6731,162 +6731,162 @@
           "english": "Center",
           "translation": "Mitte",
           "needs_translation": false,
-          "max_length": 6,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 6
         },
         "cutoff": {
           "english": "Cutoff",
           "translation": "G-freq.",
           "needs_translation": false,
-          "max_length": 6,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 6
         },
         "dyn_notch": {
           "english": "Dynamic Filters",
           "translation": "Dynamische Filter",
           "needs_translation": false,
-          "max_length": 15,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 15
         },
         "filter_type": {
           "english": "Filter type",
           "translation": "Filtertyp",
           "needs_translation": false,
-          "max_length": 11,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 11
         },
         "help_p1": {
           "english": "Typically you would not edit this page without checking your Blackbox logs!",
           "translation": "Normalerweise sollten Sie diese Seite nicht bearbeiten, ohne Ihre Blackbox-Logs zu überprüfen!",
           "needs_translation": false,
-          "max_length": 75,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 75
         },
         "help_p2": {
           "english": "Gyro lowpass: Lowpass filters for the gyro signal. Typically left at default.",
           "translation": "Gyro-Tiefpass: Tiefpassfilter für das Gyro-Signal. In der Regel auf Standard belassen.",
           "needs_translation": false,
-          "max_length": 77,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 77
         },
         "help_p3": {
           "english": "Gyro notch filters: Use for filtering specific frequency ranges. Typically not needed in most helis.",
           "translation": "Gyro-Notch-Filter: Wird verwendet, um bestimmte Frequenzbereiche zu filtern. In den meisten Helis normalerweise nicht erforderlich.",
           "needs_translation": false,
-          "max_length": 100,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 100
         },
         "help_p4": {
           "english": "Dynamic Notch Filters: Automatically creates notch filters within the min and max frequency range.",
           "translation": "Dynamische Notch-Filter: Erstellt automatisch Notch-Filter innerhalb des minimalen und maximalen Frequenzbereichs.",
           "needs_translation": false,
-          "max_length": 98,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 98
         },
         "lowpass_1": {
           "english": "Lowpass 1",
           "translation": "TP 1",
           "needs_translation": false,
-          "max_length": 9,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 9
         },
         "lowpass_1_dyn": {
           "english": "Lowpass 1 dyn.",
           "translation": "TP 1 dyn.",
           "needs_translation": false,
-          "max_length": 14,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 14
         },
         "lowpass_2": {
           "english": "Lowpass 2",
           "translation": "TP 2",
           "needs_translation": false,
-          "max_length": 9,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 9
         },
         "max_cutoff": {
           "english": "Max cutoff",
           "translation": "Max. Grenzfreq.",
           "needs_translation": false,
-          "max_length": 10,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 10
         },
         "min_cutoff": {
           "english": "Min cutoff",
           "translation": "Min. Grenzfreq.",
           "needs_translation": false,
-          "max_length": 10,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 10
         },
         "name": {
           "english": "Filters",
           "translation": "Filter",
           "needs_translation": false,
-          "max_length": 7,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 7
         },
         "notch_1": {
           "english": "Notch 1",
           "translation": "Notch 1",
           "needs_translation": true,
-          "max_length": 7,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 7
         },
         "notch_2": {
           "english": "Notch 2",
           "translation": "Notch 2",
           "needs_translation": true,
-          "max_length": 7,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 7
         },
         "notch_c": {
           "english": "Notch Count",
           "translation": "Notch Anzahl",
           "needs_translation": false,
-          "max_length": 11,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 11
         },
         "notch_max_hz": {
           "english": "Max",
           "translation": "Max",
           "needs_translation": true,
-          "max_length": 3,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 3
         },
         "notch_min_hz": {
           "english": "Min",
           "translation": "Min",
           "needs_translation": true,
-          "max_length": 3,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 3
         },
         "notch_q": {
           "english": "Notch Q",
           "translation": "Notch Q",
           "needs_translation": true,
-          "max_length": 7,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 7
         },
         "rpm_filter": {
           "english": "RPM filter",
           "translation": "Drehzahl-Filter",
           "needs_translation": false,
-          "max_length": 10,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 10
         },
         "rpm_min_hz": {
           "english": "Min. Frequency",
           "translation": "Min. Freq.",
           "needs_translation": false,
-          "max_length": 14,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 14
         },
         "rpm_preset": {
           "english": "Type",
           "translation": "Typ",
           "needs_translation": false,
-          "max_length": 4,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 4
         }
       },
       "governor": {
@@ -6894,169 +6894,169 @@
           "english": "Autorotation Timeout",
           "translation": "Autorotations-Timeout",
           "needs_translation": false,
-          "max_length": 20,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 20
         },
         "gov_d_filter": {
           "english": "D-Term Cutoff",
           "translation": "D-Term Grenzwert",
           "needs_translation": false,
-          "max_length": 13,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 13
         },
         "gov_ff_filter": {
           "english": "Precomp Bandwidth",
           "translation": "Vorkomp. Bandbreite",
           "needs_translation": false,
-          "max_length": 17,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 17
         },
         "gov_pwr_filter": {
           "english": "Voltage Filter Cutoff",
           "translation": "Spannungsfilter Grenzwert",
           "needs_translation": false,
-          "max_length": 21,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 21
         },
         "gov_tta_filter": {
           "english": "TTA Bandwidth",
           "translation": "TTA-Bandbreite",
           "needs_translation": false,
-          "max_length": 13,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 13
         },
         "handover_throttle": {
           "english": "Handover throttle%",
           "translation": "Übergabe-Gas%",
           "needs_translation": false,
-          "max_length": 18,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 18
         },
         "help_p1": {
           "english": "These parameters apply globally to the governor regardless of the profile in use.",
           "translation": "Diese Parameter gelten global für den Drehzahlregler (Governor), unabhängig vom verwendeten Profil.",
           "needs_translation": false,
-          "max_length": 81,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 81
         },
         "help_p2": {
           "english": "Each parameter is simply a time value in seconds for each governor action.",
           "translation": "Jeder Parameter ist einfach ein Zeitwert in Sekunden für jede Regleraktion.",
           "needs_translation": false,
-          "max_length": 74,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 74
         },
         "menu_curves": {
           "english": "Bypass Curve",
           "translation": "Bypass-Kurve",
           "needs_translation": false,
-          "max_length": 12,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 12
         },
         "menu_curves_long": {
           "english": "Governor Bypass Curve",
           "translation": "Governor-Bypass-Kurve",
           "needs_translation": false,
-          "max_length": 21,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 21
         },
         "menu_filters": {
           "english": "Filters",
           "translation": "Filter",
           "needs_translation": false,
-          "max_length": 7,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 7
         },
         "menu_flags": {
           "english": "Behaviour",
           "translation": "Verhalten",
           "needs_translation": false,
-          "max_length": 9,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 9
         },
         "menu_general": {
           "english": "General",
           "translation": "Allgemein",
           "needs_translation": false,
-          "max_length": 7,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 7
         },
         "menu_time": {
           "english": "Ramp Time",
           "translation": "Rampenzeit",
           "needs_translation": false,
-          "max_length": 9,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 9
         },
         "mode": {
           "english": "Mode",
           "translation": "Modus",
           "needs_translation": false,
-          "max_length": 4,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 4
         },
         "name": {
           "english": "Governor",
           "translation": "Governor",
           "needs_translation": true,
-          "max_length": 8,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 8
         },
         "recovery_time": {
           "english": "Recovery time",
           "translation": "Erholungszeit",
           "needs_translation": false,
-          "max_length": 13,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 13
         },
         "spooldown_time": {
           "english": "Spooldown time",
           "translation": "Spooldown-Zeit",
           "needs_translation": false,
-          "max_length": 14,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 14
         },
         "spoolup_min_throttle": {
           "english": "Spoolup min throttle%",
           "translation": "Min. Spoolup-Gas%",
           "needs_translation": false,
-          "max_length": 21,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 21
         },
         "spoolup_time": {
           "english": "Spoolup time",
           "translation": "Spoolup-Zeit",
           "needs_translation": false,
-          "max_length": 12,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 12
         },
         "startup_time": {
           "english": "Startup time",
           "translation": "Startzeit",
           "needs_translation": false,
-          "max_length": 12,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 12
         },
         "throttle_hold_timeout": {
           "english": "Throttle hold timeout",
           "translation": "Gas-Hold Timeout",
           "needs_translation": false,
-          "max_length": 21,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 21
         },
         "throttle_type": {
           "english": "Throttle type",
           "translation": "Gastyp",
           "needs_translation": false,
-          "max_length": 13,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 13
         },
         "tracking_time": {
           "english": "Tracking time",
           "translation": "Tracking-Zeit",
           "needs_translation": false,
-          "max_length": 13,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 13
         }
       },
       "hardware_interfaces": {
@@ -7091,64 +7091,64 @@
           "english": "Ethos Version",
           "translation": "Ethos-Version",
           "needs_translation": true,
-          "max_length": 13,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 13
         },
         "fc_version": {
           "english": "FC Version",
           "translation": "FC-Version",
           "needs_translation": true,
-          "max_length": 10,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 10
         },
         "msp_transport": {
           "english": "MSP Transport",
           "translation": "MSP-Transport",
           "needs_translation": true,
-          "max_length": 13,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 13
         },
         "msp_version": {
           "english": "MSP Version",
           "translation": "MSP-Version",
           "needs_translation": true,
-          "max_length": 11,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 11
         },
         "name": {
           "english": "Info",
           "translation": "Info",
           "needs_translation": true,
-          "max_length": 4,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 4
         },
         "rf_version": {
           "english": "Rotorflight Version",
           "translation": "Rotorflight-Version",
           "needs_translation": true,
-          "max_length": 19,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 19
         },
         "simulation": {
           "english": "Simulation",
           "translation": "Simulation",
           "needs_translation": true,
-          "max_length": 10,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 10
         },
         "supported_versions": {
           "english": "Supported MSP Versions",
           "translation": "MSP-Versionen",
           "needs_translation": false,
-          "max_length": 22,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 22
         },
         "version": {
           "english": "Version",
           "translation": "Version",
           "needs_translation": true,
-          "max_length": 7,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 7
         }
       },
       "logs": {
@@ -7156,43 +7156,43 @@
           "english": "Please select a log file from the list below.",
           "translation": "Bitte wählen Sie eine Log-Datei aus der untenstehenden Liste aus.",
           "needs_translation": false,
-          "max_length": 45,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 45
         },
         "help_logs_p2": {
           "english": "Note. To enable logging it is essential for you to have the following sensors enabled.",
           "translation": "Hinweis: Um das Logging zu aktivieren, müssen Sie die folgenden Sensoren aktiviert haben.",
           "needs_translation": false,
-          "max_length": 86,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 86
         },
         "help_logs_p3": {
           "english": "- arm status, voltage, headspeed, current, esc temperature",
           "translation": "- Arm-Status, Spannung, Drehzahl, Strom, ESC-Temperatur",
           "needs_translation": false,
-          "max_length": 58,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 58
         },
         "help_logs_tool_p1": {
           "english": "Please use the slider to navigate the graph.",
           "translation": "Bitte verwenden Sie den Schieberegler, um im Diagramm zu navigieren.",
           "needs_translation": false,
-          "max_length": 44,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 44
         },
         "msg_no_logs_found": {
           "english": "NO LOG FILES FOUND",
           "translation": "KEINE LOG-DATEIEN GEFUNDEN",
           "needs_translation": false,
-          "max_length": 18,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 18
         },
         "name": {
           "english": "Logs",
           "translation": "Logs",
           "needs_translation": true,
-          "max_length": 4,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 4
         }
       },
       "mixer": {
@@ -7200,57 +7200,57 @@
           "english": "Aileron Direction",
           "translation": "Querruder-Richtung",
           "needs_translation": false,
-          "max_length": 17,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 17
         },
         "collective_calibration": {
           "english": "Collective Calibration",
           "translation": "Kollektive Kalibrierung",
           "needs_translation": false,
-          "max_length": 22,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 22
         },
         "collective_direction": {
           "english": "Collective Direction",
           "translation": "Kollektiv-Richtung",
           "needs_translation": false,
-          "max_length": 20,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 20
         },
         "collective_pitch_limit": {
           "english": "Collective Pitch Limit",
           "translation": "Kollektives Pitch-Limit",
           "needs_translation": false,
-          "max_length": 22,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 22
         },
         "collective_tilt_correction_neg": {
           "english": "Collective Tilt Correction -",
           "translation": "Kollektive Neigungskorrektur -",
           "needs_translation": false,
-          "max_length": 28,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 28
         },
         "collective_tilt_correction_pos": {
           "english": "Collective Tilt Correction +",
           "translation": "Kollektive Neigungskorrektur +",
           "needs_translation": false,
-          "max_length": 28,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 28
         },
         "cyclic_calibration": {
           "english": "Cyclic Calibration",
           "translation": "Zyklische Kalibrierung",
           "needs_translation": false,
-          "max_length": 18,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 18
         },
         "cyclic_pitch_limit": {
           "english": "Cyclic Pitch Limit",
           "translation": "Zyklisches Pitch-Limit",
           "needs_translation": false,
-          "max_length": 18,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 18
         },
         "disable_swash_override": {
           "english": "Disable swash setup mode",
@@ -7270,8 +7270,8 @@
           "english": "Elevator Direction",
           "translation": "Höhenruder-Richtung",
           "needs_translation": false,
-          "max_length": 18,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 18
         },
         "enable_swash_override": {
           "english": "Enable swash setup mode",
@@ -7291,43 +7291,43 @@
           "english": "Geo Correction",
           "translation": "Geo-Korrektur",
           "needs_translation": false,
-          "max_length": 14,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 14
         },
         "geometry": {
           "english": "Geometry",
           "translation": "Geometrie",
           "needs_translation": false,
-          "max_length": 8,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 8
         },
         "help_p1": {
           "english": "Adust swash plate geometry, phase angles, and limits.",
           "translation": "Passen Sie die Taumelscheibengeometrie, Phasenwinkel und Begrenzungen an.",
           "needs_translation": false,
-          "max_length": 53,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 53
         },
         "main_rotor_dir": {
           "english": "Rotor Direction",
           "translation": "Rotordrehrichtung",
           "needs_translation": false,
-          "max_length": 15,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 15
         },
         "name": {
           "english": "Mixer",
           "translation": "Mischer",
           "needs_translation": false,
-          "max_length": 5,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 5
         },
         "swash": {
           "english": "Swash",
           "translation": "Taumelscheibe",
           "needs_translation": false,
-          "max_length": 5,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 5
         },
         "swash_override": {
           "english": "Swash Setup Mode",
@@ -7354,99 +7354,99 @@
           "english": "Phase Angle",
           "translation": "Phasenwinkel",
           "needs_translation": false,
-          "max_length": 11,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 11
         },
         "swash_pitch_limit": {
           "english": "Total Pitch Limit",
           "translation": "Gesamter Pitch-Limit",
           "needs_translation": false,
-          "max_length": 17,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 17
         },
         "swash_tta_precomp": {
           "english": "TTA Precomp",
           "translation": "TTA-Vorkompensation",
           "needs_translation": false,
-          "max_length": 11,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 11
         },
         "swash_type": {
           "english": "Swash Type",
           "translation": "Taumelscheibentyp",
           "needs_translation": false,
-          "max_length": 10,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 10
         },
         "tail": {
           "english": "Tail",
           "translation": "Heck",
           "needs_translation": false,
-          "max_length": 4,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 4
         },
         "tail_center_offset": {
           "english": "Tail Center Offset",
           "translation": "Heck-Mittenversatz",
           "needs_translation": false,
-          "max_length": 18,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 18
         },
         "tail_motor_idle": {
           "english": "Tail Idle Thr%",
           "translation": "Heckleerlauf-Gas%",
           "needs_translation": false,
-          "max_length": 14,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 14
         },
         "tail_rotor_mode": {
           "english": "Tail Mode",
           "translation": "Heckmodus",
           "needs_translation": false,
-          "max_length": 9,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 9
         },
         "trims": {
           "english": "Trims",
           "translation": "Trimmungen",
           "needs_translation": false,
-          "max_length": 5,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 5
         },
         "yaw_calibration": {
           "english": "Yaw Calibration",
           "translation": "Gier-Kalibrierung",
           "needs_translation": false,
-          "max_length": 15,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 15
         },
         "yaw_ccw_limit": {
           "english": "Yaw CCW Limit",
           "translation": "Gier CCW-Limit",
           "needs_translation": false,
-          "max_length": 13,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 13
         },
         "yaw_center_trim": {
           "english": "Yaw Center Trim",
           "translation": "Gier-Mitten-Trimmung",
           "needs_translation": false,
-          "max_length": 15,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 15
         },
         "yaw_cw_limit": {
           "english": "Yaw CW Limit",
           "translation": "Gier CW-Limit",
           "needs_translation": false,
-          "max_length": 12,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 12
         },
         "yaw_direction": {
           "english": "Yaw Direction",
           "translation": "Gier-Richtung",
           "needs_translation": false,
-          "max_length": 13,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 13
         }
       },
       "modes": {
@@ -7463,22 +7463,22 @@
           "english": "This tool provides the ability to send a custom byte string to the flight controller. It is useful for developers when debugging values.",
           "translation": "Dieses Tool ermöglicht das Senden einer benutzerdefinierten Byte-Zeichenfolge an den Flugcontroller. Es ist nützlich für Entwickler beim Debuggen von Werten.",
           "needs_translation": false,
-          "max_length": 136,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 136
         },
         "help_p2": {
           "english": "If you do not understand what you are doing, do not use it as bad things can happen.",
           "translation": "Wenn Sie nicht verstehen, was Sie tun, verwenden Sie es nicht, da dies zu Problemen führen kann.",
           "needs_translation": false,
-          "max_length": 84,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 84
         },
         "name": {
           "english": "MSP Expermental",
           "translation": "MSP Experimentell",
           "needs_translation": false,
-          "max_length": 15,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 15
         }
       },
       "msp_speed": {
@@ -7486,141 +7486,141 @@
           "english": "Average query time",
           "translation": "Durchschnittliche Anfragezeit",
           "needs_translation": false,
-          "max_length": 18,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 18
         },
         "checksum_errors": {
           "english": "Checksum errors",
           "translation": "Prüfsummenfehler",
           "needs_translation": false,
-          "max_length": 15,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 15
         },
         "max_query_time": {
           "english": "Maximum query time",
           "translation": "Maximale Anfragezeit",
           "needs_translation": false,
-          "max_length": 18,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 18
         },
         "memory_free": {
           "english": "Memory free",
           "translation": "Freier Speicher",
           "needs_translation": false,
-          "max_length": 11,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 11
         },
         "min_query_time": {
           "english": "Minimum query time",
           "translation": "Minimale Anfragezeit",
           "needs_translation": false,
-          "max_length": 18,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 18
         },
         "name": {
           "english": "MSP Speed",
           "translation": "MSP-Geschwindigkeit",
           "needs_translation": false,
-          "max_length": 9,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 9
         },
         "retries": {
           "english": "Retries",
           "translation": "Wiederholungen",
           "needs_translation": false,
-          "max_length": 7,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 7
         },
         "rf_protocol": {
           "english": "RF protocol",
           "translation": "RF-Protokoll",
           "needs_translation": false,
-          "max_length": 11,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 11
         },
         "seconds_120": {
           "english": "  120S  ",
           "translation": "  120S  ",
           "needs_translation": true,
-          "max_length": 8,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 8
         },
         "seconds_30": {
           "english": "  30S  ",
           "translation": "  30S  ",
           "needs_translation": true,
-          "max_length": 7,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 7
         },
         "seconds_300": {
           "english": "  300S  ",
           "translation": "  300S  ",
           "needs_translation": true,
-          "max_length": 8,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 8
         },
         "seconds_600": {
           "english": "  600S  ",
           "translation": "  600S  ",
           "needs_translation": true,
-          "max_length": 8,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 8
         },
         "start": {
           "english": "Start",
           "translation": "Start",
           "needs_translation": true,
-          "max_length": 5,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 5
         },
         "start_prompt": {
           "english": "Would you like to start the test? Choose the test run time below.",
           "translation": "Möchten Sie den Test starten? Wählen Sie unten die Testlaufzeit aus.",
           "needs_translation": false,
-          "max_length": 65,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 65
         },
         "successful_queries": {
           "english": "Successful queries",
           "translation": "Erfolgreiche Anfragen",
           "needs_translation": false,
-          "max_length": 18,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 18
         },
         "test_length": {
           "english": "Test length",
           "translation": "Testdauer",
           "needs_translation": false,
-          "max_length": 11,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 11
         },
         "testing": {
           "english": "Testing",
           "translation": "Testlauf",
           "needs_translation": false,
-          "max_length": 7,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 7
         },
         "testing_performance": {
           "english": "Testing MSP performance...",
           "translation": "MSP-Leistung wird getestet...",
           "needs_translation": false,
-          "max_length": 26,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 26
         },
         "timeouts": {
           "english": "Timeouts",
           "translation": "Zeitüberschreitungen",
           "needs_translation": false,
-          "max_length": 8,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 8
         },
         "total_queries": {
           "english": "Total queries",
           "translation": "Gesamtanzahl Anfragen",
           "needs_translation": false,
-          "max_length": 13,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 13
         }
       },
       "pids": {
@@ -7628,99 +7628,99 @@
           "english": "B",
           "translation": "B",
           "needs_translation": true,
-          "max_length": 1,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 1
         },
         "d": {
           "english": "D",
           "translation": "D",
           "needs_translation": true,
-          "max_length": 1,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 1
         },
         "f": {
           "english": "FF",
           "translation": "FF",
           "needs_translation": true,
-          "max_length": 2,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 2
         },
         "help_p1": {
           "english": "FeedForward (Roll/Pitch): Start at 70, increase until stops are sharp with no drift. Keep roll and pitch equal.",
           "translation": "FeedForward (Roll/Nick): Beginnen Sie bei 70, erhöhen Sie den Wert, bis Stopps scharf sind und kein Driften auftritt. Halten Sie Roll und Nick gleich.",
           "needs_translation": false,
-          "max_length": 111,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 111
         },
         "help_p2": {
           "english": "I Gain (Roll/Pitch): Raise gradually for stable piro pitch pumps. Too high causes wobbles; match roll/pitch values.",
           "translation": "I-Gain (Roll/Nick): Erhöhen Sie den Wert schrittweise für stabile Piro-Pitch-Pumps. Ein zu hoher Wert verursacht Wackeln; Roll- und Nick-Werte sollten übereinstimmen.",
           "needs_translation": false,
-          "max_length": 115,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 115
         },
         "help_p3": {
           "english": "Tail P/I/D Gains: Increase P until slight wobble in funnels, then back off slightly. Raise I until tail holds firm in hard moves (too high causes slow wag). Adjust D for smooth stops-higher for slow servos, lower for fast ones.",
           "translation": "Heck P/I/D-Gains: Erhöhen Sie P, bis leichtes Wackeln in Funnels auftritt, dann leicht reduzieren. Erhöhen Sie I, bis das Heck in harten Manövern stabil bleibt (zu hoch verursacht langsames Schwingen). D anpassen für sanfte Stopps – höher für langsame Servos, niedriger für schnelle.",
           "needs_translation": false,
-          "max_length": 227,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 227
         },
         "help_p4": {
           "english": "Test & Adjust: Fly, observe, and fine-tune for best performance in real conditions.",
           "translation": "Testen & Anpassen: Fliegen, beobachten und feinjustieren, um die beste Leistung unter realen Bedingungen zu erreichen.",
           "needs_translation": false,
-          "max_length": 83,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 83
         },
         "i": {
           "english": "I",
           "translation": "I",
           "needs_translation": true,
-          "max_length": 1,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 1
         },
         "name": {
           "english": "PIDs",
           "translation": "PIDs",
           "needs_translation": true,
-          "max_length": 4,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 4
         },
         "o": {
           "english": "O",
           "translation": "O",
           "needs_translation": true,
-          "max_length": 1,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 1
         },
         "p": {
           "english": "P",
           "translation": "P",
           "needs_translation": true,
-          "max_length": 1,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 1
         },
         "pitch": {
           "english": "Pitch",
           "translation": "Nick",
           "needs_translation": false,
-          "max_length": 5,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 5
         },
         "roll": {
           "english": "Roll",
           "translation": "Roll",
           "needs_translation": true,
-          "max_length": 4,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 4
         },
         "yaw": {
           "english": "Yaw",
           "translation": "Gier",
           "needs_translation": false,
-          "max_length": 3,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 3
         }
       },
       "power": {
@@ -7728,29 +7728,29 @@
           "english": "Alerts",
           "translation": "Warnungen",
           "needs_translation": false,
-          "max_length": 6,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 6
         },
         "alert_type": {
           "english": "Rx Voltage Alert",
           "translation": "Rx-Spannungswarnung",
           "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 16
         },
         "battery_capacity": {
           "english": "Battery Capacity",
           "translation": "Akkukapazität",
           "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 16
         },
         "battery_name": {
           "english": "Battery",
           "translation": "Akku",
           "needs_translation": false,
-          "max_length": 7,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 7
         },
         "capacity": {
           "english": "Capacity",
@@ -7763,71 +7763,71 @@
           "english": "BEC Alert Value",
           "translation": "BEC-Warnwert",
           "needs_translation": false,
-          "max_length": 15,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 15
         },
         "calcfuel_local": {
           "english": "Calculate Fuel Using",
           "translation": "Kraftstoff berechnen mit",
           "needs_translation": false,
-          "max_length": 20,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 20
         },
         "cell_count": {
           "english": "Cell Count",
           "translation": "Zellenanzahl",
           "needs_translation": false,
-          "max_length": 10,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 10
         },
         "consumption_warning_percentage": {
           "english": "Consumption Warning %",
           "translation": "Verbrauchswarnung %",
           "needs_translation": false,
-          "max_length": 21,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 21
         },
         "current_meter_source": {
           "english": "Current Source",
           "translation": "Stromquelle",
           "needs_translation": false,
-          "max_length": 14,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 14
         },
         "full_cell_voltage": {
           "english": "Full Cell Voltage",
           "translation": "Volle Zellenspannung",
           "needs_translation": false,
-          "max_length": 17,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 17
         },
         "help_p1": {
           "english": "The battery settings are used to configure the flight controller to monitor the battery voltage and provide warnings when the voltage drops below a certain level.",
           "translation": "Die Batterieeinstellungen dienen dazu, den Flugcontroller so zu konfigurieren, dass er die Batteriespannung überwacht und Warnungen ausgibt, wenn die Spannung unter einen bestimmten Wert fällt.",
           "needs_translation": false,
-          "max_length": 162,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 162
         },
         "max_cell_voltage": {
           "english": "Max Cell Voltage",
           "translation": "Max. Zellenspannung",
           "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 16
         },
         "min_cell_voltage": {
           "english": "Min Cell Voltage",
           "translation": "Min. Zellenspannung",
           "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 16
         },
         "name": {
           "english": "Power",
           "translation": "Stromversorgung",
           "needs_translation": false,
-          "max_length": 5,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 5
         },
         "selected": {
           "english": "Selected",
@@ -7840,43 +7840,43 @@
           "english": "RxBatt Alert Value",
           "translation": "RxBatt-Warnwert",
           "needs_translation": false,
-          "max_length": 18,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 18
         },
         "source_name": {
           "english": "Sources",
           "translation": "Quellen",
           "needs_translation": false,
-          "max_length": 7,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 7
         },
         "timer": {
           "english": "Flight Time Alarm",
           "translation": "Flugzeitalarm",
           "needs_translation": false,
-          "max_length": 17,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 17
         },
         "voltage_meter_source": {
           "english": "Voltage Source",
           "translation": "Spannungsquelle",
           "needs_translation": false,
-          "max_length": 14,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 14
         },
         "voltage_multiplier": {
           "english": "Sag Compensation",
           "translation": "Spannungseinbruch-Kompensation",
           "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 16
         },
         "warn_cell_voltage": {
           "english": "Warn Cell Voltage",
           "translation": "Warn-Zellenspannung",
           "needs_translation": false,
-          "max_length": 17,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 17
         }
       },
       "ports": {
@@ -8077,239 +8077,69 @@
           "max_length": 11
         }
       },
-      "power": {
-        "alert_name": {
-          "english": "Alerts",
-          "translation": "Warnungen",
-          "needs_translation": false,
-          "max_length": 6,
-          "reverse_text": false
-        },
-        "alert_type": {
-          "english": "Rx Voltage Alert",
-          "translation": "Rx-Spannungswarnung",
-          "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
-        },
-        "battery_capacity": {
-          "english": "Battery Capacity",
-          "translation": "Akkukapazität",
-          "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
-        },
-        "battery_name": {
-          "english": "Battery",
-          "translation": "Akku",
-          "needs_translation": false,
-          "max_length": 7,
-          "reverse_text": false
-        },
-        "bec_voltage_alert": {
-          "english": "BEC Alert Value",
-          "translation": "BEC-Warnwert",
-          "needs_translation": false,
-          "max_length": 15,
-          "reverse_text": false
-        },
-        "calcfuel_local": {
-          "english": "Calculate Fuel Using",
-          "translation": "Kraftstoff berechnen mit",
-          "needs_translation": false,
-          "max_length": 20,
-          "reverse_text": false
-        },
-        "capacity": {
-          "english": "Capacity",
-          "translation": "Capacity",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 8
-        },
-        "cell_count": {
-          "english": "Cell Count",
-          "translation": "Zellenanzahl",
-          "needs_translation": false,
-          "max_length": 10,
-          "reverse_text": false
-        },
-        "consumption_warning_percentage": {
-          "english": "Consumption Warning %",
-          "translation": "Verbrauchswarnung %",
-          "needs_translation": false,
-          "max_length": 21,
-          "reverse_text": false
-        },
-        "current_meter_source": {
-          "english": "Current Source",
-          "translation": "Stromquelle",
-          "needs_translation": false,
-          "max_length": 14,
-          "reverse_text": false
-        },
-        "full_cell_voltage": {
-          "english": "Full Cell Voltage",
-          "translation": "Volle Zellenspannung",
-          "needs_translation": false,
-          "max_length": 17,
-          "reverse_text": false
-        },
-        "help_p1": {
-          "english": "The battery settings are used to configure the flight controller to monitor the battery voltage and provide warnings when the voltage drops below a certain level.",
-          "translation": "Die Batterieeinstellungen dienen dazu, den Flugcontroller so zu konfigurieren, dass er die Batteriespannung überwacht und Warnungen ausgibt, wenn die Spannung unter einen bestimmten Wert fällt.",
-          "needs_translation": false,
-          "max_length": 162,
-          "reverse_text": false
-        },
-        "max_cell_voltage": {
-          "english": "Max Cell Voltage",
-          "translation": "Max. Zellenspannung",
-          "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
-        },
-        "min_cell_voltage": {
-          "english": "Min Cell Voltage",
-          "translation": "Min. Zellenspannung",
-          "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
-        },
-        "name": {
-          "english": "Power",
-          "translation": "Stromversorgung",
-          "needs_translation": false,
-          "max_length": 5,
-          "reverse_text": false
-        },
-        "rx_voltage_alert": {
-          "english": "RxBatt Alert Value",
-          "translation": "RxBatt-Warnwert",
-          "needs_translation": false,
-          "max_length": 18,
-          "reverse_text": false
-        },
-        "selected": {
-          "english": "Selected",
-          "translation": "Selected",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 8
-        },
-        "show_battery_profile_startup": {
-          "english": "Show battery type choose (startup)",
-          "translation": "Show battery type choose (startup)",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 34
-        },
-        "show_confirmation_dialog": {
-          "english": "Show confirmation dialog",
-          "translation": "Show confirmation dialog",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 24
-        },
-        "source_name": {
-          "english": "Sources",
-          "translation": "Quellen",
-          "needs_translation": false,
-          "max_length": 7,
-          "reverse_text": false
-        },
-        "timer": {
-          "english": "Flight Time Alarm",
-          "translation": "Flugzeitalarm",
-          "needs_translation": false,
-          "max_length": 17,
-          "reverse_text": false
-        },
-        "voltage_meter_source": {
-          "english": "Voltage Source",
-          "translation": "Spannungsquelle",
-          "needs_translation": false,
-          "max_length": 14,
-          "reverse_text": false
-        },
-        "voltage_multiplier": {
-          "english": "Sag Compensation",
-          "translation": "Spannungseinbruch-Kompensation",
-          "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
-        },
-        "warn_cell_voltage": {
-          "english": "Warn Cell Voltage",
-          "translation": "Warn-Zellenspannung",
-          "needs_translation": false,
-          "max_length": 17,
-          "reverse_text": false
-        }
-      },
       "profile_autolevel": {
         "acro_trainer": {
           "english": "Acro trainer",
           "translation": "Acro-Trainer",
           "needs_translation": true,
-          "max_length": 12,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 12
         },
         "angle_mode": {
           "english": "Angle mode",
           "translation": "Winkelmodus",
           "needs_translation": false,
-          "max_length": 10,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 10
         },
         "gain": {
           "english": "Gain",
           "translation": "Verstärkung",
           "needs_translation": false,
-          "max_length": 4,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 4
         },
         "help_p1": {
           "english": "Acro Trainer: How aggressively the heli tilts back to level when flying in Acro Trainer Mode.",
           "translation": "Acro-Trainer: Rückstellkraft des Helikopters zurück zur Waagerechten im Acro-Trainer-Modus .",
           "needs_translation": false,
-          "max_length": 93,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 93
         },
         "help_p2": {
           "english": "Angle Mode: How aggressively the heli tilts back to level when flying in Angle Mode.",
           "translation": "Winkelmodus: Rückstellkraft des Helikopters zurück zur Waagerechten im Winkelmodus.",
           "needs_translation": false,
-          "max_length": 84,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 84
         },
         "help_p3": {
           "english": "Horizon Mode: How aggressively the heli tilts back to level when flying in Horizon Mode.",
           "translation": "Horizontmodus: Rückstellkraft des Helikopters zurück zur Waagerechten im Horizontmodus.",
           "needs_translation": false,
-          "max_length": 88,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 88
         },
         "horizon_mode": {
           "english": "Horizon mode",
           "translation": "Horizontmodus",
           "needs_translation": false,
-          "max_length": 12,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 12
         },
         "max": {
           "english": "Max",
           "translation": "Max",
           "needs_translation": true,
-          "max_length": 3,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 3
         },
         "name": {
           "english": "Autolevel",
           "translation": "Autonivellierung",
           "needs_translation": false,
-          "max_length": 9,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 9
         }
       },
       "profile_governor": {
@@ -8317,218 +8147,218 @@
           "english": "Auto throttle",
           "translation": "Automatisches Gas",
           "needs_translation": false,
-          "max_length": 13,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 13
         },
         "col": {
           "english": "Col",
           "translation": "Kol.",
           "needs_translation": false,
-          "max_length": 3,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 3
         },
         "cyc": {
           "english": "Cyc",
           "translation": "Zyk.",
           "needs_translation": false,
-          "max_length": 3,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 3
         },
         "d": {
           "english": "D",
           "translation": "D",
           "needs_translation": true,
-          "max_length": 1,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 1
         },
         "disabled_message": {
           "english": "Rotorflight governor is not enabled",
           "translation": "Rotorflight-Governor ist nicht aktiviert",
           "needs_translation": false,
-          "max_length": 35,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 35
         },
         "dyn_min_throttle": {
           "english": "Dyn. Min Throttle",
           "translation": "Dyn. Min. Gas",
           "needs_translation": false,
-          "max_length": 17,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 17
         },
         "f": {
           "english": "FF",
           "translation": "FF",
           "needs_translation": true,
-          "max_length": 2,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 2
         },
         "fallback_drop": {
           "english": "Thr. Fallback drop",
           "translation": "Fallback-Gasabfall",
           "needs_translation": false,
-          "max_length": 18,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 18
         },
         "fallback_precomp": {
           "english": "Fallback Precomp",
           "translation": "Fallback-Vorkomp.",
           "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 16
         },
         "full_headspeed": {
           "english": "Full headspeed",
           "translation": "Volle Drehzahl",
           "needs_translation": false,
-          "max_length": 14,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 14
         },
         "gain": {
           "english": "PID master gain",
           "translation": "PID-Masterverstärkung",
           "needs_translation": false,
-          "max_length": 15,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 15
         },
         "gains": {
           "english": "Gains",
           "translation": "Verstärkungen",
           "needs_translation": false,
-          "max_length": 5,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 5
         },
         "help_p1": {
           "english": "Full headspeed: Headspeed target when at 100% throttle input.",
           "translation": "Volle Drehzahl: Ziel-Drehzahl bei 100 % Gas-Eingang.",
           "needs_translation": false,
-          "max_length": 61,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 61
         },
         "help_p2": {
           "english": "PID master gain: How hard the governor works to hold the RPM.",
           "translation": "PID-Masterverstärkung: Wie stark der Regler arbeitet, um die Drehzahl zu halten.",
           "needs_translation": false,
-          "max_length": 61,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 61
         },
         "help_p3": {
           "english": "Gains: Fine tuning of the governor.",
           "translation": "Verstärkungen: Feineinstellung des Governors.",
           "needs_translation": false,
-          "max_length": 35,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 35
         },
         "help_p4": {
           "english": "Precomp: Governor precomp gain for yaw, cyclic, and collective inputs.",
           "translation": "Vorkompensation: Governor-Vorkompensation für Gier-, zyklische und kollektive Eingaben.",
           "needs_translation": false,
-          "max_length": 70,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 70
         },
         "help_p5": {
           "english": "Max throttle: The maximum throttle % the governor is allowed to use.",
           "translation": "Max. Gas: Der maximale Gas-%-Wert, den der Governor verwenden darf.",
           "needs_translation": false,
-          "max_length": 68,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 68
         },
         "help_p6": {
           "english": "Tail Torque Assist: For motorized tails. Gain and limit of headspeed increase when using main rotor torque for yaw assist.",
           "translation": "Heck-Drehmoment-Unterstützung: Für motorisierte Heckrotoren. Verstärkung und Begrenzung der Drehzahlerhöhung beim Gierausgleich durch das Hauptrotordrehmoment.",
           "needs_translation": false,
-          "max_length": 122,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 122
         },
         "i": {
           "english": "I",
           "translation": "I",
           "needs_translation": true,
-          "max_length": 1,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 1
         },
         "idle_throttle": {
           "english": "Idle throttle",
           "translation": "Leerlaufgas",
           "needs_translation": false,
-          "max_length": 13,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 13
         },
         "max_throttle": {
           "english": "Max throttle",
           "translation": "Max. Gas",
           "needs_translation": false,
-          "max_length": 12,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 12
         },
         "min_throttle": {
           "english": "Min throttle",
           "translation": "Min. Gas",
           "needs_translation": false,
-          "max_length": 12,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 12
         },
         "name": {
           "english": "Governor",
           "translation": "Governor",
           "needs_translation": true,
-          "max_length": 8,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 8
         },
         "p": {
           "english": "P",
           "translation": "P",
           "needs_translation": true,
-          "max_length": 1,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 1
         },
         "pid_spoolup": {
           "english": "Governed Spoolup",
           "translation": "PID-Spoolup",
           "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 16
         },
         "precomp": {
           "english": "Precomp",
           "translation": "Vorkompensation",
           "needs_translation": false,
-          "max_length": 7,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 7
         },
         "tail_torque_assist": {
           "english": "Tail Torque Assist",
           "translation": "Heck-Drehmoment-Assistent",
           "needs_translation": false,
-          "max_length": 18,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 18
         },
         "tta_gain": {
           "english": "Gain",
           "translation": "Verst.",
           "needs_translation": false,
-          "max_length": 4,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 4
         },
         "tta_limit": {
           "english": "Limit",
           "translation": "Limit",
           "needs_translation": true,
-          "max_length": 5,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 5
         },
         "voltage_comp": {
           "english": "Voltage Compensation",
           "translation": "Spannungskomp.",
           "needs_translation": false,
-          "max_length": 20,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 20
         },
         "yaw": {
           "english": "Yaw",
           "translation": "Gier",
           "needs_translation": false,
-          "max_length": 3,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 3
         }
       },
       "profile_mainrotor": {
@@ -8536,78 +8366,78 @@
           "english": "Collective Pitch Compensation",
           "translation": "Kollektive Pitch-Kompensation",
           "needs_translation": false,
-          "max_length": 29,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 29
         },
         "collective_pitch_comp_short": {
           "english": "Col. Pitch Compensation",
           "translation": "Kol. Pitch-Kompensation",
           "needs_translation": false,
-          "max_length": 23,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 23
         },
         "cutoff": {
           "english": "Cutoff",
           "translation": "Grenzwert",
           "needs_translation": false,
-          "max_length": 6,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 6
         },
         "cyclic_cross_coupling": {
           "english": "Cyclic Cross coupling",
           "translation": "Zyklische Kreuzkopplung",
           "needs_translation": false,
-          "max_length": 21,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 21
         },
         "gain": {
           "english": "Gain",
           "translation": "Verstärkung",
           "needs_translation": false,
-          "max_length": 4,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 4
         },
         "help_p1": {
           "english": "Collective Pitch Compensation: Increasing will compensate for the pitching motion caused by tail drag when climbing.",
           "translation": "Kollektive Pitch-Kompensation: Erhöhen Sie diesen Wert, um das Kippmoment durch den Heckrotorzug beim Steigen auszugleichen.",
           "needs_translation": false,
-          "max_length": 116,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 116
         },
         "help_p2": {
           "english": "Cross Coupling Gain: Removes roll coupling when only elevator is applied.",
           "translation": "Kreuzkopplungs-Verstärkung: Entfernt Roll-Kopplung, wenn nur Höhenruder (Elevator) angewendet wird.",
           "needs_translation": false,
-          "max_length": 73,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 73
         },
         "help_p3": {
           "english": "Cross Coupling Ratio: Amount of compensation (pitch vs roll) to apply.",
           "translation": "Kreuzkopplungs-Verhältnis: Menge der angewandten Kompensation (Nick vs. Roll).",
           "needs_translation": false,
-          "max_length": 70,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 70
         },
         "help_p4": {
           "english": "Cross Coupling Freq. Limit: Frequency limit for the compensation, higher value will make the compensation action faster.",
           "translation": "Kreuzkopplungs-Frequenzgrenze: Frequenzgrenze für die Kompensation – ein höherer Wert führt zu einer schnelleren Kompensationsreaktion.",
           "needs_translation": false,
-          "max_length": 120,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 120
         },
         "name": {
           "english": "Main Rotor",
           "translation": "Hauptrotor",
           "needs_translation": false,
-          "max_length": 10,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 10
         },
         "ratio": {
           "english": "Ratio",
           "translation": "Verhältnis",
           "needs_translation": false,
-          "max_length": 5,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 5
         }
       },
       "profile_pidbandwidth": {
@@ -8615,64 +8445,64 @@
           "english": "B-term cut-off",
           "translation": "B-Term Grenzfrequenz",
           "needs_translation": false,
-          "max_length": 14,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 14
         },
         "dterm_cutoff": {
           "english": "D-term cut-off",
           "translation": "D-Term Grenzfrequenz",
           "needs_translation": false,
-          "max_length": 14,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 14
         },
         "help_p1": {
           "english": "PID Bandwidth: Overall bandwidth in HZ used by the PID loop.",
           "translation": "PID-Bandbreite: Gesamtbandbreite in Hz, die vom PID-Regler verwendet wird.",
           "needs_translation": false,
-          "max_length": 60,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 60
         },
         "help_p2": {
           "english": "D-term cutoff: D-term cutoff frequency in HZ.",
           "translation": "D-Term Grenzfrequenz: Grenzfrequenz des D-Terms in Hz.",
           "needs_translation": false,
-          "max_length": 45,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 45
         },
         "help_p3": {
           "english": "B-term cutoff: B-term cutoff frequency in HZ.",
           "translation": "B-Term Grenzfrequenz: Grenzfrequenz des B-Terms in Hz.",
           "needs_translation": false,
-          "max_length": 45,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 45
         },
         "name": {
           "english": "PID Bandwidth",
           "translation": "PID-Bandbreite",
           "needs_translation": false,
-          "max_length": 13,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 13
         },
         "pitch": {
           "english": "P",
           "translation": "P",
           "needs_translation": true,
-          "max_length": 1,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 1
         },
         "roll": {
           "english": "R",
           "translation": "R",
           "needs_translation": true,
-          "max_length": 1,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 1
         },
         "yaw": {
           "english": "Y",
           "translation": "Y",
           "needs_translation": true,
-          "max_length": 1,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 1
         }
       },
       "profile_pidcontroller": {
@@ -8680,127 +8510,127 @@
           "english": "Cut-off point",
           "translation": "Grenzpunkt",
           "needs_translation": false,
-          "max_length": 13,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 13
         },
         "error_limit": {
           "english": "Error limit",
           "translation": "Fehlergrenze",
           "needs_translation": false,
-          "max_length": 11,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 11
         },
         "error_rotation": {
           "english": "Error rotation",
           "translation": "Fehlerrotation",
           "needs_translation": false,
-          "max_length": 14,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 14
         },
         "ground_error_decay": {
           "english": "Ground Error Decay",
           "translation": "Fehlerrückgang am Boden",
           "needs_translation": false,
-          "max_length": 18,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 18
         },
         "help_p1": {
           "english": "Error decay ground: PID decay to help prevent heli from tipping over when on the ground.",
           "translation": "Fehlerrückgang am Boden: PID-Abfall zur Vermeidung eines Kippens des Helis am Boden.",
           "needs_translation": false,
-          "max_length": 88,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 88
         },
         "help_p2": {
           "english": "Error limit: Angle limit for I-term.",
           "translation": "Fehlergrenze: Winkelbegrenzung für den I-Term.",
           "needs_translation": false,
-          "max_length": 36,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 36
         },
         "help_p3": {
           "english": "Offset limit: Angle limit for High Speed Integral (O-term).",
           "translation": "Offset-Grenze: Winkelbegrenzung für High Speed Integral (O-Term).",
           "needs_translation": false,
-          "max_length": 59,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 59
         },
         "help_p4": {
           "english": "Error rotation: Allow errors to be shared between all axes.",
           "translation": "Fehlerrotation: Ermöglicht das Teilen von Fehlern zwischen allen Achsen.",
           "needs_translation": false,
-          "max_length": 59,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 59
         },
         "help_p5": {
           "english": "I-term relax: Limit accumulation of I-term during fast movements - helps reduce bounce back after fast stick movements. Generally needs to be lower for large helis and can be higher for small helis. Best to only reduce as much as is needed for your flying style.",
           "translation": "I-Term-Entspannung: Begrenzung der I-Term-Akkumulation bei schnellen Bewegungen – hilft, das Nachschwingen nach schnellen Steuerbewegungen zu reduzieren. Sollte für große Helis niedriger und für kleine Helis höher sein. Am besten nur so weit reduzieren, wie es für den eigenen Flugstil erforderlich ist.",
           "needs_translation": false,
-          "max_length": 262,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 262
         },
         "hsi_offset_limit": {
           "english": "HSI Offset limit",
           "translation": "HSI-Offset-Grenze",
           "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 16
         },
         "inflight_error_decay": {
           "english": "Inflight Error Decay",
           "translation": "Fehlerrückgang im Flug",
           "needs_translation": false,
-          "max_length": 20,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 20
         },
         "iterm_relax": {
           "english": "I-term relax",
           "translation": "I-Term-Entspannung",
           "needs_translation": false,
-          "max_length": 12,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 12
         },
         "limit": {
           "english": "Limit",
           "translation": "Grenze",
           "needs_translation": false,
-          "max_length": 5,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 5
         },
         "name": {
           "english": "PID Controller",
           "translation": "PID-Regler",
           "needs_translation": false,
-          "max_length": 14,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 14
         },
         "pitch": {
           "english": "P",
           "translation": "P",
           "needs_translation": true,
-          "max_length": 1,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 1
         },
         "roll": {
           "english": "R",
           "translation": "R",
           "needs_translation": true,
-          "max_length": 1,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 1
         },
         "time": {
           "english": "Time",
           "translation": "Zeit",
           "needs_translation": false,
-          "max_length": 4,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 4
         },
         "yaw": {
           "english": "Y",
           "translation": "Y",
           "needs_translation": true,
-          "max_length": 1,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 1
         }
       },
       "profile_rescue": {
@@ -8808,155 +8638,155 @@
           "english": "Accel",
           "translation": "Beschleunigung",
           "needs_translation": false,
-          "max_length": 5,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 5
         },
         "climb": {
           "english": "Climb",
           "translation": "Steigen",
           "needs_translation": false,
-          "max_length": 5,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 5
         },
         "collective": {
           "english": "Collective",
           "translation": "Kollektiv",
           "needs_translation": false,
-          "max_length": 10,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 10
         },
         "exit_time": {
           "english": "Exit time",
           "translation": "Ausstiegszeit",
           "needs_translation": false,
-          "max_length": 9,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 9
         },
         "fail_time": {
           "english": "Fail time",
           "translation": "Fehlerzeit",
           "needs_translation": false,
-          "max_length": 9,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 9
         },
         "flip": {
           "english": "Flip",
           "translation": "Flip",
           "needs_translation": true,
-          "max_length": 4,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 4
         },
         "flip_upright": {
           "english": "Flip to upright",
           "translation": "Aufrichten",
           "needs_translation": false,
-          "max_length": 15,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 15
         },
         "gains": {
           "english": "Gains",
           "translation": "Verstärkungen",
           "needs_translation": false,
-          "max_length": 5,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 5
         },
         "help_p1": {
           "english": "Flip to upright: Flip the heli upright when rescue is activated.",
           "translation": "Aufrichten: Richtet den Heli aus dem Rückenflug auf, wenn der Rettungsmodus aktiviert wird.",
           "needs_translation": false,
-          "max_length": 64,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 64
         },
         "help_p2": {
           "english": "Pull-up: How much collective and for how long to arrest the fall.",
           "translation": "Abfangen: Wie viel Kollektiv und wie lange zum Stoppen des Sinkflugs verwendet wird.",
           "needs_translation": false,
-          "max_length": 65,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 65
         },
         "help_p3": {
           "english": "Climb: How much collective to maintain a steady climb - and how long.",
           "translation": "Steigen: Wie viel Kollektiv benötigt wird, um einen gleichmäßigen Steigflug zu halten – und wie lange.",
           "needs_translation": false,
-          "max_length": 69,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 69
         },
         "help_p4": {
           "english": "Hover: How much collective to maintain a steady hover.",
           "translation": "Schweben: Wie viel Kollektiv benötigt wird, um ein stabiles Schweben zu halten.",
           "needs_translation": false,
-          "max_length": 54,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 54
         },
         "help_p5": {
           "english": "Flip: How long to wait before aborting because the flip did not work.",
           "translation": "Flip: Wie lange gewartet wird, bevor der Rettungsmodus abgebrochen wird, falls der Flip (Aufrichten) nicht funktioniert.",
           "needs_translation": false,
-          "max_length": 69,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 69
         },
         "help_p6": {
           "english": "Gains: How hard to fight to keep heli level when engaging rescue mode.",
           "translation": "Verstärkungen: Wie stark der Heli kämpft, um in der Waagerechten zu bleiben, wenn der Rettungsmodus aktiviert wird.",
           "needs_translation": false,
-          "max_length": 70,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 70
         },
         "help_p7": {
           "english": "Rate and Accel: Max rotation and acceleration rates when leveling during rescue.",
           "translation": "Rate und Beschleunigung: Maximale Rotations- und Beschleunigungswerte beim Aufrichten während der Rettung.",
           "needs_translation": false,
-          "max_length": 80,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 80
         },
         "hover": {
           "english": "Hover",
           "translation": "Schweben",
           "needs_translation": false,
-          "max_length": 5,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 5
         },
         "level_gain": {
           "english": "Level",
           "translation": "Nivellierung",
           "needs_translation": false,
-          "max_length": 5,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 5
         },
         "mode_enable": {
           "english": "Rescue mode enable",
           "translation": "Rettungsmodus aktivieren",
           "needs_translation": false,
-          "max_length": 18,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 18
         },
         "name": {
           "english": "Rescue",
           "translation": "Rettung",
           "needs_translation": false,
-          "max_length": 6,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 6
         },
         "pull_up": {
           "english": "Pull-up",
           "translation": "Abfangen",
           "needs_translation": false,
-          "max_length": 7,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 7
         },
         "rate": {
           "english": "Rate",
           "translation": "Rate",
           "needs_translation": true,
-          "max_length": 4,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 4
         },
         "time": {
           "english": "Time",
           "translation": "Zeit",
           "needs_translation": false,
-          "max_length": 4,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 4
         }
       },
       "profile_select": {
@@ -8964,71 +8794,71 @@
           "english": "CANCEL",
           "translation": "ABBRECHEN",
           "needs_translation": false,
-          "max_length": 6,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 6
         },
         "help_p1": {
           "english": "Set the current flight profile or rate profile you would like to use.",
           "translation": "Wählen Sie das aktuelle Flugprofil oder Rate-Profil aus, das Sie verwenden möchten.",
           "needs_translation": false,
-          "max_length": 69,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 69
         },
         "help_p2": {
           "english": "If you use a switch on your radio to change flight or rate modes, this will override this choice as soon as you toggle the switch.",
           "translation": "Wenn Sie einen Schalter an Ihrer Fernsteuerung verwenden, um Flug- oder Rate-Modi zu ändern, wird diese Auswahl überschrieben, sobald Sie den Schalter umlegen.",
           "needs_translation": false,
-          "max_length": 130,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 130
         },
         "name": {
           "english": "Select Profile",
           "translation": "Profil auswählen",
           "needs_translation": false,
-          "max_length": 14,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 14
         },
         "ok": {
           "english": "OK",
           "translation": "OK",
           "needs_translation": true,
-          "max_length": 2,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 2
         },
         "pid_profile": {
           "english": "PID profile",
           "translation": "PID-Profil",
           "needs_translation": false,
-          "max_length": 11,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 11
         },
         "rate_profile": {
           "english": "Rate Profile",
           "translation": "Raten-Profil",
           "needs_translation": false,
-          "max_length": 12,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 12
         },
         "save_prompt": {
           "english": "Save current page to flight controller?",
           "translation": "Aktuelle Seite auf dem Flugcontroller speichern?",
           "needs_translation": false,
-          "max_length": 39,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 39
         },
         "save_prompt_local": {
           "english": "Save current page to radio?",
           "translation": "Aktuelle Seite auf der Fernsteuerung speichern?",
           "needs_translation": false,
-          "max_length": 27,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 27
         },
         "save_settings": {
           "english": "Save settings",
           "translation": "Einstellungen speichern",
           "needs_translation": false,
-          "max_length": 13,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 13
         }
       },
       "profile_tailrotor": {
@@ -9036,120 +8866,120 @@
           "english": "CCW",
           "translation": "CCW",
           "needs_translation": true,
-          "max_length": 3,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 3
         },
         "collective_ff_gain": {
           "english": "Collective FF gain",
           "translation": "Kollektive FF-Verstärkung",
           "needs_translation": false,
-          "max_length": 18,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 18
         },
         "collective_impulse_ff": {
           "english": "Collective Impulse FF",
           "translation": "Kollektiv-Impuls-FF",
           "needs_translation": false,
-          "max_length": 21,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 21
         },
         "cutoff": {
           "english": "Cutoff",
           "translation": "Grenzw.",
           "needs_translation": false,
-          "max_length": 6,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 6
         },
         "cw": {
           "english": "CW",
           "translation": "CW",
           "needs_translation": true,
-          "max_length": 2,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 2
         },
         "cyclic_ff_gain": {
           "english": "Cyclic FF gain",
           "translation": "Zyklische FF-Verstärkung",
           "needs_translation": false,
-          "max_length": 14,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 14
         },
         "decay": {
           "english": "Decay",
           "translation": "Abfall",
           "needs_translation": false,
-          "max_length": 5,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 5
         },
         "gain": {
           "english": "Gain",
           "translation": "Verst.",
           "needs_translation": false,
-          "max_length": 4,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 4
         },
         "help_p1": {
           "english": "Yaw Stop Gain: Higher stop gain will make the tail stop more aggressively but may cause oscillations if too high. Adjust CW or CCW to make the yaw stops even.",
           "translation": "Gier-Stopp-Verstärkung: Eine höhere Stopp-Verstärkung führt zu aggressiveren Heckstopps, kann aber bei zu hohen Werten zu Oszillationen führen. Passen Sie CW oder CCW an, um gleichmäßige Gierstopps zu erzielen.",
           "needs_translation": false,
-          "max_length": 158,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 158
         },
         "help_p2": {
           "english": "Precomp Cutoff: Frequency limit for all yaw precompensation actions.",
           "translation": "Vorkompensation Grenzwert: Frequenzgrenze für alle Gier-Vorkompensationsaktionen.",
           "needs_translation": false,
-          "max_length": 68,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 68
         },
         "help_p3": {
           "english": "Cyclic FF Gain: Tail precompensation for cyclic inputs.",
           "translation": "Zyklische FF-Verstärkung: Heck-Vorkompensation für zyklische Eingaben.",
           "needs_translation": false,
-          "max_length": 55,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 55
         },
         "help_p4": {
           "english": "Collective FF Gain: Tail precompensation for collective inputs.",
           "translation": "Kollektive FF-Verstärkung: Heck-Vorkompensation für kollektive Eingaben.",
           "needs_translation": false,
-          "max_length": 63,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 63
         },
         "help_p5": {
           "english": "Collective Impulse FF: Impulse tail precompensation for collective inputs. If you need extra tail precompensation at the beginning of collective input.",
           "translation": "Kollektiv-Impuls-FF: Impulsartige Heck-Vorkompensation für kollektive Eingaben. Falls zusätzliche Heck-Vorkompensation zu Beginn einer kollektiven Eingabe erforderlich ist.",
           "needs_translation": false,
-          "max_length": 151,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 151
         },
         "inertia_precomp": {
           "english": "Inertia Precomp",
           "translation": "Trägheits-Vorkomp.",
           "needs_translation": false,
-          "max_length": 15,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 15
         },
         "name": {
           "english": "Tail Rotor",
           "translation": "Heckrotor",
           "needs_translation": false,
-          "max_length": 10,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 10
         },
         "precomp_cutoff": {
           "english": "Precomp Cutoff",
           "translation": "Vorkompensation Grenzwert",
           "needs_translation": false,
-          "max_length": 14,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 14
         },
         "yaw_stop_gain": {
           "english": "Yaw stop gain",
           "translation": "Gier-Stopp-Verstärkung",
           "needs_translation": false,
-          "max_length": 13,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 13
         }
       },
       "radio_config": {
@@ -9157,85 +8987,85 @@
           "english": "Arming",
           "translation": "Scharf",
           "needs_translation": false,
-          "max_length": 6,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 6
         },
         "center": {
           "english": "Center",
           "translation": "Mitte",
           "needs_translation": false,
-          "max_length": 6,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 6
         },
         "cyclic": {
           "english": "Cyclic",
           "translation": "Zyklisch",
           "needs_translation": false,
-          "max_length": 6,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 6
         },
         "deadband": {
           "english": "Deadband",
           "translation": "Totzone",
           "needs_translation": false,
-          "max_length": 8,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 8
         },
         "deflection": {
           "english": "Deflection",
           "translation": "Ausschlag",
           "needs_translation": false,
-          "max_length": 10,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 10
         },
         "help_p1": {
           "english": "Configure your radio settings. Stick center, arm, throttle hold, and throttle cut.",
           "translation": "Konfigurieren Sie Ihre Fernsteuerungseinstellungen: Knüppelzentrum, Arm, Gas-Hold und Gas-Abschaltung.",
           "needs_translation": false,
-          "max_length": 82,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 82
         },
         "max_throttle": {
           "english": "Max",
           "translation": "Max",
           "needs_translation": true,
-          "max_length": 3,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 3
         },
         "min_throttle": {
           "english": "Min",
           "translation": "Min",
           "needs_translation": true,
-          "max_length": 3,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 3
         },
         "name": {
           "english": "Radio Config",
           "translation": "Fernsteuerung",
           "needs_translation": false,
-          "max_length": 12,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 12
         },
         "stick": {
           "english": "Stick",
           "translation": "Knüppel",
           "needs_translation": false,
-          "max_length": 5,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 5
         },
         "throttle": {
           "english": "Throttle",
           "translation": "Gas",
           "needs_translation": false,
-          "max_length": 8,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 8
         },
         "yaw_deadband": {
           "english": "Yaw",
           "translation": "Gier",
           "needs_translation": false,
-          "max_length": 3,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 3
         }
       },
       "rates": {
@@ -9243,295 +9073,295 @@
           "english": "Acro+",
           "translation": "Acro+",
           "needs_translation": true,
-          "max_length": 5,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 5
         },
         "actual": {
           "english": "ACTUAL",
           "translation": "ACTUAL",
           "needs_translation": true,
-          "max_length": 6,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 6
         },
         "betaflight": {
           "english": "BETAFLIGHT",
           "translation": "BETAFLIGHT",
           "needs_translation": true,
-          "max_length": 10,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 10
         },
         "center_sensitivity": {
           "english": "Cntr. Sens.",
           "translation": "Zentr. Empfindl.",
           "needs_translation": false,
-          "max_length": 11,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 11
         },
         "collective": {
           "english": "Col",
           "translation": "Kol",
           "needs_translation": false,
-          "max_length": 3,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 3
         },
         "expo": {
           "english": "Expo",
           "translation": "Expo",
           "needs_translation": true,
-          "max_length": 4,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 4
         },
         "help_default_p1": {
           "english": "Default: We keep this to make button appear for rates.",
           "translation": "Standard: Diese Option bleibt erhalten, damit der Button für die Rates erscheint.",
           "needs_translation": false,
-          "max_length": 54,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 54
         },
         "help_default_p2": {
           "english": "We will use the sub keys below.",
           "translation": "Wir verwenden die folgenden Unteroptionen.",
           "needs_translation": false,
-          "max_length": 31,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 31
         },
         "help_table_0_p1": {
           "english": "All values are set to zero because no RATE TABLE is in use.",
           "translation": "Alle Werte sind auf null gesetzt, da keine RATE-TABELLE verwendet wird.",
           "needs_translation": false,
-          "max_length": 59,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 59
         },
         "help_table_1_p1": {
           "english": "RC Rate: Maximum rotation rate at full stick deflection.",
           "translation": "RC-Drehrate: Maximale Rotationsgeschwindigkeit bei vollem Knüppelausschlag.",
           "needs_translation": false,
-          "max_length": 56,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 56
         },
         "help_table_1_p2": {
           "english": "SuperRate: Increases maximum rotation rate while reducing sensitivity around half stick.",
           "translation": "Super-Drehrate: Erhöht die maximale Rotationsgeschwindigkeit und verringert gleichzeitig die Empfindlichkeit in der Mitte des Knüppelwegs.",
           "needs_translation": false,
-          "max_length": 88,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 88
         },
         "help_table_1_p3": {
           "english": "Expo: Reduces sensitivity near the stick's center where fine controls are needed.",
           "translation": "Expo: Verringert die Empfindlichkeit nahe der Knüppelmitte für feinere Steuerung.",
           "needs_translation": false,
-          "max_length": 81,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 81
         },
         "help_table_2_p1": {
           "english": "Rate: Maximum rotation rate at full stick deflection in degrees per second.",
           "translation": "Rate: Maximale Rotationsgeschwindigkeit bei vollem Knüppelausschlag in Grad pro Sekunde.",
           "needs_translation": false,
-          "max_length": 75,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 75
         },
         "help_table_2_p2": {
           "english": "Acro+: Increases the maximum rotation rate while reducing sensitivity around half stick.",
           "translation": "Acro+: Erhöht die maximale Rotationsgeschwindigkeit und verringert die Empfindlichkeit in der Mitte des Knüppelwegs.",
           "needs_translation": false,
-          "max_length": 88,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 88
         },
         "help_table_2_p3": {
           "english": "Expo: Reduces sensitivity near the stick's center where fine controls are needed.",
           "translation": "Expo: Verringert die Empfindlichkeit nahe der Knüppelmitte für feinere Steuerung.",
           "needs_translation": false,
-          "max_length": 81,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 81
         },
         "help_table_3_p1": {
           "english": "RC Rate: Maximum rotation rate at full stick deflection.",
           "translation": "RC-Drehrate: Maximale Rotationsgeschwindigkeit bei vollem Knüppelausschlag.",
           "needs_translation": false,
-          "max_length": 56,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 56
         },
         "help_table_3_p2": {
           "english": "Rate: Increases maximum rotation rate while reducing sensitivity around half stick.",
           "translation": "Rate: Erhöht die maximale Rotationsgeschwindigkeit und verringert die Empfindlichkeit in der Mitte des Knüppelwegs.",
           "needs_translation": false,
-          "max_length": 83,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 83
         },
         "help_table_3_p3": {
           "english": "RC Curve: Reduces sensitivity near the stick's center where fine controls are needed.",
           "translation": "RC-Kurve: Verringert die Empfindlichkeit nahe der Knüppelmitte für feinere Steuerung.",
           "needs_translation": false,
-          "max_length": 85,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 85
         },
         "help_table_4_p1": {
           "english": "Center Sensitivity: Use to reduce sensitivity around center stick. Set Center Sensitivity to the same as Max Rate for a linear response. A lower number than Max Rate will reduce sensitivity around center stick. Note that higher than Max Rate will increase the Max Rate - not recommended as it causes issues in the Blackbox log.",
           "translation": "Zentrale Empfindlichkeit: Reduziert die Empfindlichkeit um die Knüppelmitte. Wenn die zentrale Empfindlichkeit auf denselben Wert wie die Maximalrate gesetzt wird, ist die Reaktion linear. Ein niedrigerer Wert als die Maximalrate reduziert die Empfindlichkeit um die Knüppelmitte. Ein höherer Wert als die Maximalrate erhöht die Maximalrate – nicht empfohlen, da dies zu Problemen in den Blackbox-Logs führt.",
           "needs_translation": false,
-          "max_length": 327,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 327
         },
         "help_table_4_p2": {
           "english": "Max Rate: Maximum rotation rate at full stick deflection in degrees per second.",
           "translation": "Maximaldrehrate: Maximale Rotationsgeschwindigkeit bei vollem Knüppelausschlag in Grad pro Sekunde.",
           "needs_translation": false,
-          "max_length": 79,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 79
         },
         "help_table_4_p3": {
           "english": "Expo: Reduces sensitivity near the stick's center where fine controls are needed.",
           "translation": "Expo: Verringert die Empfindlichkeit nahe der Knüppelmitte für feinere Steuerung.",
           "needs_translation": false,
-          "max_length": 81,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 81
         },
         "help_table_5_p1": {
           "english": "RC Rate: Use to reduce sensitivity around center stick. RC Rate set to one half of the Max Rate is linear. A lower number will reduce sensitivity around center stick. Higher than one half of the Max Rate will also increase the Max Rate.",
           "translation": "RC-Rate: Reduziert die Empfindlichkeit um die Knüppelmitte. Eine RC-Rate, die auf die Hälfte der Maximalrate eingestellt ist, ist linear. Ein niedrigerer Wert reduziert die Empfindlichkeit um die Knüppelmitte. Ein höherer Wert als die Hälfte der Maximalrate erhöht auch die Maximalrate.",
           "needs_translation": false,
-          "max_length": 236,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 236
         },
         "help_table_5_p2": {
           "english": "Max Rate: Maximum rotation rate at full stick deflection in degrees per second.",
           "translation": "Maximaldrehrate: Maximale Rotationsgeschwindigkeit bei vollem Knüppelausschlag in Grad pro Sekunde.",
           "needs_translation": false,
-          "max_length": 79,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 79
         },
         "help_table_5_p3": {
           "english": "Expo: Reduces sensitivity near the stick's center where fine controls are needed.",
           "translation": "Expo: Verringert die Empfindlichkeit nahe der Knüppelmitte für feinere Steuerung.",
           "needs_translation": false,
-          "max_length": 81,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 81
         },
         "help_table_6_p1": {
           "english": "Rate: Maximum rotation rate at full stick deflection in degrees per second.",
           "translation": "Drehrate: Maximale Rotationsgeschwindigkeit bei vollem Knüppelausschlag in Grad pro Sekunde.",
           "needs_translation": false,
-          "max_length": 75,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 75
         },
         "help_table_6_p2": {
           "english": "Shape: Shifts the vertex of the control curve. Up to this point, the signal translation is linear. This defines how far the stick travel remains proportional before the curve becomes progressive.",
           "translation": "Form: Verschiebt den Scheitelpunkt der Steuerkurve. Bis zu diesem Punkt verläuft die Signalumsetzung linear. Dies definiert, wie weit der Knüppelweg proportional bleibt, bevor die Kurve progressiv wird.",
           "needs_translation": false,
-          "max_length": 195,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 195
         },
         "help_table_6_p3": {
           "english": "Expo: Reduces sensitivity near the stick's center where fine controls are needed.",
           "translation": "Expo: Verringert die Empfindlichkeit nahe der Knüppelmitte für feinere Steuerung.",
           "needs_translation": false,
-          "max_length": 81,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 81
         },
         "kiss": {
           "english": "KISS",
           "translation": "KISS",
           "needs_translation": true,
-          "max_length": 4,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 4
         },
         "max_rate": {
           "english": "Max Rate",
           "translation": "Max. Drehrate",
           "needs_translation": false,
-          "max_length": 8,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 8
         },
         "name": {
           "english": "Rates",
           "translation": "Drehraten",
           "needs_translation": false,
-          "max_length": 5,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 5
         },
         "none": {
           "english": "NONE",
           "translation": "KEINE",
           "needs_translation": false,
-          "max_length": 4,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 4
         },
         "pitch": {
           "english": "Pitch",
           "translation": "Nick",
           "needs_translation": false,
-          "max_length": 5,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 5
         },
         "quick": {
           "english": "QUICK",
           "translation": "SCHNELL",
           "needs_translation": false,
-          "max_length": 5,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 5
         },
         "raceflight": {
           "english": "RACEFLIGHT",
           "translation": "RACEFLIGHT",
           "needs_translation": true,
-          "max_length": 10,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 10
         },
         "rate": {
           "english": "Rate",
           "translation": "Drehrate",
           "needs_translation": false,
-          "max_length": 4,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 4
         },
         "rc_curve": {
           "english": "RC Curve",
           "translation": "RC-Kurve",
           "needs_translation": false,
-          "max_length": 8,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 8
         },
         "rc_rate": {
           "english": "RC Rate",
           "translation": "RC-Drehrate",
           "needs_translation": false,
-          "max_length": 7,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 7
         },
         "roll": {
           "english": "Roll",
           "translation": "Roll",
           "needs_translation": true,
-          "max_length": 4,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 4
         },
         "rotorflight": {
           "english": "ROTORFLIGHT",
           "translation": "ROTORFLIGHT",
           "needs_translation": true,
-          "max_length": 11,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 11
         },
         "shape": {
           "english": "Shape",
           "translation": "Form",
           "needs_translation": false,
-          "max_length": 5,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 5
         },
         "superrate": {
           "english": "SuperRate",
           "translation": "Super-Drehrate",
           "needs_translation": false,
-          "max_length": 9,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 9
         },
         "yaw": {
           "english": "Yaw",
           "translation": "Gier",
           "needs_translation": false,
-          "max_length": 3,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 3
         }
       },
       "rates_advanced": {
@@ -9539,141 +9369,141 @@
           "english": "Accelerometer Limit",
           "translation": "Beschl. Grenze",
           "needs_translation": false,
-          "max_length": 19,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 19
         },
         "advanced": {
           "english": "Advanced",
           "translation": "Erweitert",
           "needs_translation": false,
-          "max_length": 8,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 8
         },
         "col": {
           "english": "Col",
           "translation": "Kol",
           "needs_translation": false,
-          "max_length": 3,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 3
         },
         "dyn_ceiling_gain": {
           "english": "Dynamic ceiling gain",
           "translation": "Dyn. Max. Verst.",
           "needs_translation": false,
-          "max_length": 20,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 20
         },
         "dyn_deadband_filter": {
           "english": "Dynamic deadband filter",
           "translation": "Dyn. Totzeit-Filter",
           "needs_translation": false,
-          "max_length": 23,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 23
         },
         "dyn_deadband_gain": {
           "english": "Dynamic deadband gain",
           "translation": "Dyn. Totzeit-Verst.",
           "needs_translation": false,
-          "max_length": 21,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 21
         },
         "dynamics": {
           "english": "Dynamics",
           "translation": "Dynamik",
           "needs_translation": false,
-          "max_length": 8,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 8
         },
         "help_p1": {
           "english": "Rates type: Choose the rate type you prefer flying with. Raceflight and Actual are the most straightforward.",
           "translation": "Raten-Typ: Wählen Sie den Rate-Typ aus, mit dem Sie fliegen möchten. Raceflight und Actual sind die einfachsten.",
           "needs_translation": false,
-          "max_length": 108,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 108
         },
         "help_p2": {
           "english": "Dynamics: Applied regardless of rates type. Typically left on defaults but can be adjusted to smooth heli movements, like with scale helis.",
           "translation": "Dynamik: Wird unabhängig vom Rate-Typ angewendet. Anpassen, um Heli-Bewegungen weicher zu machen, z. B. für Scale-Helis.",
           "needs_translation": false,
-          "max_length": 139,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 139
         },
         "msg_reset_to_defaults": {
           "english": "Rate type changed. Values will be reset to defaults.",
           "translation": "Rate-Typ geändert. Werte werden auf Standardwerte zurückgesetzt.",
           "needs_translation": false,
-          "max_length": 52,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 52
         },
         "name": {
           "english": "Rates",
           "translation": "Raten",
           "needs_translation": false,
-          "max_length": 5,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 5
         },
         "pitch": {
           "english": "Pitch",
           "translation": "Nick",
           "needs_translation": false,
-          "max_length": 5,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 5
         },
         "rate_table": {
           "english": "Rate Table",
           "translation": "Rate-Tabelle",
           "needs_translation": false,
-          "max_length": 10,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 10
         },
         "rates_type": {
           "english": "Rates Type",
           "translation": "Raten-Typ",
           "needs_translation": false,
-          "max_length": 10,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 10
         },
         "response_time": {
           "english": "Response Time",
           "translation": "Reaktionszeit",
           "needs_translation": false,
-          "max_length": 13,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 13
         },
         "roll": {
           "english": "Roll",
           "translation": "Roll",
           "needs_translation": true,
-          "max_length": 4,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 4
         },
         "setpoint_boost_cutoff": {
           "english": "Setpoint boost cutoff",
           "translation": "Sollwert-Boost-Grenze",
           "needs_translation": false,
-          "max_length": 21,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 21
         },
         "setpoint_boost_gain": {
           "english": "Setpoint boost gain",
           "translation": "Sollwert-Boost-Verst.",
           "needs_translation": false,
-          "max_length": 19,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 19
         },
         "table": {
           "english": "Rate Table",
           "translation": "Raten-Tabelle",
           "needs_translation": false,
-          "max_length": 10,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 10
         },
         "yaw": {
           "english": "Yaw",
           "translation": "Gier",
           "needs_translation": false,
-          "max_length": 3,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 3
         }
       },
       "rfstatus": {
@@ -9681,64 +9511,64 @@
           "english": "MSP API Version",
           "translation": "MSP-API-Version",
           "needs_translation": true,
-          "max_length": 15,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 15
         },
         "bgtask": {
           "english": "Background Task",
           "translation": "Hintergrund-Task",
           "needs_translation": false,
-          "max_length": 15,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 15
         },
         "error": {
           "english": "ERROR",
           "translation": "FEHLER",
           "needs_translation": false,
-          "max_length": 5,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 5
         },
         "fblconnected": {
           "english": "FBL Connected",
           "translation": "FBL verbunden",
           "needs_translation": false,
-          "max_length": 13,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 13
         },
         "mspsensor": {
           "english": "MSP Sensor",
           "translation": "MSP-Sensor",
           "needs_translation": true,
-          "max_length": 10,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 10
         },
         "name": {
           "english": "Status",
           "translation": "Status",
           "needs_translation": true,
-          "max_length": 6,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 6
         },
         "ok": {
           "english": "OK",
           "translation": "OK",
           "needs_translation": true,
-          "max_length": 2,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 2
         },
         "rfmodule": {
           "english": "RF Module",
           "translation": "RF-Modul",
           "needs_translation": false,
-          "max_length": 9,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 9
         },
         "telemetrysensors": {
           "english": "Telemetry Sensors",
           "translation": "Telemetrie-Sensoren",
           "needs_translation": false,
-          "max_length": 17,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 17
         }
       },
       "servos": {
@@ -9746,302 +9576,302 @@
           "english": "BUS Output",
           "translation": "BUS Ausgang",
           "needs_translation": false,
-          "max_length": 10,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 10
         },
         "center": {
           "english": "Center",
           "translation": "Mitte",
           "needs_translation": false,
-          "max_length": 6,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 6
         },
         "cyc_left": {
           "english": "CYC.LEFT",
           "translation": "ZYK. LINKS",
           "needs_translation": false,
-          "max_length": 8,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 8
         },
         "cyc_pitch": {
           "english": "CYC.PITCH",
           "translation": "ZYK. PITCH",
           "needs_translation": false,
-          "max_length": 9,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 9
         },
         "cyc_right": {
           "english": "CYC.RIGHT",
           "translation": "ZYK. RECHTS",
           "needs_translation": false,
-          "max_length": 9,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 9
         },
         "disable_servo_override": {
           "english": "Disable servo override",
           "translation": "Servo-Überschreibung deaktivieren",
           "needs_translation": false,
-          "max_length": 22,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 22
         },
         "disable_servo_override_msg": {
           "english": "Return control of the servos to the flight controller.",
           "translation": "Gibt die Steuerung der Servos an den Flugcontroller zurück.",
           "needs_translation": false,
-          "max_length": 54,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 54
         },
         "disabling_servo_override": {
           "english": "Disabling servo override...",
           "translation": "Deaktiviere Servo-Überschreibung...",
           "needs_translation": false,
-          "max_length": 27,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 27
         },
         "enable_servo_override": {
           "english": "Enable servo override",
           "translation": "Servo-Überschreibung aktivieren",
           "needs_translation": false,
-          "max_length": 21,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 21
         },
         "enable_servo_override_msg": {
           "english": "Servo override allows you to 'trim' your servo center point in real time.",
           "translation": "Die Servo-Überschreibung ermöglicht es Ihnen, den Servo-Mittelpunkt in Echtzeit zu 'trimmen'.",
           "needs_translation": false,
-          "max_length": 73,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 73
         },
         "enabling_servo_override": {
           "english": "Enabling servo override...",
           "translation": "Aktiviere Servo-Überschreibung...",
           "needs_translation": false,
-          "max_length": 26,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 26
         },
         "geometry": {
           "english": "Geometry",
           "translation": "Geometrie",
           "needs_translation": false,
-          "max_length": 8,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 8
         },
         "help_default_p1": {
           "english": "Please select the servo you would like to configure from the list below.",
           "translation": "Bitte wählen Sie das Servo aus, das Sie konfigurieren möchten, aus der untenstehenden Liste.",
           "needs_translation": false,
-          "max_length": 72,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 72
         },
         "help_default_p2": {
           "english": "Primary flight controls that use the rotorflight mixer will display in the section called 'mixer'.",
           "translation": "Primäre Flugsteuerungen, die den Rotorflight-Mischer verwenden, werden im Abschnitt 'Mischer' angezeigt.",
           "needs_translation": false,
-          "max_length": 98,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 98
         },
         "help_default_p3": {
           "english": "Any other servos that are not controlled by the primary flight mixer will be displayed in the section called 'Other servos'.",
           "translation": "Alle anderen Servos, die nicht vom primären Flugmischer gesteuert werden, werden im Abschnitt 'Andere Servos' angezeigt.",
           "needs_translation": false,
-          "max_length": 124,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 124
         },
         "help_fields_flags": {
           "english": "0 = Default, 1=Reverse, 2 = Geo Correction, 3 = Reverse + Geo Correction",
           "translation": "0 = Standard, 1 = Umkehren, 2 = Geo-Korrektur, 3 = Umkehren + Geo-Korrektur",
           "needs_translation": false,
-          "max_length": 72,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 72
         },
         "help_fields_max": {
           "english": "Servo positive travel limit.",
           "translation": "Positiver Reiseweg des Servos.",
           "needs_translation": false,
-          "max_length": 28,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 28
         },
         "help_fields_mid": {
           "english": "Servo center position pulse width.",
           "translation": "Servo-Mittelposition als Pulsbreite.",
           "needs_translation": false,
-          "max_length": 34,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 34
         },
         "help_fields_min": {
           "english": "Servo negative travel limit.",
           "translation": "Negativer Reiseweg des Servos.",
           "needs_translation": false,
-          "max_length": 28,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 28
         },
         "help_fields_rate": {
           "english": "Servo PWM rate.",
           "translation": "Servo-PWM-Frequenz.",
           "needs_translation": false,
-          "max_length": 15,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 15
         },
         "help_fields_scale_neg": {
           "english": "Servo negative scaling.",
           "translation": "Negatives Servo-Scaling.",
           "needs_translation": false,
-          "max_length": 23,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 23
         },
         "help_fields_scale_pos": {
           "english": "Servo positive scaling.",
           "translation": "Positives Servo-Scaling.",
           "needs_translation": false,
-          "max_length": 23,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 23
         },
         "help_fields_speed": {
           "english": "Servo motion speed in milliseconds.",
           "translation": "Servo-Geschwindigkeit in Millisekunden.",
           "needs_translation": false,
-          "max_length": 35,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 35
         },
         "help_tool_p1": {
           "english": "Override: [*] Enable override to allow real-time updates of servo center point.",
           "translation": "Überschreiben: [*] Aktivieren Sie die Überschreibung, um Echtzeitaktualisierungen der Servo-Mittelposition zu ermöglichen.",
           "needs_translation": false,
-          "max_length": 79,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 79
         },
         "help_tool_p2": {
           "english": "Center: Adjust the center position of the servo.",
           "translation": "Zentrum: Passen Sie die Mittelposition des Servos an.",
           "needs_translation": false,
-          "max_length": 48,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 48
         },
         "help_tool_p3": {
           "english": "Minimum/Maximum: Adjust the end points of the selected servo.",
           "translation": "Minimum/Maximum: Passen Sie die Endpunkte des ausgewählten Servos an.",
           "needs_translation": false,
-          "max_length": 61,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 61
         },
         "help_tool_p4": {
           "english": "Scale: Adjust the amount the servo moves for a given input.",
           "translation": "Scaling: Passen Sie den Bewegungsbereich des Servos für eine bestimmte Eingabe an.",
           "needs_translation": false,
-          "max_length": 59,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 59
         },
         "help_tool_p5": {
           "english": "Rate: The frequency the servo runs best at - check with manufacturer.",
           "translation": "Rate: Die Frequenz, mit der das Servo am besten arbeitet – prüfen Sie dies beim Hersteller.",
           "needs_translation": false,
-          "max_length": 69,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 69
         },
         "help_tool_p6": {
           "english": "Speed: The speed the servo moves. Generally only used for the cyclic servos to help the swash move evenly. Optional - leave all at 0 if unsure.",
           "translation": "Geschwindigkeit: Die Geschwindigkeit, mit der sich das Servo bewegt. Wird normalerweise nur für zyklische Servos verwendet, um eine gleichmäßige Bewegung der Taumelscheibe zu gewährleisten. Optional – alle Werte auf 0 lassen, wenn Sie unsicher sind.",
           "needs_translation": false,
-          "max_length": 143,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 143
         },
         "maximum": {
           "english": "Maximum",
           "translation": "Max",
           "needs_translation": false,
-          "max_length": 7,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 7
         },
         "minimum": {
           "english": "Minimum",
           "translation": "Min",
           "needs_translation": false,
-          "max_length": 7,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 7
         },
         "name": {
           "english": "Servos",
           "translation": "Servos",
           "needs_translation": true,
-          "max_length": 6,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 6
         },
         "pwm": {
           "english": "PWM Output",
           "translation": "PWM-Ausgang",
           "needs_translation": false,
-          "max_length": 10,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 10
         },
         "rate": {
           "english": "Rate",
           "translation": "Rate",
           "needs_translation": true,
-          "max_length": 4,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 4
         },
         "reverse": {
           "english": "Reverse",
           "translation": "Umkehren",
           "needs_translation": false,
-          "max_length": 7,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 7
         },
         "scale_negative": {
           "english": "Scale Negative",
           "translation": "Negatives Scaling",
           "needs_translation": false,
-          "max_length": 14,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 14
         },
         "scale_positive": {
           "english": "Scale Positive",
           "translation": "Positives Scaling",
           "needs_translation": false,
-          "max_length": 14,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 14
         },
         "servo_override": {
           "english": "Servo Override",
           "translation": "Servo-Überschreibung",
           "needs_translation": false,
-          "max_length": 14,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 14
         },
         "servo_prefix": {
           "english": "SERVO ",
           "translation": "SERVO ",
-          "needs_translation": true,
-          "max_length": 6,
-          "reverse_text": false
+          "needs_translation": false,
+          "reverse_text": false,
+          "max_length": 6
         },
         "speed": {
           "english": "Speed",
           "translation": "Geschwindigkeit",
           "needs_translation": false,
-          "max_length": 5,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 5
         },
         "tail": {
           "english": "TAIL",
           "translation": "HECK",
           "needs_translation": false,
-          "max_length": 4,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 4
         },
         "tbl_no": {
           "english": "NO",
           "translation": "NEIN",
           "needs_translation": false,
-          "max_length": 2,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 2
         },
         "tbl_yes": {
           "english": "YES",
           "translation": "JA",
           "needs_translation": false,
-          "max_length": 3,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 3
         }
       },
       "settings": {
@@ -10054,29 +9884,29 @@
         },
         "txt_show_battery_profile_connect": {
           "english": "Battery Type on connect",
-          "translation": "Battery Type on connect",
-          "needs_translation": true,
+          "translation": "Akkutyp bei Verbindung",
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 23
         },
         "txt_show_confirmation_dialog": {
           "english": "Battery Type confirmation",
-          "translation": "Battery Type confirmation",
-          "needs_translation": true,
+          "translation": "Akkutyp bestätigen",
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 25
         },
         "battery_profile_event": {
           "english": "Battery",
-          "translation": "Battery",
-          "needs_translation": true,
+          "translation": "Akku",
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 7
         },
         "battery_capacity_callout": {
           "english": "Battery capacity",
-          "translation": "Battery capacity",
-          "needs_translation": true,
+          "translation": "Akku-Kapazität",
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 16
         },
@@ -10084,302 +9914,302 @@
           "english": "Adjustment Callouts",
           "translation": "Einstellungsansagen",
           "needs_translation": false,
-          "max_length": 19,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 19
         },
         "adj_function": {
           "english": "Adjustment Function",
           "translation": "Einstellungsfunktion",
           "needs_translation": false,
-          "max_length": 19,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 19
         },
         "adj_value": {
           "english": "Adjustment Value",
           "translation": "Einstellungswert",
           "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 16
         },
         "altitude_unit": {
           "english": "Altitude Unit",
           "translation": "Höheneinheit",
           "needs_translation": false,
-          "max_length": 13,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 13
         },
         "arming_flags": {
           "english": "Arming Flags",
           "translation": "Arming-Flags",
           "needs_translation": true,
-          "max_length": 12,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 12
         },
         "audio": {
           "english": "Audio",
           "translation": "Audio",
           "needs_translation": true,
-          "max_length": 5,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 5
         },
         "celcius": {
           "english": "Celsius",
           "translation": "Celsius",
           "needs_translation": true,
-          "max_length": 7,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 7
         },
         "dashboard": {
           "english": "Dashboard",
           "translation": "Dashboard",
           "needs_translation": true,
-          "max_length": 9,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 9
         },
         "dashboard_loader_loader_style_select": {
           "english": "Theme loader style",
           "translation": "Stil der Ladeanzeige",
           "needs_translation": false,
-          "max_length": 18,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 18
         },
         "dashboard_settings": {
           "english": "Settings",
           "translation": "Einstellungen",
           "needs_translation": false,
-          "max_length": 8,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 8
         },
         "dashboard_theme": {
           "english": "Theme",
           "translation": "Design",
           "needs_translation": false,
-          "max_length": 5,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 5
         },
         "dashboard_theme_inflight": {
           "english": "Inflight Theme",
           "translation": "Flug-Design",
           "needs_translation": false,
-          "max_length": 14,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 14
         },
         "dashboard_theme_panel_global": {
           "english": "Default theme for all models",
           "translation": "Standard-Design für alle Modelle",
           "needs_translation": false,
-          "max_length": 28,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 28
         },
         "dashboard_theme_panel_model": {
           "english": "Optional theme for this model",
           "translation": "Optionales Design für dieses Modell",
           "needs_translation": false,
-          "max_length": 29,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 29
         },
         "dashboard_theme_panel_model_disabled": {
           "english": "Disabled",
           "translation": "Deaktiviert",
           "needs_translation": false,
-          "max_length": 8,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 8
         },
         "dashboard_theme_postflight": {
           "english": "Postflight Theme",
           "translation": "Nachflug-Design",
           "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 16
         },
         "dashboard_theme_preflight": {
           "english": "Preflight Theme",
           "translation": "Vorflug-Design",
           "needs_translation": false,
-          "max_length": 15,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 15
         },
         "esc_temperature": {
           "english": "ESC Temperature",
           "translation": "ESC-Temperatur",
           "needs_translation": false,
-          "max_length": 15,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 15
         },
         "esc_threshold": {
           "english": "Threshold (°)",
           "translation": "Schwellwert (°)",
           "needs_translation": false,
-          "max_length": 13,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 13
         },
         "fahrenheit": {
           "english": "Fahrenheit",
           "translation": "Fahrenheit",
           "needs_translation": true,
-          "max_length": 10,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 10
         },
         "feet": {
           "english": "Feet",
           "translation": "Fuß",
           "needs_translation": false,
-          "max_length": 4,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 4
         },
         "fuel": {
           "english": "Fuel",
           "translation": "Kraftstoff",
           "needs_translation": false,
-          "max_length": 4,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 4
         },
         "fuel_callout_10": {
           "english": "Every 10%",
           "translation": "Alle 10%",
           "needs_translation": false,
-          "max_length": 9,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 9
         },
         "fuel_callout_20": {
           "english": "Every 20%",
           "translation": "Alle 20%",
           "needs_translation": false,
-          "max_length": 9,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 9
         },
         "fuel_callout_25": {
           "english": "Every 25%",
           "translation": "Alle 25%",
           "needs_translation": false,
-          "max_length": 9,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 9
         },
         "fuel_callout_5": {
           "english": "50% and 5%",
           "translation": "50% und 5%",
           "needs_translation": false,
-          "max_length": 10,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 10
         },
         "fuel_callout_50": {
           "english": "Every 50%",
           "translation": "Alle 50%",
           "needs_translation": false,
-          "max_length": 9,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 9
         },
         "fuel_callout_default": {
           "english": "Default (Only at 10%)",
           "translation": "Standard (Nur bei 10%)",
           "needs_translation": false,
-          "max_length": 21,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 21
         },
         "fuel_callout_percent": {
           "english": "Callout %",
           "translation": "Ansage %",
           "needs_translation": false,
-          "max_length": 9,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 9
         },
         "fuel_haptic_below": {
           "english": "Haptic below 0%",
           "translation": "Haptisch unter 0%",
           "needs_translation": false,
-          "max_length": 15,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 15
         },
         "fuel_repeats_below": {
           "english": "Repeats below 0%",
           "translation": "Wiederholungen unter 0%",
           "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 16
         },
         "governor_state": {
           "english": "Governor State",
           "translation": "Governor-Status",
           "needs_translation": false,
-          "max_length": 14,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 14
         },
         "help_audio_events": {
           "english": "Use this section to configure which system events and telemetry values will trigger voice announcements or alerts.",
           "translation": "Verwenden Sie diesen Abschnitt, um zu konfigurieren, welche Systemereignisse und Telemetriewerte eine Sprachansage oder Warnung auslösen.",
           "needs_translation": false,
-          "max_length": 115,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 115
         },
         "help_modelAnnouncement": {
           "english": "Model announcement requires a .wav file in the 'audio' folder matching the model name (e.g. 'racer.wav' for model 'racer').",
           "translation": "Für die Modellansage wird eine .wav-Datei im Ordner 'audio' benötigt, die dem Modellnamen entspricht (z. B. 'racer.wav' für das Modell 'racer').",
           "needs_translation": false,
-          "max_length": 123,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 123
         },
         "loader_style_large": {
           "english": "LARGE",
           "translation": "GROSS",
           "needs_translation": false,
-          "max_length": 5,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 5
         },
         "loader_style_medium": {
           "english": "MEDIUM",
           "translation": "MITTEL",
           "needs_translation": false,
-          "max_length": 6,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 6
         },
         "loader_style_small": {
           "english": "SMALL",
           "translation": "KLEIN",
           "needs_translation": false,
-          "max_length": 5,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 5
         },
         "localizations": {
           "english": "Localization",
           "translation": "Lokalisierung",
           "needs_translation": false,
-          "max_length": 12,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 12
         },
         "meters": {
           "english": "Meters",
           "translation": "Meter",
           "needs_translation": false,
-          "max_length": 6,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 6
         },
         "modelAnnouncement": {
           "english": "Model announcement",
           "translation": "Modellansage",
           "needs_translation": false,
-          "max_length": 18,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 18
         },
         "name": {
           "english": "Settings",
           "translation": "Einstellungen",
           "needs_translation": false,
-          "max_length": 8,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 8
         },
         "no_themes_available_to_configure": {
           "english": "No configurable themes installed on this device",
           "translation": "Keine konfigurierbaren Designs auf dem Gerät installiert.",
           "needs_translation": false,
-          "max_length": 47,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 47
         },
         "otherSoundSettings": {
           "english": "Other",
           "translation": "Sonstiges",
           "needs_translation": false,
-          "max_length": 5,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 5
         },
         "panel_display": {
           "english": "Display",
@@ -10391,7 +10221,7 @@
         "panel_integration": {
           "english": "Integration",
           "translation": "Integration",
-          "needs_translation": true,
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 11
         },
@@ -10406,162 +10236,162 @@
           "english": "PID Profile",
           "translation": "PID-Profil",
           "needs_translation": false,
-          "max_length": 11,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 11
         },
         "pid_rates_profile": {
           "english": "PID/Rates Profile",
           "translation": "PID/Raten-Profil",
           "needs_translation": false,
-          "max_length": 17,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 17
         },
         "rate_profile": {
           "english": "Rate Profile",
           "translation": "Raten-Profil",
           "needs_translation": false,
-          "max_length": 12,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 12
         },
         "shortcuts": {
           "english": "Shortcuts",
-          "max_length": 9,
+          "translation": "Shortcuts",
           "needs_translation": true,
           "reverse_text": false,
-          "translation": "Shortcuts"
+          "max_length": 9
         },
         "shortcuts_group": {
           "english": "Category",
-          "max_length": 8,
-          "needs_translation": true,
+          "translation": "Kategorie",
+          "needs_translation": false,
           "reverse_text": false,
-          "translation": "Category"
+          "max_length": 8
         },
         "shortcuts_none": {
           "english": "No shortcut sources available.",
-          "max_length": 30,
+          "translation": "No shortcut sources available.",
           "needs_translation": true,
           "reverse_text": false,
-          "translation": "No shortcut sources available."
+          "max_length": 30
         },
         "temperature_unit": {
           "english": "Temperature Unit",
           "translation": "Temperatureinheit",
           "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 16
         },
         "timer_alert_period": {
           "english": "Alert Period",
           "translation": "Alarmierungsperiode",
           "needs_translation": false,
-          "max_length": 12,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 12
         },
         "timer_alerting": {
           "english": "Timer Alerting",
           "translation": "Timer-Alarmierung",
           "needs_translation": false,
-          "max_length": 14,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 14
         },
         "timer_elapsed_alert_mode": {
           "english": "Timer Elapsed Alert",
           "translation": "Alarmierung bei Timer-Ablauf",
           "needs_translation": false,
-          "max_length": 19,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 19
         },
         "timer_postalert": {
           "english": "Post-timer Alert",
           "translation": "Nach-Timer-Alarmierung",
           "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 16
         },
         "timer_postalert_interval": {
           "english": "Alert Interval",
           "translation": "Alarmierungsintervall",
           "needs_translation": false,
-          "max_length": 14,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 14
         },
         "timer_postalert_options": {
           "english": "Post-timer Alert Options",
           "translation": "Nach-Timer-Alarmierungsoptionen",
           "needs_translation": false,
-          "max_length": 24,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 24
         },
         "timer_prealert": {
           "english": "Pre-timer Alert",
           "translation": "Vor-Timer-Alarmierung",
           "needs_translation": false,
-          "max_length": 15,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 15
         },
         "timer_prealert_options": {
           "english": "Pre-timer Alert Options",
           "translation": "Vor-Timer-Alarmierungsoptionen",
           "needs_translation": false,
-          "max_length": 23,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 23
         },
         "txt_apiversion": {
           "english": "SIM API Version",
           "translation": "SIM API Version",
           "needs_translation": true,
-          "max_length": 15,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 15
         },
         "txt_audio_events": {
           "english": "Events",
           "translation": "Events",
           "needs_translation": true,
-          "max_length": 6,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 6
         },
         "txt_audio_switches": {
           "english": "Switches",
           "translation": "Schalter",
           "needs_translation": false,
-          "max_length": 8,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 8
         },
         "txt_audio_timer": {
           "english": "Timer",
           "translation": "Timer",
           "needs_translation": true,
-          "max_length": 5,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 5
         },
         "txt_battdef": {
           "english": "Default",
           "translation": "Standard",
           "needs_translation": false,
-          "max_length": 7,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 7
         },
         "txt_battdig": {
           "english": "Digital",
           "translation": "Digital",
-          "needs_translation": true,
-          "max_length": 7,
-          "reverse_text": false
+          "needs_translation": false,
+          "reverse_text": false,
+          "max_length": 7
         },
         "txt_batttext": {
           "english": "Text",
           "translation": "Text",
-          "needs_translation": true,
-          "max_length": 4,
-          "reverse_text": false
+          "needs_translation": false,
+          "reverse_text": false,
+          "max_length": 4
         },
         "txt_batttype": {
           "english": "Tx Battery Options",
           "translation": "Sender-Batterieoptionen",
           "needs_translation": false,
-          "max_length": 18,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 18
         },
         "txt_collapse_unused_menu_entries": {
           "english": "Collapse Navigation",
@@ -10573,21 +10403,21 @@
         "txt_debug": {
           "english": "DEBUG",
           "translation": "DEBUG",
-          "needs_translation": true,
-          "max_length": 5,
-          "reverse_text": false
+          "needs_translation": false,
+          "reverse_text": false,
+          "max_length": 5
         },
         "txt_developer": {
           "english": "Developer",
-          "translation": "Developer",
-          "needs_translation": true,
+          "translation": "Entwickler",
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 9
         },
         "txt_developer_tools": {
           "english": "Developer Tools",
-          "translation": "Developer Tools",
-          "needs_translation": true,
+          "translation": "Entwickler Tools",
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 15
         },
@@ -10595,64 +10425,64 @@
           "english": "Development",
           "translation": "Entwicklung",
           "needs_translation": false,
-          "max_length": 11,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 11
         },
         "txt_general": {
           "english": "General",
           "translation": "Allgemein",
           "needs_translation": false,
-          "max_length": 7,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 7
         },
         "txt_hs_loader": {
           "english": "Progress Loader",
           "translation": "Fortschrittsanzeige",
           "needs_translation": false,
-          "max_length": 15,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 15
         },
         "txt_hs_loader_fastclose": {
           "english": "CLOSE ASAP",
           "translation": "SOFORT SCHLIESSEN",
           "needs_translation": false,
-          "max_length": 10,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 10
         },
         "txt_hs_loader_wait": {
           "english": "CLOSE AT 100%",
           "translation": "BEI 100% SCHLIESSEN",
           "needs_translation": false,
-          "max_length": 13,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 13
         },
         "txt_iconsize": {
           "english": "Icon Size",
           "translation": "Icongröße",
           "needs_translation": false,
-          "max_length": 9,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 9
         },
         "txt_info": {
           "english": "INFO",
           "translation": "INFO",
-          "needs_translation": true,
-          "max_length": 4,
-          "reverse_text": false
+          "needs_translation": false,
+          "reverse_text": false,
+          "max_length": 4
         },
         "txt_large": {
           "english": "LARGE",
           "translation": "GROSS",
           "needs_translation": false,
-          "max_length": 5,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 5
         },
         "txt_loglevel": {
           "english": "Log level",
           "translation": "Protokollierungsgrad",
           "needs_translation": false,
-          "max_length": 9,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 9
         },
         "txt_logevents": {
           "english": "Log events",
@@ -10665,22 +10495,22 @@
           "english": "Log memory usage",
           "translation": "Speicher",
           "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 16
         },
         "txt_cachestats": {
           "english": "Log cache stats",
-          "max_length": 15,
+          "translation": "Log cache stats",
           "needs_translation": false,
           "reverse_text": false,
-          "translation": "Log cache stats"
+          "max_length": 15
         },
         "txt_mspdata": {
           "english": "Log msp data",
           "translation": "Protokolliere MSP-Daten",
           "needs_translation": false,
-          "max_length": 12,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 12
         },
         "txt_msprwlog": {
           "english": "Log MSP read/write",
@@ -10693,76 +10523,76 @@
           "english": "MSP Activity Display",
           "translation": "MSP Aktivitaet Anzeige",
           "needs_translation": false,
-          "max_length": 20,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 20
         },
         "txt_objectprofiler": {
           "english": "Log dashboard speed",
           "translation": "Dashboard-Geschw. protok.",
           "needs_translation": false,
-          "max_length": 19,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 19
         },
         "txt_off": {
           "english": "OFF",
           "translation": "AUS",
           "needs_translation": false,
-          "max_length": 3,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 3
         },
         "txt_overlaygrid": {
           "english": "Overlay grid in dashboard",
           "translation": "Overlay Raster im Dashboard",
           "needs_translation": false,
-          "max_length": 25,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 25
         },
         "txt_overlaystats": {
           "english": "Overlay stats in dashboard",
           "translation": "Overlay Statistik im Dashboard",
           "needs_translation": false,
-          "max_length": 26,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 26
         },
         "txt_overlaystatsadmin": {
           "english": "Overlay stats in admin",
           "translation": "Overlay-Statistiken im Admin-Bereich",
           "needs_translation": false,
-          "max_length": 22,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 22
         },
         "txt_queuesize": {
           "english": "Log MSP queue size",
           "translation": "MSP-Warteschlange",
           "needs_translation": false,
-          "max_length": 18,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 18
         },
         "txt_reload_confirm": {
           "english": "Confirm on reload",
           "translation": "Bestätigen beim Neuladen",
           "needs_translation": false,
-          "max_length": 17,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 17
         },
         "txt_save_armed_warning": {
           "english": "Show disarm-to-save warning",
           "translation": "Warnung 'Bitte disarmen zum Speichern' anzeigen",
           "needs_translation": false,
-          "max_length": 27,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 27
         },
         "txt_save_confirm": {
           "english": "Confirm on save",
           "translation": "Bestätigen beim Speichern",
           "needs_translation": false,
-          "max_length": 15,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 15
         },
         "txt_save_requires_changes": {
           "english": "Save requires changes",
           "translation": "Save requires changes",
-          "needs_translation": true,
+          "needs_translation": false,
           "reverse_text": false,
           "max_length": 21
         },
@@ -10770,36 +10600,36 @@
           "english": "SMALL",
           "translation": "KLEIN",
           "needs_translation": false,
-          "max_length": 5,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 5
         },
         "txt_syncname": {
           "english": "Sync model name",
           "translation": "Modellname synchronisieren",
           "needs_translation": false,
-          "max_length": 15,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 15
         },
         "txt_taskprofiler": {
           "english": "Log tasks speed",
           "translation": "Aufgabengeschwindigkeit",
           "needs_translation": false,
-          "max_length": 15,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 15
         },
         "txt_text": {
           "english": "TEXT",
           "translation": "TEXT",
-          "needs_translation": true,
-          "max_length": 4,
-          "reverse_text": false
+          "needs_translation": false,
+          "reverse_text": false,
+          "max_length": 4
         },
         "voltage": {
           "english": "Voltage",
           "translation": "Spannung",
           "needs_translation": false,
-          "max_length": 7,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 7
         }
       },
       "stats": {
@@ -10807,29 +10637,29 @@
           "english": "Flight Count",
           "translation": "Fluganzahl",
           "needs_translation": false,
-          "max_length": 12,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 12
         },
         "help_p1": {
           "english": "Use this module to update the recorded flight statistics on the flight controller.",
           "translation": "Verwenden Sie dieses Modul, um die aufgezeichneten Flugstatistiken am Flugcontroller zu aktualisieren.",
           "needs_translation": false,
-          "max_length": 82,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 82
         },
         "name": {
           "english": "Stats",
           "translation": "Statistiken",
           "needs_translation": false,
-          "max_length": 5,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 5
         },
         "totalflighttime": {
           "english": "Total Flight Time",
           "translation": "Gesamtflugzeit",
           "needs_translation": false,
-          "max_length": 17,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 17
         }
       },
       "telemetry": {
@@ -10837,29 +10667,29 @@
           "english": "RF2.2 or later required",
           "translation": "RF2.2 oder neuer erforderlich",
           "needs_translation": false,
-          "max_length": 23,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 23
         },
         "msg_set_defaults": {
           "english": "Apply default sensors?",
           "translation": "Standard-Sensoren anwenden?",
           "needs_translation": false,
-          "max_length": 22,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 22
         },
         "name": {
           "english": "Telemetry",
           "translation": "Telemetrie",
           "needs_translation": false,
-          "max_length": 9,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 9
         },
         "no_more_than_40": {
           "english": "No more than 40 sensors can be enabled at once",
           "translation": "Es können nicht mehr als 40 Sensoren gleichzeitig aktiviert werden",
           "needs_translation": false,
-          "max_length": 46,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 46
         }
       },
       "trim": {
@@ -10867,85 +10697,85 @@
           "english": "Col. trim %",
           "translation": "Kollektiv-Trimmung %",
           "needs_translation": false,
-          "max_length": 11,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 11
         },
         "disable_mixer_message": {
           "english": "Return control of the servos to the flight controller.",
           "translation": "Gibt die Steuerung der Servos an den Flugcontroller zurück.",
           "needs_translation": false,
-          "max_length": 54,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 54
         },
         "disable_mixer_override": {
           "english": "Disable mixer override",
           "translation": "Mischer-Überschreibung deaktivieren",
           "needs_translation": false,
-          "max_length": 22,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 22
         },
         "enable_mixer_message": {
           "english": "Set all servos to their configured center position. \r\n\r\nThis will result in all values on this page being saved when adjusting the servo trim.",
           "translation": "Alle Servos auf ihre konfigurierte Mittelposition setzen. \r\n\r\nAlle Werte auf dieser Seite werden gespeichert, wenn die Servo-Trimmung angepasst wird.",
           "needs_translation": false,
-          "max_length": 142,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 142
         },
         "enable_mixer_override": {
           "english": "Enable mixer override",
           "translation": "Mischer-Überschreibung aktivieren",
           "needs_translation": false,
-          "max_length": 21,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 21
         },
         "mixer_override": {
           "english": "Mixer Override",
           "translation": "Mischer-Überschreibung",
           "needs_translation": false,
-          "max_length": 14,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 14
         },
         "mixer_override_disabling": {
           "english": "Disabling mixer override...",
           "translation": "Mischer-Überschreibung wird deaktiviert...",
           "needs_translation": false,
-          "max_length": 27,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 27
         },
         "mixer_override_enabling": {
           "english": "Enabling mixer override...",
           "translation": "Mischer-Überschreibung wird aktiviert...",
           "needs_translation": false,
-          "max_length": 26,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 26
         },
         "pitch_trim": {
           "english": "Pitch trim %",
           "translation": "Nick-Trimmung %",
           "needs_translation": false,
-          "max_length": 12,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 12
         },
         "roll_trim": {
           "english": "Roll trim %",
           "translation": "Roll-Trimmung %",
           "needs_translation": false,
-          "max_length": 11,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 11
         },
         "tail_motor_idle": {
           "english": "Tail Motor idle  %",
           "translation": "Heckmotor-Leerlauf %",
           "needs_translation": false,
-          "max_length": 18,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 18
         },
         "yaw_trim": {
           "english": "Yaw. trim %",
           "translation": "Gier-Trimmung %",
           "needs_translation": false,
-          "max_length": 11,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 11
         }
       },
       "validate_sensors": {
@@ -10953,50 +10783,50 @@
           "english": "This tool attempts to list all the sensors that you are not receiving in a concise list.",
           "translation": "Dieses Tool versucht, eine kurze Liste aller Sensoren zu erstellen, die nicht empfangen werden.",
           "needs_translation": false,
-          "max_length": 88,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 88
         },
         "help_p2": {
           "english": "Use this tool to ensure you are sending the correct sensors.",
           "translation": "Verwenden Sie dieses Tool, um sicherzustellen, dass Sie die richtigen Sensoren senden.",
           "needs_translation": false,
-          "max_length": 60,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 60
         },
         "invalid": {
           "english": "INVALID",
           "translation": "UNGÜLTIG",
           "needs_translation": false,
-          "max_length": 7,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 7
         },
         "msg_repair": {
           "english": "Enable required sensors on flight controller?",
           "translation": "Erforderliche Sensoren auf dem Flugcontroller aktivieren?",
           "needs_translation": false,
-          "max_length": 45,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 45
         },
         "msg_repair_fin": {
           "english": "The flight controller has been configured? You may need to perform a discover sensors to see the changes.",
           "translation": "Der Flugcontroller wurde konfiguriert? Möglicherweise müssen Sie Sensoren neu suchen, um die Änderungen zu sehen.",
           "needs_translation": false,
-          "max_length": 105,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 105
         },
         "name": {
           "english": "Sensors",
           "translation": "Sensoren",
           "needs_translation": false,
-          "max_length": 7,
-          "reverse_text": false
+          "reverse_text": false,
+          "max_length": 7
         },
         "ok": {
           "english": "OK",
           "translation": "OK",
-          "needs_translation": true,
-          "max_length": 2,
-          "reverse_text": false
+          "needs_translation": false,
+          "reverse_text": false,
+          "max_length": 2
         }
       }
     },
@@ -11004,34 +10834,34 @@
       "english": "Loaded task",
       "translation": "Aufgabe geladen",
       "needs_translation": false,
-      "max_length": 11,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 11
     },
     "msg_loading": {
       "english": "Loading...",
       "translation": "Lädt...",
       "needs_translation": false,
-      "max_length": 10,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 10
     },
     "msg_loading_from_fbl": {
       "english": "Loading data from flight controller...",
       "translation": "Daten vom Flugcontroller werden geladen...",
       "needs_translation": false,
-      "max_length": 38,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 38
     },
     "msg_lua_memory_critical_title": {
       "english": "Lua memory critically low",
-      "translation": "Lua memory critically low",
-      "needs_translation": true,
+      "translation": "Lua-Speicher: Kritisch",
+      "needs_translation": false,
       "reverse_text": false,
       "max_length": 25
     },
     "msg_lua_memory_critical_restart_radio": {
       "english": "Please powercycle the radio to ensure system stability",
-      "translation": "Please powercycle the radio to ensure system stability",
-      "needs_translation": true,
+      "translation": "Sender neu starten, um Systemstabilität zu gewährleisten.",
+      "needs_translation": false,
       "reverse_text": false,
       "max_length": 54
     },
@@ -11039,381 +10869,381 @@
       "english": "Model changed, resetting session",
       "translation": "Modell geändert, Sitzung wird zurückgesetzt",
       "needs_translation": false,
-      "max_length": 32,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 32
     },
     "msg_not_available_now": "Not available right now.",
     "msg_please_disarm_to_save": {
       "english": "Please disarm to save",
       "translation": "Bitte disarmen, um die Datensicherheit zu gewährleisten.",
       "needs_translation": false,
-      "max_length": 21,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 21
     },
     "msg_please_disarm_to_save_warning": {
       "english": "Settings will only be saved to eeprom on disarm",
       "translation": "Einstellungen werden nur beim Entschärfen im EEPROM gespeichert",
       "needs_translation": false,
-      "max_length": 47,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 47
     },
     "msg_rebooting": {
       "english": "Rebooting...",
       "translation": "Neustart...",
       "needs_translation": false,
-      "max_length": 12,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 12
     },
     "msg_reload_settings": {
       "english": "Reload data from flight controller?",
       "translation": "Daten vom Flugcontroller neu laden?",
       "needs_translation": false,
-      "max_length": 35,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 35
     },
     "msg_save_current_page": {
       "english": "Save current page to flight controller?",
       "translation": "Aktuelle Seite auf dem Flugcontroller speichern?",
       "needs_translation": false,
-      "max_length": 39,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 39
     },
     "msg_save_not_commited": {
       "english": "Save not committed to EEPROM",
       "translation": "Speicherung nicht im EEPROM übernommen",
       "needs_translation": false,
-      "max_length": 28,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 28
     },
     "msg_save_settings": {
       "english": "Save settings",
       "translation": "Einstellungen speichern",
       "needs_translation": false,
-      "max_length": 13,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 13
     },
     "msg_saving": {
       "english": "Saving...",
       "translation": "Speichern...",
       "needs_translation": false,
-      "max_length": 9,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 9
     },
     "msg_saving_settings": {
       "english": "Saving settings...",
       "translation": "Einstellungen werden gespeichert...",
       "needs_translation": false,
-      "max_length": 18,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 18
     },
     "msg_saving_to_fbl": {
       "english": "Saving data to flight controller...",
       "translation": "Daten werden auf dem Flugcontroller gespeichert...",
       "needs_translation": false,
-      "max_length": 35,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 35
     },
     "msg_tasks_initialized": {
       "english": "All tasks initialized.",
       "translation": "Alle Aufgaben initialisiert.",
       "needs_translation": false,
-      "max_length": 22,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 22
     },
     "msg_telem_sensor_changed": {
       "english": "Telem. sensor changed to",
       "translation": "Telem. Sensor geändert zu",
       "needs_translation": false,
-      "max_length": 24,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 24
     },
     "msg_telem_type_changed": {
       "english": "Telem. type changed to",
       "translation": "Telem. Typ geändert zu",
       "needs_translation": false,
-      "max_length": 22,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 22
     },
     "msg_unavailable": "Unavailable",
     "msg_waiting_for_connection": {
       "english": "Waiting for connection",
       "translation": "Warte auf Verbindung",
       "needs_translation": false,
-      "max_length": 22,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 22
     },
     "navigation_help": {
       "english": "?",
       "translation": "?",
-      "needs_translation": true,
-      "max_length": 1,
-      "reverse_text": false
+      "needs_translation": false,
+      "reverse_text": false,
+      "max_length": 1
     },
     "navigation_menu": {
       "english": "BACK",
       "translation": "ZURÜCK",
       "needs_translation": false,
-      "max_length": 4,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 4
     },
     "navigation_reload": {
       "english": "RELOAD",
       "translation": "NEU LADEN",
       "needs_translation": false,
-      "max_length": 6,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 6
     },
     "navigation_save": {
       "english": "SAVE",
       "translation": "SPEICHERN",
       "needs_translation": false,
-      "max_length": 4,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 4
     },
     "navigation_tools": {
       "english": "*",
       "translation": "*",
-      "needs_translation": true,
-      "max_length": 1,
-      "reverse_text": false
+      "needs_translation": false,
+      "reverse_text": false,
+      "max_length": 1
     },
     "unit_hertz": {
       "english": "Hz",
       "translation": "Hz",
-      "needs_translation": true,
-      "max_length": 2,
-      "reverse_text": false
+      "needs_translation": false,
+      "reverse_text": false,
+      "max_length": 2
     }
   },
   "error": {
     "english": "error",
     "translation": "Fehler",
     "needs_translation": false,
-    "max_length": 5,
-    "reverse_text": false
+    "reverse_text": false,
+    "max_length": 5
   },
   "iscompiledcheck": {
     "english": "true",
     "translation": "true",
-    "needs_translation": true,
-    "max_length": 4,
-    "reverse_text": false
+    "needs_translation": false,
+    "reverse_text": false,
+    "max_length": 4
   },
   "reload": {
     "english": "Reload",
     "translation": "Neu laden",
     "needs_translation": false,
-    "max_length": 6,
-    "reverse_text": false
+    "reverse_text": false,
+    "max_length": 6
   },
   "sensors": {
     "accx": {
       "english": "Accel X",
       "translation": "Beschl. X",
       "needs_translation": false,
-      "max_length": 7,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 7
     },
     "accy": {
       "english": "Accel Y",
       "translation": "Beschl. Y",
       "needs_translation": false,
-      "max_length": 7,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 7
     },
     "accz": {
       "english": "Accel Z",
       "translation": "Beschl. Z",
       "needs_translation": false,
-      "max_length": 7,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 7
     },
     "adj_func": {
       "english": "Adj (Function)",
       "translation": "Adj (Funktion)",
       "needs_translation": false,
-      "max_length": 14,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 14
     },
     "adj_val": {
       "english": "Adj (Value)",
       "translation": "Adj (Wert)",
       "needs_translation": false,
-      "max_length": 11,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 11
     },
     "altitude": {
       "english": "Altitude",
       "translation": "Höhe",
       "needs_translation": false,
-      "max_length": 8,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 8
     },
     "armdisableflags": {
       "english": "Arming Disable",
       "translation": "Arming-Disable",
       "needs_translation": true,
-      "max_length": 14,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 14
     },
     "arming_flags": {
       "english": "Arming Flags",
       "translation": "Arming-Flags",
       "needs_translation": true,
-      "max_length": 12,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 12
     },
     "attpitch": {
       "english": "P.angle",
       "translation": "P.Winkel",
       "needs_translation": false,
-      "max_length": 7,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 7
     },
     "attroll": {
       "english": "R.angle",
       "translation": "R.Winkel",
       "needs_translation": false,
-      "max_length": 7,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 7
     },
     "attyaw": {
       "english": "Y.angle",
       "translation": "Y.Winkel",
       "needs_translation": false,
-      "max_length": 7,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 7
     },
     "battery_profile": {
       "english": "Battery Profile",
-      "translation": "Battery Profile",
-      "needs_translation": true,
+      "translation": "Akku Profil",
+      "needs_translation": false,
       "reverse_text": false,
-      "max_length": 12
+      "max_length": 15
     },
     "bec_voltage": {
       "english": "Bec voltage",
       "translation": "BEC-Spannung",
       "needs_translation": false,
-      "max_length": 11,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 11
     },
     "cell_count": {
       "english": "Cell count",
       "translation": "Zellenanzahl",
       "needs_translation": false,
-      "max_length": 10,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 10
     },
     "consumption": {
       "english": "Consumption",
       "translation": "Verbrauch",
       "needs_translation": false,
-      "max_length": 11,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 11
     },
     "current": {
       "english": "Current",
       "translation": "Strom",
       "needs_translation": false,
-      "max_length": 7,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 7
     },
     "esc_temp": {
       "english": "ESC Temperature",
       "translation": "ESC-Temperatur",
       "needs_translation": false,
-      "max_length": 15,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 15
     },
     "fuel": {
       "english": "Fuel",
       "translation": "Kraftstoffstand",
       "needs_translation": false,
-      "max_length": 4,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 4
     },
     "governor": {
       "english": "Governor State",
       "translation": "Governor-Status",
       "needs_translation": false,
-      "max_length": 14,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 14
     },
     "groundspeed": {
       "english": "Ground Speed",
       "translation": "Boden­geschwindigkeit",
       "needs_translation": false,
-      "max_length": 12,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 12
     },
     "headspeed": {
       "english": "Headspeed",
       "translation": "Drehzahl",
       "needs_translation": false,
-      "max_length": 9,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 9
     },
     "link": {
       "english": "Link Quality",
       "translation": "Verbindungsqualität",
       "needs_translation": false,
-      "max_length": 12,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 12
     },
     "mcu_temp": {
       "english": "MCU Temperature",
       "translation": "MCU-Temperatur",
       "needs_translation": false,
-      "max_length": 15,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 15
     },
     "pid_profile": {
       "english": "PID Profile",
       "translation": "PID-Profil",
       "needs_translation": false,
-      "max_length": 11,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 11
     },
     "rate_profile": {
       "english": "Rate Profile",
       "translation": "Raten-Profil",
       "needs_translation": false,
-      "max_length": 12,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 12
     },
     "rssi": {
       "english": "RSSI",
       "translation": "RSSI",
-      "needs_translation": true,
-      "max_length": 4,
-      "reverse_text": false
+      "needs_translation": false,
+      "reverse_text": false,
+      "max_length": 4
     },
     "smartconsumption": {
       "english": "Smart Consumption",
       "translation": "Intelligenter Verbrauch",
       "needs_translation": false,
-      "max_length": 17,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 17
     },
     "smartfuel": {
       "english": "Smart Fuel",
       "translation": "Intelligenter Kraftstoff",
       "needs_translation": false,
-      "max_length": 10,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 10
     },
     "throttle_pct": {
       "english": "Throttle %",
       "translation": "Gas %",
       "needs_translation": false,
-      "max_length": 10,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 10
     },
     "vfr": {
       "english": "VFR",
       "translation": "VFR",
-      "needs_translation": true,
+      "needs_translation": false,
       "reverse_text": false,
       "max_length": 3
     },
@@ -11421,8 +11251,8 @@
       "english": "Voltage",
       "translation": "Spannung",
       "needs_translation": false,
-      "max_length": 7,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 7
     }
   },
   "telemetry": {
@@ -11430,106 +11260,106 @@
       "english": "Barometer",
       "translation": "Barometer",
       "needs_translation": true,
-      "max_length": 9,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 9
     },
     "group_battery": {
       "english": "Battery",
       "translation": "Akku",
       "needs_translation": false,
-      "max_length": 7,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 7
     },
     "group_control": {
       "english": "Control",
       "translation": "Steuerung",
       "needs_translation": false,
-      "max_length": 7,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 7
     },
     "group_current": {
       "english": "Current",
       "translation": "Strom",
       "needs_translation": false,
-      "max_length": 7,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 7
     },
     "group_debug": {
       "english": "Debug",
       "translation": "Debug",
-      "needs_translation": true,
-      "max_length": 5,
-      "reverse_text": false
+      "needs_translation": false,
+      "reverse_text": false,
+      "max_length": 5
     },
     "group_esc1": {
       "english": "ESC 1",
       "translation": "Regler 1",
       "needs_translation": false,
-      "max_length": 5,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 5
     },
     "group_esc2": {
       "english": "ESC 2",
       "translation": "Regler 2",
       "needs_translation": false,
-      "max_length": 5,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 5
     },
     "group_gps": {
       "english": "GPS",
       "translation": "GPS",
-      "needs_translation": true,
-      "max_length": 3,
-      "reverse_text": false
+      "needs_translation": false,
+      "reverse_text": false,
+      "max_length": 3
     },
     "group_gyro": {
       "english": "Gyro",
       "translation": "Kreisel",
       "needs_translation": false,
-      "max_length": 4,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 4
     },
     "group_profiles": {
       "english": "Profiles",
       "translation": "Profile",
       "needs_translation": false,
-      "max_length": 8,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 8
     },
     "group_rpm": {
       "english": "RPM",
       "translation": "U/min",
       "needs_translation": false,
-      "max_length": 3,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 3
     },
     "group_status": {
       "english": "Status",
       "translation": "Status",
-      "needs_translation": true,
-      "max_length": 6,
-      "reverse_text": false
+      "needs_translation": false,
+      "reverse_text": false,
+      "max_length": 6
     },
     "group_system": {
       "english": "System",
       "translation": "System",
-      "needs_translation": true,
-      "max_length": 6,
-      "reverse_text": false
+      "needs_translation": false,
+      "reverse_text": false,
+      "max_length": 6
     },
     "group_temps": {
       "english": "Temperatures",
       "translation": "Temperaturen",
       "needs_translation": false,
-      "max_length": 12,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 12
     },
     "group_voltage": {
       "english": "Voltage",
       "translation": "Spannung",
       "needs_translation": false,
-      "max_length": 7,
-      "reverse_text": false
+      "reverse_text": false,
+      "max_length": 7
     }
   },
   "widgets": {
@@ -11548,15 +11378,15 @@
       },
       "msg_battery_selected": {
         "english": "Selected battery:",
-        "translation": "Selected battery:",
-        "needs_translation": true,
+        "translation": "Akku auswählen:",
+        "needs_translation": false,
         "reverse_text": false,
         "max_length": 17
       },
       "msg_select_battery": {
         "english": "Please select the battery you want to use:",
-        "translation": "Please select the battery you want to use:",
-        "needs_translation": true,
+        "translation": "     Wähle den gewünschten Akku:     ",
+        "needs_translation": false,
         "reverse_text": false,
         "max_length": 42
       },
@@ -11578,8 +11408,8 @@
         "english": "Erase dataflash",
         "translation": "Blackbox speicher loeschen",
         "needs_translation": false,
-        "max_length": 15,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 15
       }
     },
     "craftimage": {},
@@ -11589,8 +11419,8 @@
         "english": "Altitude Max",
         "translation": "Höhe Max.",
         "needs_translation": false,
-        "max_length": 12,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 12
       },
       "battery": {
         "english": "Battery Profile",
@@ -11600,255 +11430,255 @@
       },
       "battery_profile": {
         "english": "Battery Profile",
-        "translation": "Battery Profile",
-        "needs_translation": true,
+        "translation": "Akku Profil",
+        "needs_translation": false,
         "reverse_text": false,
-        "max_length": 12
+        "max_length": 15
       },
       "bec_voltage": {
         "english": "BEC Voltage",
         "translation": "BEC-Spannung",
         "needs_translation": false,
-        "max_length": 11,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 11
       },
       "blackbox": {
         "english": "Blackbox",
         "translation": "Blackbox",
-        "needs_translation": true,
-        "max_length": 8,
-        "reverse_text": false
+        "needs_translation": false,
+        "reverse_text": false,
+        "max_length": 8
       },
       "consumed_mah": {
         "english": "Consumed mAh",
         "translation": "Verbrauchte mAh",
         "needs_translation": false,
-        "max_length": 12,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 12
       },
       "current": {
         "english": "Current",
         "translation": "Strom",
         "needs_translation": false,
-        "max_length": 7,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 7
       },
       "current_max": {
         "english": "Current Max",
         "translation": "Strom Max.",
         "needs_translation": false,
-        "max_length": 11,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 11
       },
       "esc_max_temp": {
         "english": "ESC Temp Max",
         "translation": "ESC-Temp. Max.",
         "needs_translation": true,
-        "max_length": 12,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 12
       },
       "esc_temp": {
         "english": "ESC Temp",
         "translation": "ESC-Temp.",
         "needs_translation": true,
-        "max_length": 8,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 8
       },
       "flight_duration": {
         "english": "Flight Duration",
         "translation": "Flugdauer",
         "needs_translation": false,
-        "max_length": 15,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 15
       },
       "flight_time": {
         "english": "Flight Time",
         "translation": "Flugzeit",
         "needs_translation": false,
-        "max_length": 11,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 11
       },
       "flights": {
         "english": "Flights",
         "translation": "Flüge",
         "needs_translation": false,
-        "max_length": 7,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 7
       },
       "fuel": {
         "english": "Fuel",
         "translation": "Kraftstoff",
         "needs_translation": false,
-        "max_length": 4,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 4
       },
       "fuel_remaining": {
         "english": "Fuel Remaining",
         "translation": "Verfügbarer Kraftstoff",
         "needs_translation": false,
-        "max_length": 14,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 14
       },
       "governor": {
         "english": "Governor",
         "translation": "Governor",
         "needs_translation": true,
-        "max_length": 8,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 8
       },
       "headspeed": {
         "english": "Headspeed",
         "translation": "Rotordrehzahl",
         "needs_translation": false,
-        "max_length": 9,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 9
       },
       "link_max": {
         "english": "Link Max",
         "translation": "Verbindung Max.",
         "needs_translation": false,
-        "max_length": 8,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 8
       },
       "link_min": {
         "english": "Link Min",
         "translation": "Verbindung Min.",
         "needs_translation": false,
-        "max_length": 8,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 8
       },
       "loading": {
         "english": "ROTORFLIGHT",
         "translation": "ROTORFLIGHT",
         "needs_translation": true,
-        "max_length": 11,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 11
       },
       "lq": {
         "english": "LQ",
         "translation": "LQ",
         "needs_translation": true,
-        "max_length": 2,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 2
       },
       "max": {
         "english": "Max",
         "translation": "Max",
         "needs_translation": true,
-        "max_length": 3,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 3
       },
       "max_current": {
         "english": "Max Current",
         "translation": "Max. Strom",
         "needs_translation": false,
-        "max_length": 11,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 11
       },
       "max_emcu": {
         "english": "Max E.MCU",
         "translation": "Max. E.MCU",
         "needs_translation": true,
-        "max_length": 9,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 9
       },
       "max_tmcu": {
         "english": "Max T.MCU",
         "translation": "Max. T.MCU",
         "needs_translation": true,
-        "max_length": 9,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 9
       },
       "max_voltage": {
         "english": "Max Voltage",
         "translation": "Max. Spannung",
         "needs_translation": false,
-        "max_length": 11,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 11
       },
       "min": {
         "english": "Min",
         "translation": "Min",
         "needs_translation": true,
-        "max_length": 3,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 3
       },
       "min_current": {
         "english": "Min Current",
         "translation": "Min. Strom",
         "needs_translation": false,
-        "max_length": 11,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 11
       },
       "min_voltage": {
         "english": "Min Voltage",
         "translation": "Min. Spannung",
         "needs_translation": false,
-        "max_length": 11,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 11
       },
       "min_volts_cell": {
         "english": "Min Volts per cell",
         "translation": "Min. Volt pro Zelle",
         "needs_translation": false,
-        "max_length": 18,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 18
       },
       "profile": {
         "english": "Profile",
         "translation": "Profil",
         "needs_translation": false,
-        "max_length": 7,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 7
       },
       "rates": {
         "english": "Rates",
         "translation": "Raten",
         "needs_translation": false,
-        "max_length": 5,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 5
       },
       "reset_flight": {
         "english": "Reset flight",
         "translation": "Flug zuruecksetzen",
         "needs_translation": false,
-        "max_length": 12,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 12
       },
       "reset_flight_ask_text": {
         "english": "Are you sure you want to reset the flight?",
         "translation": "Sind Sie sicher, dass Sie den Flug zurücksetzen möchten?",
         "needs_translation": false,
-        "max_length": 42,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 42
       },
       "reset_flight_ask_title": {
         "english": "Reset flight",
         "translation": "Flug zurücksetzen",
         "needs_translation": false,
-        "max_length": 12,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 12
       },
       "rpm": {
         "english": "RPM",
         "translation": "RPM",
         "needs_translation": true,
-        "max_length": 3,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 3
       },
       "rpm_max": {
         "english": "RPM Max",
         "translation": "RPM Max.",
         "needs_translation": true,
-        "max_length": 7,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 7
       },
       "rpm_min": {
         "english": "RPM Min",
         "translation": "RPM Min.",
         "needs_translation": true,
-        "max_length": 7,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 7
       },
       "setup": {
         "english": "Setup",
@@ -11861,71 +11691,71 @@
         "english": "Throttle",
         "translation": "Gas",
         "needs_translation": false,
-        "max_length": 8,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 8
       },
       "throttle_max": {
         "english": "Throttle Max",
         "translation": "Gas Max.",
         "needs_translation": false,
-        "max_length": 12,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 12
       },
       "time": {
         "english": "Time",
         "translation": "Zeit",
         "needs_translation": false,
-        "max_length": 4,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 4
       },
       "timer": {
         "english": "Timer",
         "translation": "Timer",
         "needs_translation": true,
-        "max_length": 5,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 5
       },
       "total_flight_duration": {
         "english": "Total Model Flight Duration",
         "translation": "Modell-Gesamtflugzeit",
         "needs_translation": false,
-        "max_length": 27,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 27
       },
       "unsupported_resolution": {
         "english": "TO SMALL",
         "translation": "ZU KLEIN",
         "needs_translation": false,
-        "max_length": 8,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 8
       },
       "voltage": {
         "english": "Voltage",
         "translation": "Spannung",
         "needs_translation": false,
-        "max_length": 7,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 7
       },
       "volts_per_cell": {
         "english": "Volts per cell",
         "translation": "Volt pro Zelle",
         "needs_translation": false,
-        "max_length": 14,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 14
       },
       "warning": {
         "english": "Warning",
         "translation": "Warnung",
         "needs_translation": false,
-        "max_length": 7,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 7
       },
       "watts_max": {
         "english": "Max Watts",
         "translation": "Max. Watt",
         "needs_translation": false,
-        "max_length": 9,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 9
       }
     },
     "governor": {
@@ -11933,92 +11763,92 @@
         "english": "ACTIVE",
         "translation": "AKTIV",
         "needs_translation": false,
-        "max_length": 6,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 6
       },
       "ARMED": {
         "english": "ARMED",
         "translation": "SCHARF",
         "needs_translation": false,
-        "max_length": 5,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 5
       },
       "AUTOROT": {
         "english": "AUTOROT",
         "translation": "AUTOROTATION",
         "needs_translation": false,
-        "max_length": 7,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 7
       },
       "BAILOUT": {
         "english": "BAILOUT",
         "translation": "NOTAUS",
         "needs_translation": false,
-        "max_length": 7,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 7
       },
       "DISABLED": {
         "english": "DISABLED",
         "translation": "DEAKTIVIERT",
         "needs_translation": false,
-        "max_length": 8,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 8
       },
       "DISARMED": {
         "english": "DISARMED",
         "translation": "DISARMED",
         "needs_translation": true,
-        "max_length": 8,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 8
       },
       "IDLE": {
         "english": "IDLE",
         "translation": "LEERLAUF",
         "needs_translation": false,
-        "max_length": 4,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 4
       },
       "LOSTHS": {
         "english": "LOST-HS",
         "translation": "KEIN SIGNAL",
         "needs_translation": false,
-        "max_length": 7,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 7
       },
       "OFF": {
         "english": "OFF",
         "translation": "AUS",
         "needs_translation": false,
-        "max_length": 3,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 3
       },
       "RECOVERY": {
         "english": "RECOVERY",
         "translation": "ERHOLUNG",
         "needs_translation": false,
-        "max_length": 8,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 8
       },
       "SPOOLUP": {
         "english": "SPOOLUP",
         "translation": "HOCHLAUF",
         "needs_translation": false,
-        "max_length": 7,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 7
       },
       "THROFF": {
         "english": "THR-OFF",
         "translation": "GAS-AUS",
         "needs_translation": false,
-        "max_length": 7,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 7
       },
       "UNKNOWN": {
         "english": "UNKNOWN",
         "translation": "UNBEKANNT",
         "needs_translation": false,
-        "max_length": 7,
-        "reverse_text": false
+        "reverse_text": false,
+        "max_length": 7
       }
     }
   }

--- a/bin/i18n/json/en.json
+++ b/bin/i18n/json/en.json
@@ -28,10 +28,10 @@
         "translation": "The number of cells in your battery."
       },
       "batteryProfile": {
-        "english": "Selected battery profile (0-5)",
-        "max_length": 27,
+        "english": "Selected battery profile (1-6)",
+        "max_length": 30,
         "needs_translation": false,
-        "translation": "Selected battery profile (0-5)"
+        "translation": "Selected battery profile (1-6)"
       },
       "source_adc": {
         "english": "Battery ADC",
@@ -6634,8 +6634,7 @@
           "english": "Yaw",
           "max_length": 3,
           "needs_translation": false,
-          "translation": "Yaw",
-          "max_length": 3
+          "translation": "Yaw"
         }
       },
       "power": {
@@ -6770,7 +6769,6 @@
           "needs_translation": false,
           "translation": "Warn Cell Voltage",
           "max_length": 17
-          "translation": "Yaw"
         }
       },
       "ports": {
@@ -6941,152 +6939,6 @@
           "max_length": 11,
           "needs_translation": false,
           "translation": "Save error:"
-        }
-      },
-      "power": {
-        "alert_name": {
-          "english": "Alerts",
-          "max_length": 6,
-          "needs_translation": false,
-          "translation": "Alerts"
-        },
-        "alert_type": {
-          "english": "Rx Voltage Alert",
-          "max_length": 16,
-          "needs_translation": false,
-          "translation": "Rx Voltage Alert"
-        },
-        "battery_capacity": {
-          "english": "Battery Capacity",
-          "max_length": 16,
-          "needs_translation": false,
-          "translation": "Battery Capacity"
-        },
-        "battery_name": {
-          "english": "Battery",
-          "max_length": 7,
-          "needs_translation": false,
-          "translation": "Battery"
-        },
-        "bec_voltage_alert": {
-          "english": "BEC Alert Value",
-          "max_length": 15,
-          "needs_translation": false,
-          "translation": "BEC Alert Value"
-        },
-        "calcfuel_local": {
-          "english": "Calculate Fuel Using",
-          "max_length": 20,
-          "needs_translation": false,
-          "translation": "Calculate Fuel Using"
-        },
-        "capacity": {
-          "english": "Capacity",
-          "max_length": 8,
-          "needs_translation": false,
-          "translation": "Capacity"
-        },
-        "cell_count": {
-          "english": "Cell Count",
-          "max_length": 10,
-          "needs_translation": false,
-          "translation": "Cell Count"
-        },
-        "consumption_warning_percentage": {
-          "english": "Consumption Warning %",
-          "max_length": 21,
-          "needs_translation": false,
-          "translation": "Consumption Warning %"
-        },
-        "current_meter_source": {
-          "english": "Current Source",
-          "max_length": 14,
-          "needs_translation": false,
-          "translation": "Current Source"
-        },
-        "full_cell_voltage": {
-          "english": "Full Cell Voltage",
-          "max_length": 17,
-          "needs_translation": false,
-          "translation": "Full Cell Voltage"
-        },
-        "help_p1": {
-          "english": "The battery settings are used to configure the flight controller to monitor the battery voltage and provide warnings when the voltage drops below a certain level.",
-          "max_length": 162,
-          "needs_translation": false,
-          "translation": "The battery settings are used to configure the flight controller to monitor the battery voltage and provide warnings when the voltage drops below a certain level."
-        },
-        "max_cell_voltage": {
-          "english": "Max Cell Voltage",
-          "max_length": 16,
-          "needs_translation": false,
-          "translation": "Max Cell Voltage"
-        },
-        "min_cell_voltage": {
-          "english": "Min Cell Voltage",
-          "max_length": 16,
-          "needs_translation": false,
-          "translation": "Min Cell Voltage"
-        },
-        "name": {
-          "english": "Power",
-          "max_length": 5,
-          "needs_translation": false,
-          "translation": "Power"
-        },
-        "rx_voltage_alert": {
-          "english": "RxBatt Alert Value",
-          "max_length": 18,
-          "needs_translation": false,
-          "translation": "RxBatt Alert Value"
-        },
-        "selected": {
-          "english": "Selected",
-          "max_length": 8,
-          "needs_translation": false,
-          "translation": "Selected"
-        },
-        "show_battery_profile_startup": {
-          "english": "Show battery type choose (startup)",
-          "max_length": 34,
-          "needs_translation": false,
-          "translation": "Show battery type choose (startup)"
-        },
-        "show_confirmation_dialog": {
-          "english": "Show confirmation dialog",
-          "max_length": 24,
-          "needs_translation": false,
-          "translation": "Show confirmation dialog"
-        },
-        "source_name": {
-          "english": "Sources",
-          "max_length": 7,
-          "needs_translation": false,
-          "translation": "Sources"
-        },
-        "timer": {
-          "english": "Flight Time Alarm",
-          "max_length": 17,
-          "needs_translation": false,
-          "translation": "Flight Time Alarm"
-        },
-        "voltage_meter_source": {
-          "english": "Voltage Source",
-          "max_length": 14,
-          "needs_translation": false,
-          "translation": "Voltage Source"
-        },
-        "voltage_multiplier": {
-          "english": "Sag Compensation",
-          "max_length": 16,
-          "needs_translation": false,
-          "translation": "Sag Compensation"
-        },
-        "warn_cell_voltage": {
-          "english": "Warn Cell Voltage",
-          "max_length": 17,
-          "needs_translation": false,
-          "translation": "Warn Cell Voltage"
         }
       },
       "profile_autolevel": {
@@ -9700,7 +9552,7 @@
     },
     "battery_profile": {
       "english": "Battery Profile",
-      "max_length": 12,
+      "max_length": 15,
       "needs_translation": false,
       "translation": "Battery Profile"
     },
@@ -9975,7 +9827,7 @@
       },
       "battery_profile": {
         "english": "Battery Profile",
-        "max_length": 12,
+        "max_length": 15,
         "needs_translation": false,
         "translation": "Battery Profile"
       },

--- a/bin/i18n/json/es.json
+++ b/bin/i18n/json/es.json
@@ -32,11 +32,11 @@
         "reverse_text": false
       },
       "batteryProfile": {
-        "english": "Selected battery profile (0-5)",
+        "english": "Selected battery profile (1-6)",
         "translation": "Selected battery profile (0-5)",
         "needs_translation": true,
         "reverse_text": false,
-        "max_length": 27
+        "max_length": 30
       },
       "source_adc": {
         "english": "Battery ADC",
@@ -8077,176 +8077,6 @@
           "max_length": 11
         }
       },
-      "power": {
-        "alert_name": {
-          "english": "Alerts",
-          "translation": "Alertas",
-          "needs_translation": false,
-          "max_length": 6,
-          "reverse_text": false
-        },
-        "alert_type": {
-          "english": "Rx Voltage Alert",
-          "translation": "Rx Voltaje Alerta",
-          "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
-        },
-        "battery_capacity": {
-          "english": "Battery Capacity",
-          "translation": "Bateria Capacidad",
-          "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
-        },
-        "battery_name": {
-          "english": "Battery",
-          "translation": "Bateria",
-          "needs_translation": false,
-          "max_length": 7,
-          "reverse_text": false
-        },
-        "bec_voltage_alert": {
-          "english": "BEC Alert Value",
-          "translation": "BEC Alerta Valor",
-          "needs_translation": false,
-          "max_length": 15,
-          "reverse_text": false
-        },
-        "calcfuel_local": {
-          "english": "Calculate Fuel Using",
-          "translation": "Calcular Combust Usando",
-          "needs_translation": false,
-          "max_length": 20,
-          "reverse_text": false
-        },
-        "capacity": {
-          "english": "Capacity",
-          "translation": "Capacity",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 8
-        },
-        "cell_count": {
-          "english": "Cell Count",
-          "translation": "Celda Conteo",
-          "needs_translation": false,
-          "max_length": 10,
-          "reverse_text": false
-        },
-        "consumption_warning_percentage": {
-          "english": "Consumption Warning %",
-          "translation": "Consumption Aviso %",
-          "needs_translation": false,
-          "max_length": 21,
-          "reverse_text": false
-        },
-        "current_meter_source": {
-          "english": "Current Source",
-          "translation": "Corriente Fuente",
-          "needs_translation": false,
-          "max_length": 14,
-          "reverse_text": false
-        },
-        "full_cell_voltage": {
-          "english": "Full Cell Voltage",
-          "translation": "Full Celda Voltaje",
-          "needs_translation": false,
-          "max_length": 17,
-          "reverse_text": false
-        },
-        "help_p1": {
-          "english": "The battery settings are used to configure the flight controller to monitor the battery voltage and provide warnings when the voltage drops below a certain level.",
-          "translation": "Los ajustes de bateria configuran el controlador para vigilar voltaje y avisar cuando baja.",
-          "needs_translation": false,
-          "max_length": 162,
-          "reverse_text": false
-        },
-        "max_cell_voltage": {
-          "english": "Max Cell Voltage",
-          "translation": "Max Celda Voltaje",
-          "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
-        },
-        "min_cell_voltage": {
-          "english": "Min Cell Voltage",
-          "translation": "Min Celda Voltaje",
-          "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
-        },
-        "name": {
-          "english": "Power",
-          "translation": "Potencia",
-          "needs_translation": false,
-          "max_length": 5,
-          "reverse_text": false
-        },
-        "rx_voltage_alert": {
-          "english": "RxBatt Alert Value",
-          "translation": "RxBatt Alerta Valor",
-          "needs_translation": false,
-          "max_length": 18,
-          "reverse_text": false
-        },
-        "selected": {
-          "english": "Selected",
-          "translation": "Selected",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 8
-        },
-        "show_battery_profile_startup": {
-          "english": "Show battery type choose (startup)",
-          "translation": "Show battery type choose (startup)",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 34
-        },
-        "show_confirmation_dialog": {
-          "english": "Show confirmation dialog",
-          "translation": "Show confirmation dialog",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 24
-        },
-        "source_name": {
-          "english": "Sources",
-          "translation": "Fuentes",
-          "needs_translation": false,
-          "max_length": 7,
-          "reverse_text": false
-        },
-        "timer": {
-          "english": "Flight Time Alarm",
-          "translation": "Alarma tiempo vuelo",
-          "needs_translation": false,
-          "max_length": 17,
-          "reverse_text": false
-        },
-        "voltage_meter_source": {
-          "english": "Voltage Source",
-          "translation": "Voltaje Fuente",
-          "needs_translation": false,
-          "max_length": 14,
-          "reverse_text": false
-        },
-        "voltage_multiplier": {
-          "english": "Sag Compensation",
-          "translation": "Caida Compens",
-          "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
-        },
-        "warn_cell_voltage": {
-          "english": "Warn Cell Voltage",
-          "translation": "Aviso Celda Voltaje",
-          "needs_translation": false,
-          "max_length": 17,
-          "reverse_text": false
-        }
-      },
       "profile_autolevel": {
         "acro_trainer": {
           "english": "Acro trainer",
@@ -11289,7 +11119,7 @@
       "translation": "Battery Profile",
       "needs_translation": true,
       "reverse_text": false,
-      "max_length": 12
+      "max_length": 15
     },
     "bec_voltage": {
       "english": "Bec voltage",
@@ -11603,7 +11433,7 @@
         "translation": "Battery Profile",
         "needs_translation": true,
         "reverse_text": false,
-        "max_length": 12
+        "max_length": 15
       },
       "bec_voltage": {
         "english": "BEC Voltage",

--- a/bin/i18n/json/fr.json
+++ b/bin/i18n/json/fr.json
@@ -32,11 +32,11 @@
         "reverse_text": false
       },
       "batteryProfile": {
-        "english": "Selected battery profile (0-5)",
+        "english": "Selected battery profile (1-6)",
         "translation": "Selected battery profile (0-5)",
         "needs_translation": true,
         "reverse_text": false,
-        "max_length": 27
+        "max_length": 30
       },
       "source_adc": {
         "english": "Battery ADC",
@@ -8077,176 +8077,6 @@
           "max_length": 11
         }
       },
-      "power": {
-        "alert_name": {
-          "english": "Alerts",
-          "translation": "Alertes",
-          "needs_translation": false,
-          "max_length": 6,
-          "reverse_text": false
-        },
-        "alert_type": {
-          "english": "Rx Voltage Alert",
-          "translation": "Rx Tension Alerte",
-          "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
-        },
-        "battery_capacity": {
-          "english": "Battery Capacity",
-          "translation": "Batterie Capacite",
-          "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
-        },
-        "battery_name": {
-          "english": "Battery",
-          "translation": "Batterie",
-          "needs_translation": false,
-          "max_length": 7,
-          "reverse_text": false
-        },
-        "bec_voltage_alert": {
-          "english": "BEC Alert Value",
-          "translation": "BEC Alerte Valeur",
-          "needs_translation": false,
-          "max_length": 15,
-          "reverse_text": false
-        },
-        "calcfuel_local": {
-          "english": "Calculate Fuel Using",
-          "translation": "Calculer Carburant Utilisant",
-          "needs_translation": false,
-          "max_length": 20,
-          "reverse_text": false
-        },
-        "capacity": {
-          "english": "Capacity",
-          "translation": "Capacity",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 8
-        },
-        "cell_count": {
-          "english": "Cell Count",
-          "translation": "Cellule Nombre",
-          "needs_translation": false,
-          "max_length": 10,
-          "reverse_text": false
-        },
-        "consumption_warning_percentage": {
-          "english": "Consumption Warning %",
-          "translation": "Consumption Avert %",
-          "needs_translation": false,
-          "max_length": 21,
-          "reverse_text": false
-        },
-        "current_meter_source": {
-          "english": "Current Source",
-          "translation": "Courant Source",
-          "needs_translation": false,
-          "max_length": 14,
-          "reverse_text": false
-        },
-        "full_cell_voltage": {
-          "english": "Full Cell Voltage",
-          "translation": "Full Cellule Tension",
-          "needs_translation": false,
-          "max_length": 17,
-          "reverse_text": false
-        },
-        "help_p1": {
-          "english": "The battery settings are used to configure the flight controller to monitor the battery voltage and provide warnings when the voltage drops below a certain level.",
-          "translation": "Les reglages batterie configurent le controleur pour surveiller la tension et avertir quand elle baisse.",
-          "needs_translation": false,
-          "max_length": 162,
-          "reverse_text": false
-        },
-        "max_cell_voltage": {
-          "english": "Max Cell Voltage",
-          "translation": "Max Cellule Tension",
-          "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
-        },
-        "min_cell_voltage": {
-          "english": "Min Cell Voltage",
-          "translation": "Min Cellule Tension",
-          "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
-        },
-        "name": {
-          "english": "Power",
-          "translation": "Puissance",
-          "needs_translation": false,
-          "max_length": 5,
-          "reverse_text": false
-        },
-        "rx_voltage_alert": {
-          "english": "RxBatt Alert Value",
-          "translation": "RxBatt Alerte Valeur",
-          "needs_translation": false,
-          "max_length": 18,
-          "reverse_text": false
-        },
-        "selected": {
-          "english": "Selected",
-          "translation": "Selected",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 8
-        },
-        "show_battery_profile_startup": {
-          "english": "Show battery type choose (startup)",
-          "translation": "Show battery type choose (startup)",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 34
-        },
-        "show_confirmation_dialog": {
-          "english": "Show confirmation dialog",
-          "translation": "Show confirmation dialog",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 24
-        },
-        "source_name": {
-          "english": "Sources",
-          "translation": "Sources",
-          "needs_translation": false,
-          "max_length": 7,
-          "reverse_text": false
-        },
-        "timer": {
-          "english": "Flight Time Alarm",
-          "translation": "Alarme temps vol",
-          "needs_translation": false,
-          "max_length": 17,
-          "reverse_text": false
-        },
-        "voltage_meter_source": {
-          "english": "Voltage Source",
-          "translation": "Tension Source",
-          "needs_translation": false,
-          "max_length": 14,
-          "reverse_text": false
-        },
-        "voltage_multiplier": {
-          "english": "Sag Compensation",
-          "translation": "Affaissement Compensation",
-          "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
-        },
-        "warn_cell_voltage": {
-          "english": "Warn Cell Voltage",
-          "translation": "Avert Cellule Tension",
-          "needs_translation": false,
-          "max_length": 17,
-          "reverse_text": false
-        }
-      },
       "profile_autolevel": {
         "acro_trainer": {
           "english": "Acro trainer",
@@ -11289,7 +11119,7 @@
       "translation": "Battery Profile",
       "needs_translation": true,
       "reverse_text": false,
-      "max_length": 12
+      "max_length": 15
     },
     "bec_voltage": {
       "english": "Bec voltage",
@@ -11603,7 +11433,7 @@
         "translation": "Battery Profile",
         "needs_translation": true,
         "reverse_text": false,
-        "max_length": 12
+        "max_length": 15
       },
       "bec_voltage": {
         "english": "BEC Voltage",

--- a/bin/i18n/json/he.json
+++ b/bin/i18n/json/he.json
@@ -32,11 +32,11 @@
         "reverse_text": true
       },
       "batteryProfile": {
-        "english": "Selected battery profile (0-5)",
+        "english": "Selected battery profile (1-6)",
         "translation": "Selected battery profile (0-5)",
         "needs_translation": true,
         "reverse_text": false,
-        "max_length": 27
+        "max_length": 30
       },
       "source_adc": {
         "english": "Battery ADC",
@@ -8077,176 +8077,6 @@
           "max_length": 11
         }
       },
-      "power": {
-        "alert_name": {
-          "english": "Alerts",
-          "max_length": 6,
-          "needs_translation": true,
-          "translation": "התראות",
-          "reverse_text": true
-        },
-        "alert_type": {
-          "english": "Rx Voltage Alert",
-          "max_length": 16,
-          "needs_translation": true,
-          "translation": "התראת מתח Rx",
-          "reverse_text": true
-        },
-        "battery_capacity": {
-          "english": "Battery Capacity",
-          "max_length": 16,
-          "needs_translation": true,
-          "translation": "קיבולת סוללה",
-          "reverse_text": true
-        },
-        "battery_name": {
-          "english": "Battery",
-          "max_length": 7,
-          "needs_translation": true,
-          "translation": "סוללה",
-          "reverse_text": true
-        },
-        "bec_voltage_alert": {
-          "english": "BEC Alert Value",
-          "max_length": 15,
-          "needs_translation": true,
-          "translation": "ערך התראת BEC",
-          "reverse_text": true
-        },
-        "calcfuel_local": {
-          "english": "Calculate Fuel Using",
-          "max_length": 20,
-          "needs_translation": true,
-          "translation": "חשב דלק באמצעות",
-          "reverse_text": true
-        },
-        "capacity": {
-          "english": "Capacity",
-          "translation": "Capacity",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 8
-        },
-        "cell_count": {
-          "english": "Cell Count",
-          "max_length": 10,
-          "needs_translation": true,
-          "translation": "מספר תאים",
-          "reverse_text": true
-        },
-        "consumption_warning_percentage": {
-          "english": "Consumption Warning %",
-          "max_length": 21,
-          "needs_translation": true,
-          "translation": "אחוז אזהרת צריכה",
-          "reverse_text": true
-        },
-        "current_meter_source": {
-          "english": "Current Source",
-          "max_length": 14,
-          "needs_translation": true,
-          "translation": "מקור זרם",
-          "reverse_text": true
-        },
-        "full_cell_voltage": {
-          "english": "Full Cell Voltage",
-          "max_length": 17,
-          "needs_translation": true,
-          "translation": "מתח תא מלא",
-          "reverse_text": true
-        },
-        "help_p1": {
-          "english": "The battery settings are used to configure the flight controller to monitor the battery voltage and provide warnings when the voltage drops below a certain level.",
-          "max_length": 162,
-          "needs_translation": true,
-          "translation": "הגדרות הסוללה משמשות לקונפיגורציה של בקר הטיסה לניטור מתח הסוללה ולהתריע כשהמתח יורד מתחת לרמה מסוימת.",
-          "reverse_text": true
-        },
-        "max_cell_voltage": {
-          "english": "Max Cell Voltage",
-          "max_length": 16,
-          "needs_translation": true,
-          "translation": "מתח תא מרבי",
-          "reverse_text": true
-        },
-        "min_cell_voltage": {
-          "english": "Min Cell Voltage",
-          "max_length": 16,
-          "needs_translation": true,
-          "translation": "מתח תא מינימלי",
-          "reverse_text": true
-        },
-        "name": {
-          "english": "Power",
-          "max_length": 5,
-          "needs_translation": true,
-          "translation": "חשמל",
-          "reverse_text": true
-        },
-        "rx_voltage_alert": {
-          "english": "RxBatt Alert Value",
-          "max_length": 18,
-          "needs_translation": true,
-          "translation": "ערך התראת RxBatt",
-          "reverse_text": true
-        },
-        "selected": {
-          "english": "Selected",
-          "translation": "Selected",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 8
-        },
-        "show_battery_profile_startup": {
-          "english": "Show battery type choose (startup)",
-          "translation": "Show battery type choose (startup)",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 34
-        },
-        "show_confirmation_dialog": {
-          "english": "Show confirmation dialog",
-          "translation": "Show confirmation dialog",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 24
-        },
-        "source_name": {
-          "english": "Sources",
-          "max_length": 7,
-          "needs_translation": true,
-          "translation": "מקורות",
-          "reverse_text": true
-        },
-        "timer": {
-          "english": "Flight Time Alarm",
-          "max_length": 17,
-          "needs_translation": true,
-          "translation": "התראת זמן טיסה",
-          "reverse_text": true
-        },
-        "voltage_meter_source": {
-          "english": "Voltage Source",
-          "max_length": 14,
-          "needs_translation": true,
-          "translation": "מקור מתח",
-          "reverse_text": true
-        },
-        "voltage_multiplier": {
-          "english": "Sag Compensation",
-          "max_length": 16,
-          "needs_translation": true,
-          "translation": "פיצוי שקיעה",
-          "reverse_text": true
-        },
-        "warn_cell_voltage": {
-          "english": "Warn Cell Voltage",
-          "max_length": 17,
-          "needs_translation": true,
-          "translation": "מתח תא אזהרה",
-          "reverse_text": true
-        }
-      },
       "profile_autolevel": {
         "acro_trainer": {
           "english": "Acro trainer",
@@ -11289,7 +11119,7 @@
       "translation": "Battery Profile",
       "needs_translation": true,
       "reverse_text": false,
-      "max_length": 12
+      "max_length": 15
     },
     "bec_voltage": {
       "english": "Bec voltage",
@@ -11603,7 +11433,7 @@
         "translation": "Battery Profile",
         "needs_translation": true,
         "reverse_text": false,
-        "max_length": 12
+        "max_length": 15
       },
       "bec_voltage": {
         "english": "BEC Voltage",

--- a/bin/i18n/json/it.json
+++ b/bin/i18n/json/it.json
@@ -32,11 +32,11 @@
         "reverse_text": false
       },
       "batteryProfile": {
-        "english": "Selected battery profile (0-5)",
+        "english": "Selected battery profile (1-6)",
         "translation": "Selected battery profile (0-5)",
         "needs_translation": true,
         "reverse_text": false,
-        "max_length": 27
+        "max_length": 30
       },
       "source_adc": {
         "english": "Battery ADC",
@@ -8077,176 +8077,6 @@
           "max_length": 11
         }
       },
-      "power": {
-        "alert_name": {
-          "english": "Alerts",
-          "translation": "Avvisi",
-          "needs_translation": false,
-          "max_length": 6,
-          "reverse_text": false
-        },
-        "alert_type": {
-          "english": "Rx Voltage Alert",
-          "translation": "Rx Tensione Avviso",
-          "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
-        },
-        "battery_capacity": {
-          "english": "Battery Capacity",
-          "translation": "Batteria Capacita",
-          "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
-        },
-        "battery_name": {
-          "english": "Battery",
-          "translation": "Batteria",
-          "needs_translation": false,
-          "max_length": 7,
-          "reverse_text": false
-        },
-        "bec_voltage_alert": {
-          "english": "BEC Alert Value",
-          "translation": "BEC Avviso Valore",
-          "needs_translation": false,
-          "max_length": 15,
-          "reverse_text": false
-        },
-        "calcfuel_local": {
-          "english": "Calculate Fuel Using",
-          "translation": "Calcola Carburante Usando",
-          "needs_translation": false,
-          "max_length": 20,
-          "reverse_text": false
-        },
-        "capacity": {
-          "english": "Capacity",
-          "translation": "Capacity",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 8
-        },
-        "cell_count": {
-          "english": "Cell Count",
-          "translation": "Cella Conteggio",
-          "needs_translation": false,
-          "max_length": 10,
-          "reverse_text": false
-        },
-        "consumption_warning_percentage": {
-          "english": "Consumption Warning %",
-          "translation": "Consumption Avviso %",
-          "needs_translation": false,
-          "max_length": 21,
-          "reverse_text": false
-        },
-        "current_meter_source": {
-          "english": "Current Source",
-          "translation": "Corrente Sorgente",
-          "needs_translation": false,
-          "max_length": 14,
-          "reverse_text": false
-        },
-        "full_cell_voltage": {
-          "english": "Full Cell Voltage",
-          "translation": "Full Cella Tensione",
-          "needs_translation": false,
-          "max_length": 17,
-          "reverse_text": false
-        },
-        "help_p1": {
-          "english": "The battery settings are used to configure the flight controller to monitor the battery voltage and provide warnings when the voltage drops below a certain level.",
-          "translation": "Le impostazioni batteria configurano il controller per monitorare la tensione e avvisare quando scende.",
-          "needs_translation": false,
-          "max_length": 162,
-          "reverse_text": false
-        },
-        "max_cell_voltage": {
-          "english": "Max Cell Voltage",
-          "translation": "Max Cella Tensione",
-          "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
-        },
-        "min_cell_voltage": {
-          "english": "Min Cell Voltage",
-          "translation": "Min Cella Tensione",
-          "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
-        },
-        "name": {
-          "english": "Power",
-          "translation": "Potenza",
-          "needs_translation": false,
-          "max_length": 5,
-          "reverse_text": false
-        },
-        "rx_voltage_alert": {
-          "english": "RxBatt Alert Value",
-          "translation": "RxBatt Avviso Valore",
-          "needs_translation": false,
-          "max_length": 18,
-          "reverse_text": false
-        },
-        "selected": {
-          "english": "Selected",
-          "translation": "Selected",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 8
-        },
-        "show_battery_profile_startup": {
-          "english": "Show battery type choose (startup)",
-          "translation": "Show battery type choose (startup)",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 34
-        },
-        "show_confirmation_dialog": {
-          "english": "Show confirmation dialog",
-          "translation": "Show confirmation dialog",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 24
-        },
-        "source_name": {
-          "english": "Sources",
-          "translation": "Sorgenti",
-          "needs_translation": false,
-          "max_length": 7,
-          "reverse_text": false
-        },
-        "timer": {
-          "english": "Flight Time Alarm",
-          "translation": "Allarme tempo volo",
-          "needs_translation": false,
-          "max_length": 17,
-          "reverse_text": false
-        },
-        "voltage_meter_source": {
-          "english": "Voltage Source",
-          "translation": "Tensione Sorgente",
-          "needs_translation": false,
-          "max_length": 14,
-          "reverse_text": false
-        },
-        "voltage_multiplier": {
-          "english": "Sag Compensation",
-          "translation": "Caduta Compensazione",
-          "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
-        },
-        "warn_cell_voltage": {
-          "english": "Warn Cell Voltage",
-          "translation": "Avviso Cella Tensione",
-          "needs_translation": false,
-          "max_length": 17,
-          "reverse_text": false
-        }
-      },
       "profile_autolevel": {
         "acro_trainer": {
           "english": "Acro trainer",
@@ -11289,7 +11119,7 @@
       "translation": "Battery Profile",
       "needs_translation": true,
       "reverse_text": false,
-      "max_length": 12
+      "max_length": 15
     },
     "bec_voltage": {
       "english": "Bec voltage",
@@ -11603,7 +11433,7 @@
         "translation": "Battery Profile",
         "needs_translation": true,
         "reverse_text": false,
-        "max_length": 12
+        "max_length": 15
       },
       "bec_voltage": {
         "english": "BEC Voltage",

--- a/bin/i18n/json/nl.json
+++ b/bin/i18n/json/nl.json
@@ -32,11 +32,11 @@
         "reverse_text": false
       },
       "batteryProfile": {
-        "english": "Selected battery profile (0-5)",
+        "english": "Selected battery profile (1-6)",
         "translation": "Selected battery profile (0-5)",
         "needs_translation": true,
         "reverse_text": false,
-        "max_length": 27
+        "max_length": 30
       },
       "source_adc": {
         "english": "Battery ADC",
@@ -8077,176 +8077,6 @@
           "max_length": 11
         }
       },
-      "power": {
-        "alert_name": {
-          "english": "Alerts",
-          "translation": "Alarmen",
-          "needs_translation": false,
-          "max_length": 6,
-          "reverse_text": false
-        },
-        "alert_type": {
-          "english": "Rx Voltage Alert",
-          "translation": "Rx Spanning Alarm",
-          "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
-        },
-        "battery_capacity": {
-          "english": "Battery Capacity",
-          "translation": "Batterij Capaciteit",
-          "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
-        },
-        "battery_name": {
-          "english": "Battery",
-          "translation": "Batterij",
-          "needs_translation": false,
-          "max_length": 7,
-          "reverse_text": false
-        },
-        "bec_voltage_alert": {
-          "english": "BEC Alert Value",
-          "translation": "BEC Alarm Waarde",
-          "needs_translation": false,
-          "max_length": 15,
-          "reverse_text": false
-        },
-        "calcfuel_local": {
-          "english": "Calculate Fuel Using",
-          "translation": "Bereken Brandstof Met",
-          "needs_translation": false,
-          "max_length": 20,
-          "reverse_text": false
-        },
-        "capacity": {
-          "english": "Capacity",
-          "translation": "Capacity",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 8
-        },
-        "cell_count": {
-          "english": "Cell Count",
-          "translation": "Cel Aantal",
-          "needs_translation": false,
-          "max_length": 10,
-          "reverse_text": false
-        },
-        "consumption_warning_percentage": {
-          "english": "Consumption Warning %",
-          "translation": "Consumption Waarschuwing %",
-          "needs_translation": false,
-          "max_length": 21,
-          "reverse_text": false
-        },
-        "current_meter_source": {
-          "english": "Current Source",
-          "translation": "Stroom Bron",
-          "needs_translation": false,
-          "max_length": 14,
-          "reverse_text": false
-        },
-        "full_cell_voltage": {
-          "english": "Full Cell Voltage",
-          "translation": "Full Cel Spanning",
-          "needs_translation": false,
-          "max_length": 17,
-          "reverse_text": false
-        },
-        "help_p1": {
-          "english": "The battery settings are used to configure the flight controller to monitor the battery voltage and provide warnings when the voltage drops below a certain level.",
-          "translation": "Batterij instellingen configureren de controller om spanning te volgen en te waarschuwen bij daling.",
-          "needs_translation": false,
-          "max_length": 162,
-          "reverse_text": false
-        },
-        "max_cell_voltage": {
-          "english": "Max Cell Voltage",
-          "translation": "Max Cel Spanning",
-          "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
-        },
-        "min_cell_voltage": {
-          "english": "Min Cell Voltage",
-          "translation": "Min Cel Spanning",
-          "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
-        },
-        "name": {
-          "english": "Power",
-          "translation": "Vermogen",
-          "needs_translation": false,
-          "max_length": 5,
-          "reverse_text": false
-        },
-        "rx_voltage_alert": {
-          "english": "RxBatt Alert Value",
-          "translation": "RxBatt Alarm Waarde",
-          "needs_translation": false,
-          "max_length": 18,
-          "reverse_text": false
-        },
-        "selected": {
-          "english": "Selected",
-          "translation": "Selected",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 8
-        },
-        "show_battery_profile_startup": {
-          "english": "Show battery type choose (startup)",
-          "translation": "Show battery type choose (startup)",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 34
-        },
-        "show_confirmation_dialog": {
-          "english": "Show confirmation dialog",
-          "translation": "Show confirmation dialog",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 24
-        },
-        "source_name": {
-          "english": "Sources",
-          "translation": "Bronnen",
-          "needs_translation": false,
-          "max_length": 7,
-          "reverse_text": false
-        },
-        "timer": {
-          "english": "Flight Time Alarm",
-          "translation": "Vliegtijd alarm",
-          "needs_translation": false,
-          "max_length": 17,
-          "reverse_text": false
-        },
-        "voltage_meter_source": {
-          "english": "Voltage Source",
-          "translation": "Spanning Bron",
-          "needs_translation": false,
-          "max_length": 14,
-          "reverse_text": false
-        },
-        "voltage_multiplier": {
-          "english": "Sag Compensation",
-          "translation": "Inzak Compensatie",
-          "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
-        },
-        "warn_cell_voltage": {
-          "english": "Warn Cell Voltage",
-          "translation": "Waars Cel Spanning",
-          "needs_translation": false,
-          "max_length": 17,
-          "reverse_text": false
-        }
-      },
       "profile_autolevel": {
         "acro_trainer": {
           "english": "Acro trainer",
@@ -11289,7 +11119,7 @@
       "translation": "Battery Profile",
       "needs_translation": true,
       "reverse_text": false,
-      "max_length": 12
+      "max_length": 15
     },
     "bec_voltage": {
       "english": "Bec voltage",
@@ -11603,7 +11433,7 @@
         "translation": "Battery Profile",
         "needs_translation": true,
         "reverse_text": false,
-        "max_length": 12
+        "max_length": 15
       },
       "bec_voltage": {
         "english": "BEC Voltage",

--- a/bin/i18n/json/no.json
+++ b/bin/i18n/json/no.json
@@ -32,11 +32,11 @@
         "reverse_text": false
       },
       "batteryProfile": {
-        "english": "Selected battery profile (0-5)",
+        "english": "Selected battery profile (1-6)",
         "translation": "Selected battery profile (0-5)",
         "needs_translation": true,
         "reverse_text": false,
-        "max_length": 27
+        "max_length": 30
       },
       "source_adc": {
         "english": "Battery ADC",
@@ -8077,176 +8077,6 @@
           "max_length": 11
         }
       },
-      "power": {
-        "alert_name": {
-          "english": "Alerts",
-          "translation": "Alerts",
-          "needs_translation": true,
-          "max_length": 6,
-          "reverse_text": false
-        },
-        "alert_type": {
-          "english": "Rx Voltage Alert",
-          "translation": "Rx Voltage Alert",
-          "needs_translation": true,
-          "max_length": 16,
-          "reverse_text": false
-        },
-        "battery_capacity": {
-          "english": "Battery Capacity",
-          "translation": "Battery Capacity",
-          "needs_translation": true,
-          "max_length": 16,
-          "reverse_text": false
-        },
-        "battery_name": {
-          "english": "Battery",
-          "translation": "Battery",
-          "needs_translation": true,
-          "max_length": 7,
-          "reverse_text": false
-        },
-        "bec_voltage_alert": {
-          "english": "BEC Alert Value",
-          "translation": "BEC Alert Value",
-          "needs_translation": true,
-          "max_length": 15,
-          "reverse_text": false
-        },
-        "calcfuel_local": {
-          "english": "Calculate Fuel Using",
-          "translation": "Calculate Fuel Using",
-          "needs_translation": true,
-          "max_length": 20,
-          "reverse_text": false
-        },
-        "capacity": {
-          "english": "Capacity",
-          "translation": "Capacity",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 8
-        },
-        "cell_count": {
-          "english": "Cell Count",
-          "translation": "Cell Count",
-          "needs_translation": true,
-          "max_length": 10,
-          "reverse_text": false
-        },
-        "consumption_warning_percentage": {
-          "english": "Consumption Warning %",
-          "translation": "Forbruk Varsel %",
-          "needs_translation": false,
-          "max_length": 21,
-          "reverse_text": false
-        },
-        "current_meter_source": {
-          "english": "Current Source",
-          "translation": "Current Source",
-          "needs_translation": true,
-          "max_length": 14,
-          "reverse_text": false
-        },
-        "full_cell_voltage": {
-          "english": "Full Cell Voltage",
-          "translation": "Full Cell Voltage",
-          "needs_translation": true,
-          "max_length": 17,
-          "reverse_text": false
-        },
-        "help_p1": {
-          "english": "The battery settings are used to configure the flight controller to monitor the battery voltage and provide warnings when the voltage drops below a certain level.",
-          "translation": "The battery Innstill are Brukt to configure the flight controller to monitor the battery voltage and provide warnings when the voltage drops Under a certain level.",
-          "needs_translation": false,
-          "max_length": 162,
-          "reverse_text": false
-        },
-        "max_cell_voltage": {
-          "english": "Max Cell Voltage",
-          "translation": "Maks Cell Voltage",
-          "needs_translation": false,
-          "max_length": 16,
-          "reverse_text": false
-        },
-        "min_cell_voltage": {
-          "english": "Min Cell Voltage",
-          "translation": "Min Cell Voltage",
-          "needs_translation": true,
-          "max_length": 16,
-          "reverse_text": false
-        },
-        "name": {
-          "english": "Power",
-          "translation": "Power",
-          "needs_translation": true,
-          "max_length": 5,
-          "reverse_text": false
-        },
-        "rx_voltage_alert": {
-          "english": "RxBatt Alert Value",
-          "translation": "RxBatt Alert Value",
-          "needs_translation": true,
-          "max_length": 18,
-          "reverse_text": false
-        },
-        "selected": {
-          "english": "Selected",
-          "translation": "Selected",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 8
-        },
-        "show_battery_profile_startup": {
-          "english": "Show battery type choose (startup)",
-          "translation": "Show battery type choose (startup)",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 34
-        },
-        "show_confirmation_dialog": {
-          "english": "Show confirmation dialog",
-          "translation": "Show confirmation dialog",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 24
-        },
-        "source_name": {
-          "english": "Sources",
-          "translation": "Sources",
-          "needs_translation": true,
-          "max_length": 7,
-          "reverse_text": false
-        },
-        "timer": {
-          "english": "Flight Time Alarm",
-          "translation": "Flight Tid Alarm",
-          "needs_translation": false,
-          "max_length": 17,
-          "reverse_text": false
-        },
-        "voltage_meter_source": {
-          "english": "Voltage Source",
-          "translation": "Voltage Source",
-          "needs_translation": true,
-          "max_length": 14,
-          "reverse_text": false
-        },
-        "voltage_multiplier": {
-          "english": "Sag Compensation",
-          "translation": "Sag Compensation",
-          "needs_translation": true,
-          "max_length": 16,
-          "reverse_text": false
-        },
-        "warn_cell_voltage": {
-          "english": "Warn Cell Voltage",
-          "translation": "Warn Cell Voltage",
-          "needs_translation": true,
-          "max_length": 17,
-          "reverse_text": false
-        }
-      },
       "profile_autolevel": {
         "acro_trainer": {
           "english": "Acro trainer",
@@ -11289,7 +11119,7 @@
       "translation": "Battery Profile",
       "needs_translation": true,
       "reverse_text": false,
-      "max_length": 12
+      "max_length": 15
     },
     "bec_voltage": {
       "english": "Bec voltage",
@@ -11603,7 +11433,7 @@
         "translation": "Battery Profile",
         "needs_translation": true,
         "reverse_text": false,
-        "max_length": 12
+        "max_length": 15
       },
       "bec_voltage": {
         "english": "BEC Voltage",

--- a/bin/i18n/json/pl.json
+++ b/bin/i18n/json/pl.json
@@ -32,11 +32,11 @@
         "reverse_text": false
       },
       "batteryProfile": {
-        "english": "Selected battery profile (0-5)",
+        "english": "Selected battery profile (1-6)",
         "translation": "Selected battery profile (0-5)",
         "needs_translation": true,
         "reverse_text": false,
-        "max_length": 27
+        "max_length": 30
       },
       "source_adc": {
         "english": "Battery ADC",
@@ -8077,176 +8077,6 @@
           "max_length": 11
         }
       },
-      "power": {
-        "alert_name": {
-          "english": "Alerts",
-          "translation": "Alerts",
-          "needs_translation": true,
-          "max_length": 6,
-          "reverse_text": false
-        },
-        "alert_type": {
-          "english": "Rx Voltage Alert",
-          "translation": "Rx Voltage Alert",
-          "needs_translation": true,
-          "max_length": 16,
-          "reverse_text": false
-        },
-        "battery_capacity": {
-          "english": "Battery Capacity",
-          "translation": "Battery Capacity",
-          "needs_translation": true,
-          "max_length": 16,
-          "reverse_text": false
-        },
-        "battery_name": {
-          "english": "Battery",
-          "translation": "Battery",
-          "needs_translation": true,
-          "max_length": 7,
-          "reverse_text": false
-        },
-        "bec_voltage_alert": {
-          "english": "BEC Alert Value",
-          "translation": "BEC Alert Value",
-          "needs_translation": true,
-          "max_length": 15,
-          "reverse_text": false
-        },
-        "calcfuel_local": {
-          "english": "Calculate Fuel Using",
-          "translation": "Calculate Fuel Using",
-          "needs_translation": true,
-          "max_length": 20,
-          "reverse_text": false
-        },
-        "capacity": {
-          "english": "Capacity",
-          "translation": "Capacity",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 8
-        },
-        "cell_count": {
-          "english": "Cell Count",
-          "translation": "Cell Count",
-          "needs_translation": true,
-          "max_length": 10,
-          "reverse_text": false
-        },
-        "consumption_warning_percentage": {
-          "english": "Consumption Warning %",
-          "translation": "Zuzycie Ostrzezenie %",
-          "needs_translation": false,
-          "max_length": 21,
-          "reverse_text": false
-        },
-        "current_meter_source": {
-          "english": "Current Source",
-          "translation": "Current Source",
-          "needs_translation": true,
-          "max_length": 14,
-          "reverse_text": false
-        },
-        "full_cell_voltage": {
-          "english": "Full Cell Voltage",
-          "translation": "Pelny Cell Voltage",
-          "needs_translation": false,
-          "max_length": 17,
-          "reverse_text": false
-        },
-        "help_p1": {
-          "english": "The battery settings are used to configure the flight controller to monitor the battery voltage and provide warnings when the voltage drops below a certain level.",
-          "translation": "The battery Ustawienia are Uzyte to configure the flight controller to monitor the battery voltage and provide warnings when the voltage drops Ponizej a certain level.",
-          "needs_translation": false,
-          "max_length": 162,
-          "reverse_text": false
-        },
-        "max_cell_voltage": {
-          "english": "Max Cell Voltage",
-          "translation": "Max Cell Voltage",
-          "needs_translation": true,
-          "max_length": 16,
-          "reverse_text": false
-        },
-        "min_cell_voltage": {
-          "english": "Min Cell Voltage",
-          "translation": "Min Cell Voltage",
-          "needs_translation": true,
-          "max_length": 16,
-          "reverse_text": false
-        },
-        "name": {
-          "english": "Power",
-          "translation": "Power",
-          "needs_translation": true,
-          "max_length": 5,
-          "reverse_text": false
-        },
-        "rx_voltage_alert": {
-          "english": "RxBatt Alert Value",
-          "translation": "RxBatt Alert Value",
-          "needs_translation": true,
-          "max_length": 18,
-          "reverse_text": false
-        },
-        "selected": {
-          "english": "Selected",
-          "translation": "Selected",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 8
-        },
-        "show_battery_profile_startup": {
-          "english": "Show battery type choose (startup)",
-          "translation": "Show battery type choose (startup)",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 34
-        },
-        "show_confirmation_dialog": {
-          "english": "Show confirmation dialog",
-          "translation": "Show confirmation dialog",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 24
-        },
-        "source_name": {
-          "english": "Sources",
-          "translation": "Sources",
-          "needs_translation": true,
-          "max_length": 7,
-          "reverse_text": false
-        },
-        "timer": {
-          "english": "Flight Time Alarm",
-          "translation": "Flight Czas Alarm",
-          "needs_translation": false,
-          "max_length": 17,
-          "reverse_text": false
-        },
-        "voltage_meter_source": {
-          "english": "Voltage Source",
-          "translation": "Voltage Source",
-          "needs_translation": true,
-          "max_length": 14,
-          "reverse_text": false
-        },
-        "voltage_multiplier": {
-          "english": "Sag Compensation",
-          "translation": "Sag Compensation",
-          "needs_translation": true,
-          "max_length": 16,
-          "reverse_text": false
-        },
-        "warn_cell_voltage": {
-          "english": "Warn Cell Voltage",
-          "translation": "Warn Cell Voltage",
-          "needs_translation": true,
-          "max_length": 17,
-          "reverse_text": false
-        }
-      },
       "profile_autolevel": {
         "acro_trainer": {
           "english": "Acro trainer",
@@ -11289,7 +11119,7 @@
       "translation": "Battery Profile",
       "needs_translation": true,
       "reverse_text": false,
-      "max_length": 12
+      "max_length": 15
     },
     "bec_voltage": {
       "english": "Bec voltage",
@@ -11603,7 +11433,7 @@
         "translation": "Battery Profile",
         "needs_translation": true,
         "reverse_text": false,
-        "max_length": 12
+        "max_length": 15
       },
       "bec_voltage": {
         "english": "BEC Voltage",

--- a/bin/i18n/json/pt-br.json
+++ b/bin/i18n/json/pt-br.json
@@ -32,11 +32,11 @@
         "max_length": 36
       },
       "batteryProfile": {
-        "english": "Selected battery profile (0-5)",
+        "english": "Selected battery profile (1-6)",
         "translation": "Selected battery profile (0-5)",
         "needs_translation": true,
         "reverse_text": false,
-        "max_length": 27
+        "max_length": 30
       },
       "source_adc": {
         "english": "Battery ADC",
@@ -8077,176 +8077,6 @@
           "max_length": 11
         }
       },
-      "power": {
-        "alert_name": {
-          "english": "Alerts",
-          "translation": "Alertas",
-          "needs_translation": false,
-          "reverse_text": false,
-          "max_length": 6
-        },
-        "alert_type": {
-          "english": "Rx Voltage Alert",
-          "translation": "Alerta Tensão Rx",
-          "needs_translation": false,
-          "reverse_text": false,
-          "max_length": 16
-        },
-        "battery_capacity": {
-          "english": "Battery Capacity",
-          "translation": "Capacidade Bateria",
-          "needs_translation": false,
-          "reverse_text": false,
-          "max_length": 16
-        },
-        "battery_name": {
-          "english": "Battery",
-          "translation": "Bateria",
-          "needs_translation": false,
-          "reverse_text": false,
-          "max_length": 7
-        },
-        "bec_voltage_alert": {
-          "english": "BEC Alert Value",
-          "translation": "Valor Alerta BEC",
-          "needs_translation": false,
-          "reverse_text": false,
-          "max_length": 15
-        },
-        "calcfuel_local": {
-          "english": "Calculate Fuel Using",
-          "translation": "Calcular Combustível",
-          "needs_translation": false,
-          "reverse_text": false,
-          "max_length": 20
-        },
-        "capacity": {
-          "english": "Capacity",
-          "translation": "Capacity",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 8
-        },
-        "cell_count": {
-          "english": "Cell Count",
-          "translation": "Células",
-          "needs_translation": false,
-          "reverse_text": false,
-          "max_length": 10
-        },
-        "consumption_warning_percentage": {
-          "english": "Consumption Warning %",
-          "translation": "Aviso Consumo %",
-          "needs_translation": false,
-          "reverse_text": false,
-          "max_length": 21
-        },
-        "current_meter_source": {
-          "english": "Current Source",
-          "translation": "Fonte Corrente",
-          "needs_translation": false,
-          "reverse_text": false,
-          "max_length": 14
-        },
-        "full_cell_voltage": {
-          "english": "Full Cell Voltage",
-          "translation": "Tensão Célula Cheia",
-          "needs_translation": false,
-          "reverse_text": false,
-          "max_length": 17
-        },
-        "help_p1": {
-          "english": "The battery settings are used to configure the flight controller to monitor the battery voltage and provide warnings when the voltage drops below a certain level.",
-          "translation": "As configurações de bateria monitoram a tensão e alertam quando cai abaixo do nível definido.",
-          "needs_translation": false,
-          "reverse_text": false,
-          "max_length": 162
-        },
-        "max_cell_voltage": {
-          "english": "Max Cell Voltage",
-          "translation": "Tensão Máx. Célula",
-          "needs_translation": false,
-          "reverse_text": false,
-          "max_length": 16
-        },
-        "min_cell_voltage": {
-          "english": "Min Cell Voltage",
-          "translation": "Tensão Mín. Célula",
-          "needs_translation": false,
-          "reverse_text": false,
-          "max_length": 16
-        },
-        "name": {
-          "english": "Power",
-          "translation": "Potência",
-          "needs_translation": false,
-          "reverse_text": false,
-          "max_length": 5
-        },
-        "rx_voltage_alert": {
-          "english": "RxBatt Alert Value",
-          "translation": "Valor Alerta RxBatt",
-          "needs_translation": false,
-          "reverse_text": false,
-          "max_length": 18
-        },
-        "selected": {
-          "english": "Selected",
-          "translation": "Selected",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 8
-        },
-        "show_battery_profile_startup": {
-          "english": "Show battery type choose (startup)",
-          "translation": "Show battery type choose (startup)",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 34
-        },
-        "show_confirmation_dialog": {
-          "english": "Show confirmation dialog",
-          "translation": "Show confirmation dialog",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 24
-        },
-        "source_name": {
-          "english": "Sources",
-          "translation": "Fontes",
-          "needs_translation": false,
-          "reverse_text": false,
-          "max_length": 7
-        },
-        "timer": {
-          "english": "Flight Time Alarm",
-          "translation": "Alarme Tempo Voo",
-          "needs_translation": false,
-          "reverse_text": false,
-          "max_length": 17
-        },
-        "voltage_meter_source": {
-          "english": "Voltage Source",
-          "translation": "Fonte Tensão",
-          "needs_translation": false,
-          "reverse_text": false,
-          "max_length": 14
-        },
-        "voltage_multiplier": {
-          "english": "Sag Compensation",
-          "translation": "Compensação Sag",
-          "needs_translation": false,
-          "reverse_text": false,
-          "max_length": 16
-        },
-        "warn_cell_voltage": {
-          "english": "Warn Cell Voltage",
-          "translation": "Aviso Tensão Célula",
-          "needs_translation": false,
-          "reverse_text": false,
-          "max_length": 17
-        }
-      },
       "profile_autolevel": {
         "acro_trainer": {
           "english": "Acro trainer",
@@ -11289,7 +11119,7 @@
       "translation": "Battery Profile",
       "needs_translation": true,
       "reverse_text": false,
-      "max_length": 12
+      "max_length": 15
     },
     "bec_voltage": {
       "english": "Bec voltage",
@@ -11603,7 +11433,7 @@
         "translation": "Battery Profile",
         "needs_translation": true,
         "reverse_text": false,
-        "max_length": 12
+        "max_length": 15
       },
       "bec_voltage": {
         "english": "BEC Voltage",

--- a/bin/i18n/json/zh-cn.json
+++ b/bin/i18n/json/zh-cn.json
@@ -32,11 +32,11 @@
         "reverse_text": false
       },
       "batteryProfile": {
-        "english": "Selected battery profile (0-5)",
+        "english": "Selected battery profile (1-6)",
         "translation": "Selected battery profile (0-5)",
         "needs_translation": true,
         "reverse_text": false,
-        "max_length": 27
+        "max_length": 30
       },
       "source_adc": {
         "english": "Battery ADC",
@@ -8077,176 +8077,6 @@
           "max_length": 11
         }
       },
-      "power": {
-        "alert_name": {
-          "english": "Alerts",
-          "max_length": 6,
-          "needs_translation": false,
-          "translation": "警报",
-          "reverse_text": false
-        },
-        "alert_type": {
-          "english": "Rx Voltage Alert",
-          "max_length": 16,
-          "needs_translation": false,
-          "translation": "接收机电压警报",
-          "reverse_text": false
-        },
-        "battery_capacity": {
-          "english": "Battery Capacity",
-          "max_length": 16,
-          "needs_translation": false,
-          "translation": "电池容量",
-          "reverse_text": false
-        },
-        "battery_name": {
-          "english": "Battery",
-          "max_length": 7,
-          "needs_translation": false,
-          "translation": "电池",
-          "reverse_text": false
-        },
-        "bec_voltage_alert": {
-          "english": "BEC Alert Value",
-          "max_length": 15,
-          "needs_translation": false,
-          "translation": "BEC 警报值",
-          "reverse_text": false
-        },
-        "calcfuel_local": {
-          "english": "Calculate Fuel Using",
-          "max_length": 20,
-          "needs_translation": false,
-          "translation": "燃料计算方式",
-          "reverse_text": false
-        },
-        "capacity": {
-          "english": "Capacity",
-          "translation": "Capacity",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 8
-        },
-        "cell_count": {
-          "english": "Cell Count",
-          "max_length": 10,
-          "needs_translation": false,
-          "translation": "电芯数量",
-          "reverse_text": false
-        },
-        "consumption_warning_percentage": {
-          "english": "Consumption Warning %",
-          "max_length": 21,
-          "needs_translation": false,
-          "translation": "消耗警告 %",
-          "reverse_text": false
-        },
-        "current_meter_source": {
-          "english": "Current Source",
-          "max_length": 14,
-          "needs_translation": false,
-          "translation": "电流来源",
-          "reverse_text": false
-        },
-        "full_cell_voltage": {
-          "english": "Full Cell Voltage",
-          "max_length": 17,
-          "needs_translation": false,
-          "translation": "满电单体电压",
-          "reverse_text": false
-        },
-        "help_p1": {
-          "english": "The battery settings are used to configure the flight controller to monitor the battery voltage and provide warnings when the voltage drops below a certain level.",
-          "max_length": 162,
-          "needs_translation": false,
-          "translation": "电池设置用于配置飞控监测电池电压，并在电压低于阈值时给出警告。",
-          "reverse_text": false
-        },
-        "max_cell_voltage": {
-          "english": "Max Cell Voltage",
-          "max_length": 16,
-          "needs_translation": false,
-          "translation": "单体最高电压",
-          "reverse_text": false
-        },
-        "min_cell_voltage": {
-          "english": "Min Cell Voltage",
-          "max_length": 16,
-          "needs_translation": false,
-          "translation": "单体最低电压",
-          "reverse_text": false
-        },
-        "name": {
-          "english": "Power",
-          "max_length": 5,
-          "needs_translation": false,
-          "translation": "电源",
-          "reverse_text": false
-        },
-        "rx_voltage_alert": {
-          "english": "RxBatt Alert Value",
-          "max_length": 18,
-          "needs_translation": false,
-          "translation": "RxBatt 警报值",
-          "reverse_text": false
-        },
-        "selected": {
-          "english": "Selected",
-          "translation": "Selected",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 8
-        },
-        "show_battery_profile_startup": {
-          "english": "Show battery type choose (startup)",
-          "translation": "Show battery type choose (startup)",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 34
-        },
-        "show_confirmation_dialog": {
-          "english": "Show confirmation dialog",
-          "translation": "Show confirmation dialog",
-          "needs_translation": true,
-          "reverse_text": false,
-          "max_length": 24
-        },
-        "source_name": {
-          "english": "Sources",
-          "max_length": 7,
-          "needs_translation": false,
-          "translation": "来源",
-          "reverse_text": false
-        },
-        "timer": {
-          "english": "Flight Time Alarm",
-          "max_length": 17,
-          "needs_translation": false,
-          "translation": "飞行时间警报",
-          "reverse_text": false
-        },
-        "voltage_meter_source": {
-          "english": "Voltage Source",
-          "max_length": 14,
-          "needs_translation": false,
-          "translation": "电压来源",
-          "reverse_text": false
-        },
-        "voltage_multiplier": {
-          "english": "Sag Compensation",
-          "max_length": 16,
-          "needs_translation": false,
-          "translation": "压降补偿",
-          "reverse_text": false
-        },
-        "warn_cell_voltage": {
-          "english": "Warn Cell Voltage",
-          "max_length": 17,
-          "needs_translation": false,
-          "translation": "单体警告电压",
-          "reverse_text": false
-        }
-      },
       "profile_autolevel": {
         "acro_trainer": {
           "english": "Acro trainer",
@@ -11289,7 +11119,7 @@
       "translation": "Battery Profile",
       "needs_translation": true,
       "reverse_text": false,
-      "max_length": 12
+      "max_length": 15
     },
     "bec_voltage": {
       "english": "Bec voltage",
@@ -11603,7 +11433,7 @@
         "translation": "Battery Profile",
         "needs_translation": true,
         "reverse_text": false,
-        "max_length": 12
+        "max_length": 15
       },
       "bec_voltage": {
         "english": "BEC Voltage",

--- a/src/rfsuite/i18n/cs.json
+++ b/src/rfsuite/i18n/cs.json
@@ -32,8 +32,8 @@
         "translation": "The number of cells in your battery."
       },
       "batteryProfile": {
-        "english": "Selected battery profile (0-5)",
-        "max_length": 27,
+        "english": "Selected battery profile (1-6)",
+        "max_length": 30,
         "needs_translation": true,
         "reverse_text": false,
         "translation": "Selected battery profile (0-5)"
@@ -8041,20 +8041,6 @@
           "reverse_text": false,
           "translation": "Selected"
         },
-        "show_battery_profile_startup": {
-          "english": "Show battery type choose (startup)",
-          "max_length": 34,
-          "needs_translation": true,
-          "reverse_text": false,
-          "translation": "Show battery type choose (startup)"
-        },
-        "show_confirmation_dialog": {
-          "english": "Show confirmation dialog",
-          "max_length": 24,
-          "needs_translation": true,
-          "reverse_text": false,
-          "translation": "Show confirmation dialog"
-        },
         "source_name": {
           "english": "Sources",
           "max_length": 7,
@@ -11130,7 +11116,7 @@
     },
     "battery_profile": {
       "english": "Battery Profile",
-      "max_length": 12,
+      "max_length": 15,
       "needs_translation": true,
       "reverse_text": false,
       "translation": "Battery Profile"
@@ -11444,7 +11430,7 @@
       },
       "battery_profile": {
         "english": "Battery Profile",
-        "max_length": 12,
+        "max_length": 15,
         "needs_translation": true,
         "reverse_text": false,
         "translation": "Battery Profile"

--- a/src/rfsuite/i18n/de.json
+++ b/src/rfsuite/i18n/de.json
@@ -32,8 +32,8 @@
         "translation": "Zellenanzahl des Akkus."
       },
       "batteryProfile": {
-        "english": "Selected battery profile (0-5)",
-        "max_length": 27,
+        "english": "Selected battery profile (1-6)",
+        "max_length": 30,
         "needs_translation": true,
         "reverse_text": false,
         "translation": "Selected battery profile (0-5)"
@@ -8041,20 +8041,6 @@
           "reverse_text": false,
           "translation": "Selected"
         },
-        "show_battery_profile_startup": {
-          "english": "Show battery type choose (startup)",
-          "max_length": 34,
-          "needs_translation": true,
-          "reverse_text": false,
-          "translation": "Show battery type choose (startup)"
-        },
-        "show_confirmation_dialog": {
-          "english": "Show confirmation dialog",
-          "max_length": 24,
-          "needs_translation": true,
-          "reverse_text": false,
-          "translation": "Show confirmation dialog"
-        },
         "source_name": {
           "english": "Sources",
           "max_length": 7,
@@ -11130,7 +11116,7 @@
     },
     "battery_profile": {
       "english": "Battery Profile",
-      "max_length": 12,
+      "max_length": 15,
       "needs_translation": true,
       "reverse_text": false,
       "translation": "Battery Profile"
@@ -11444,7 +11430,7 @@
       },
       "battery_profile": {
         "english": "Battery Profile",
-        "max_length": 12,
+        "max_length": 15,
         "needs_translation": true,
         "reverse_text": false,
         "translation": "Battery Profile"

--- a/src/rfsuite/i18n/en.json
+++ b/src/rfsuite/i18n/en.json
@@ -28,10 +28,10 @@
         "translation": "The number of cells in your battery."
       },
       "batteryProfile": {
-        "english": "Selected battery profile (0-5)",
-        "max_length": 27,
+        "english": "Selected battery profile (1-6)",
+        "max_length": 30,
         "needs_translation": false,
-        "translation": "Selected battery profile (0-5)"
+        "translation": "Selected battery profile (1-6)"
       },
       "source_adc": {
         "english": "Battery ADC",
@@ -6910,18 +6910,6 @@
           "needs_translation": false,
           "translation": "Selected"
         },
-        "show_battery_profile_startup": {
-          "english": "Show battery type choose (startup)",
-          "max_length": 34,
-          "needs_translation": false,
-          "translation": "Show battery type choose (startup)"
-        },
-        "show_confirmation_dialog": {
-          "english": "Show confirmation dialog",
-          "max_length": 24,
-          "needs_translation": false,
-          "translation": "Show confirmation dialog"
-        },
         "source_name": {
           "english": "Sources",
           "max_length": 7,
@@ -9564,7 +9552,7 @@
     },
     "battery_profile": {
       "english": "Battery Profile",
-      "max_length": 12,
+      "max_length": 15,
       "needs_translation": false,
       "translation": "Battery Profile"
     },
@@ -9839,7 +9827,7 @@
       },
       "battery_profile": {
         "english": "Battery Profile",
-        "max_length": 12,
+        "max_length": 15,
         "needs_translation": false,
         "translation": "Battery Profile"
       },

--- a/src/rfsuite/i18n/es.json
+++ b/src/rfsuite/i18n/es.json
@@ -32,8 +32,8 @@
         "translation": "El numero de celdas de su bateria."
       },
       "batteryProfile": {
-        "english": "Selected battery profile (0-5)",
-        "max_length": 27,
+        "english": "Selected battery profile (1-6)",
+        "max_length": 30,
         "needs_translation": true,
         "reverse_text": false,
         "translation": "Selected battery profile (0-5)"
@@ -8041,20 +8041,6 @@
           "reverse_text": false,
           "translation": "Selected"
         },
-        "show_battery_profile_startup": {
-          "english": "Show battery type choose (startup)",
-          "max_length": 34,
-          "needs_translation": true,
-          "reverse_text": false,
-          "translation": "Show battery type choose (startup)"
-        },
-        "show_confirmation_dialog": {
-          "english": "Show confirmation dialog",
-          "max_length": 24,
-          "needs_translation": true,
-          "reverse_text": false,
-          "translation": "Show confirmation dialog"
-        },
         "source_name": {
           "english": "Sources",
           "max_length": 7,
@@ -11130,7 +11116,7 @@
     },
     "battery_profile": {
       "english": "Battery Profile",
-      "max_length": 12,
+      "max_length": 15,
       "needs_translation": true,
       "reverse_text": false,
       "translation": "Battery Profile"
@@ -11444,7 +11430,7 @@
       },
       "battery_profile": {
         "english": "Battery Profile",
-        "max_length": 12,
+        "max_length": 15,
         "needs_translation": true,
         "reverse_text": false,
         "translation": "Battery Profile"

--- a/src/rfsuite/i18n/fr.json
+++ b/src/rfsuite/i18n/fr.json
@@ -32,8 +32,8 @@
         "translation": "Nombre de cellules dans votre batterie."
       },
       "batteryProfile": {
-        "english": "Selected battery profile (0-5)",
-        "max_length": 27,
+        "english": "Selected battery profile (1-6)",
+        "max_length": 30,
         "needs_translation": true,
         "reverse_text": false,
         "translation": "Selected battery profile (0-5)"
@@ -8041,20 +8041,6 @@
           "reverse_text": false,
           "translation": "Selected"
         },
-        "show_battery_profile_startup": {
-          "english": "Show battery type choose (startup)",
-          "max_length": 34,
-          "needs_translation": true,
-          "reverse_text": false,
-          "translation": "Show battery type choose (startup)"
-        },
-        "show_confirmation_dialog": {
-          "english": "Show confirmation dialog",
-          "max_length": 24,
-          "needs_translation": true,
-          "reverse_text": false,
-          "translation": "Show confirmation dialog"
-        },
         "source_name": {
           "english": "Sources",
           "max_length": 7,
@@ -11130,7 +11116,7 @@
     },
     "battery_profile": {
       "english": "Battery Profile",
-      "max_length": 12,
+      "max_length": 15,
       "needs_translation": true,
       "reverse_text": false,
       "translation": "Battery Profile"
@@ -11444,7 +11430,7 @@
       },
       "battery_profile": {
         "english": "Battery Profile",
-        "max_length": 12,
+        "max_length": 15,
         "needs_translation": true,
         "reverse_text": false,
         "translation": "Battery Profile"

--- a/src/rfsuite/i18n/he.json
+++ b/src/rfsuite/i18n/he.json
@@ -32,8 +32,8 @@
         "translation": "מספר התאים בסוללה."
       },
       "batteryProfile": {
-        "english": "Selected battery profile (0-5)",
-        "max_length": 27,
+        "english": "Selected battery profile (1-6)",
+        "max_length": 30,
         "needs_translation": true,
         "reverse_text": false,
         "translation": "Selected battery profile (0-5)"
@@ -8041,20 +8041,6 @@
           "reverse_text": false,
           "translation": "Selected"
         },
-        "show_battery_profile_startup": {
-          "english": "Show battery type choose (startup)",
-          "max_length": 34,
-          "needs_translation": true,
-          "reverse_text": false,
-          "translation": "Show battery type choose (startup)"
-        },
-        "show_confirmation_dialog": {
-          "english": "Show confirmation dialog",
-          "max_length": 24,
-          "needs_translation": true,
-          "reverse_text": false,
-          "translation": "Show confirmation dialog"
-        },
         "source_name": {
           "english": "Sources",
           "max_length": 7,
@@ -11130,7 +11116,7 @@
     },
     "battery_profile": {
       "english": "Battery Profile",
-      "max_length": 12,
+      "max_length": 15,
       "needs_translation": true,
       "reverse_text": false,
       "translation": "Battery Profile"
@@ -11444,7 +11430,7 @@
       },
       "battery_profile": {
         "english": "Battery Profile",
-        "max_length": 12,
+        "max_length": 15,
         "needs_translation": true,
         "reverse_text": false,
         "translation": "Battery Profile"

--- a/src/rfsuite/i18n/it.json
+++ b/src/rfsuite/i18n/it.json
@@ -32,8 +32,8 @@
         "translation": "Il numero di celle della batteria."
       },
       "batteryProfile": {
-        "english": "Selected battery profile (0-5)",
-        "max_length": 27,
+        "english": "Selected battery profile (1-6)",
+        "max_length": 30,
         "needs_translation": true,
         "reverse_text": false,
         "translation": "Selected battery profile (0-5)"
@@ -8041,20 +8041,6 @@
           "reverse_text": false,
           "translation": "Selected"
         },
-        "show_battery_profile_startup": {
-          "english": "Show battery type choose (startup)",
-          "max_length": 34,
-          "needs_translation": true,
-          "reverse_text": false,
-          "translation": "Show battery type choose (startup)"
-        },
-        "show_confirmation_dialog": {
-          "english": "Show confirmation dialog",
-          "max_length": 24,
-          "needs_translation": true,
-          "reverse_text": false,
-          "translation": "Show confirmation dialog"
-        },
         "source_name": {
           "english": "Sources",
           "max_length": 7,
@@ -11130,7 +11116,7 @@
     },
     "battery_profile": {
       "english": "Battery Profile",
-      "max_length": 12,
+      "max_length": 15,
       "needs_translation": true,
       "reverse_text": false,
       "translation": "Battery Profile"
@@ -11444,7 +11430,7 @@
       },
       "battery_profile": {
         "english": "Battery Profile",
-        "max_length": 12,
+        "max_length": 15,
         "needs_translation": true,
         "reverse_text": false,
         "translation": "Battery Profile"

--- a/src/rfsuite/i18n/nl.json
+++ b/src/rfsuite/i18n/nl.json
@@ -32,8 +32,8 @@
         "translation": "Het aantal cellen in je batterij."
       },
       "batteryProfile": {
-        "english": "Selected battery profile (0-5)",
-        "max_length": 27,
+        "english": "Selected battery profile (1-6)",
+        "max_length": 30,
         "needs_translation": true,
         "reverse_text": false,
         "translation": "Selected battery profile (0-5)"
@@ -8041,20 +8041,6 @@
           "reverse_text": false,
           "translation": "Selected"
         },
-        "show_battery_profile_startup": {
-          "english": "Show battery type choose (startup)",
-          "max_length": 34,
-          "needs_translation": true,
-          "reverse_text": false,
-          "translation": "Show battery type choose (startup)"
-        },
-        "show_confirmation_dialog": {
-          "english": "Show confirmation dialog",
-          "max_length": 24,
-          "needs_translation": true,
-          "reverse_text": false,
-          "translation": "Show confirmation dialog"
-        },
         "source_name": {
           "english": "Sources",
           "max_length": 7,
@@ -11130,7 +11116,7 @@
     },
     "battery_profile": {
       "english": "Battery Profile",
-      "max_length": 12,
+      "max_length": 15,
       "needs_translation": true,
       "reverse_text": false,
       "translation": "Battery Profile"
@@ -11444,7 +11430,7 @@
       },
       "battery_profile": {
         "english": "Battery Profile",
-        "max_length": 12,
+        "max_length": 15,
         "needs_translation": true,
         "reverse_text": false,
         "translation": "Battery Profile"

--- a/src/rfsuite/i18n/no.json
+++ b/src/rfsuite/i18n/no.json
@@ -32,8 +32,8 @@
         "translation": "The number of cells in your battery."
       },
       "batteryProfile": {
-        "english": "Selected battery profile (0-5)",
-        "max_length": 27,
+        "english": "Selected battery profile (1-6)",
+        "max_length": 30,
         "needs_translation": true,
         "reverse_text": false,
         "translation": "Selected battery profile (0-5)"
@@ -8041,20 +8041,6 @@
           "reverse_text": false,
           "translation": "Selected"
         },
-        "show_battery_profile_startup": {
-          "english": "Show battery type choose (startup)",
-          "max_length": 34,
-          "needs_translation": true,
-          "reverse_text": false,
-          "translation": "Show battery type choose (startup)"
-        },
-        "show_confirmation_dialog": {
-          "english": "Show confirmation dialog",
-          "max_length": 24,
-          "needs_translation": true,
-          "reverse_text": false,
-          "translation": "Show confirmation dialog"
-        },
         "source_name": {
           "english": "Sources",
           "max_length": 7,
@@ -11130,7 +11116,7 @@
     },
     "battery_profile": {
       "english": "Battery Profile",
-      "max_length": 12,
+      "max_length": 15,
       "needs_translation": true,
       "reverse_text": false,
       "translation": "Battery Profile"
@@ -11444,7 +11430,7 @@
       },
       "battery_profile": {
         "english": "Battery Profile",
-        "max_length": 12,
+        "max_length": 15,
         "needs_translation": true,
         "reverse_text": false,
         "translation": "Battery Profile"

--- a/src/rfsuite/i18n/pl.json
+++ b/src/rfsuite/i18n/pl.json
@@ -32,8 +32,8 @@
         "translation": "The number of cells in your battery."
       },
       "batteryProfile": {
-        "english": "Selected battery profile (0-5)",
-        "max_length": 27,
+        "english": "Selected battery profile (1-6)",
+        "max_length": 30,
         "needs_translation": true,
         "reverse_text": false,
         "translation": "Selected battery profile (0-5)"
@@ -8041,20 +8041,6 @@
           "reverse_text": false,
           "translation": "Selected"
         },
-        "show_battery_profile_startup": {
-          "english": "Show battery type choose (startup)",
-          "max_length": 34,
-          "needs_translation": true,
-          "reverse_text": false,
-          "translation": "Show battery type choose (startup)"
-        },
-        "show_confirmation_dialog": {
-          "english": "Show confirmation dialog",
-          "max_length": 24,
-          "needs_translation": true,
-          "reverse_text": false,
-          "translation": "Show confirmation dialog"
-        },
         "source_name": {
           "english": "Sources",
           "max_length": 7,
@@ -11130,7 +11116,7 @@
     },
     "battery_profile": {
       "english": "Battery Profile",
-      "max_length": 12,
+      "max_length": 15,
       "needs_translation": true,
       "reverse_text": false,
       "translation": "Battery Profile"
@@ -11444,7 +11430,7 @@
       },
       "battery_profile": {
         "english": "Battery Profile",
-        "max_length": 12,
+        "max_length": 15,
         "needs_translation": true,
         "reverse_text": false,
         "translation": "Battery Profile"

--- a/src/rfsuite/i18n/pt-br.json
+++ b/src/rfsuite/i18n/pt-br.json
@@ -32,8 +32,8 @@
         "translation": "O número de células na sua bateria."
       },
       "batteryProfile": {
-        "english": "Selected battery profile (0-5)",
-        "max_length": 27,
+        "english": "Selected battery profile (1-6)",
+        "max_length": 30,
         "needs_translation": true,
         "reverse_text": false,
         "translation": "Selected battery profile (0-5)"
@@ -8041,20 +8041,6 @@
           "reverse_text": false,
           "translation": "Selected"
         },
-        "show_battery_profile_startup": {
-          "english": "Show battery type choose (startup)",
-          "max_length": 34,
-          "needs_translation": true,
-          "reverse_text": false,
-          "translation": "Show battery type choose (startup)"
-        },
-        "show_confirmation_dialog": {
-          "english": "Show confirmation dialog",
-          "max_length": 24,
-          "needs_translation": true,
-          "reverse_text": false,
-          "translation": "Show confirmation dialog"
-        },
         "source_name": {
           "english": "Sources",
           "max_length": 7,
@@ -11130,7 +11116,7 @@
     },
     "battery_profile": {
       "english": "Battery Profile",
-      "max_length": 12,
+      "max_length": 15,
       "needs_translation": true,
       "reverse_text": false,
       "translation": "Battery Profile"
@@ -11444,7 +11430,7 @@
       },
       "battery_profile": {
         "english": "Battery Profile",
-        "max_length": 12,
+        "max_length": 15,
         "needs_translation": true,
         "reverse_text": false,
         "translation": "Battery Profile"

--- a/src/rfsuite/i18n/zh-cn.json
+++ b/src/rfsuite/i18n/zh-cn.json
@@ -32,8 +32,8 @@
         "translation": "电池电芯数量。"
       },
       "batteryProfile": {
-        "english": "Selected battery profile (0-5)",
-        "max_length": 27,
+        "english": "Selected battery profile (1-6)",
+        "max_length": 30,
         "needs_translation": true,
         "reverse_text": false,
         "translation": "Selected battery profile (0-5)"
@@ -8041,20 +8041,6 @@
           "reverse_text": false,
           "translation": "Selected"
         },
-        "show_battery_profile_startup": {
-          "english": "Show battery type choose (startup)",
-          "max_length": 34,
-          "needs_translation": true,
-          "reverse_text": false,
-          "translation": "Show battery type choose (startup)"
-        },
-        "show_confirmation_dialog": {
-          "english": "Show confirmation dialog",
-          "max_length": 24,
-          "needs_translation": true,
-          "reverse_text": false,
-          "translation": "Show confirmation dialog"
-        },
         "source_name": {
           "english": "Sources",
           "max_length": 7,
@@ -11130,7 +11116,7 @@
     },
     "battery_profile": {
       "english": "Battery Profile",
-      "max_length": 12,
+      "max_length": 15,
       "needs_translation": true,
       "reverse_text": false,
       "translation": "Battery Profile"
@@ -11444,7 +11430,7 @@
       },
       "battery_profile": {
         "english": "Battery Profile",
-        "max_length": 12,
+        "max_length": 15,
         "needs_translation": true,
         "reverse_text": false,
         "translation": "Battery Profile"


### PR DESCRIPTION
…ages

- Changed the battery profile selection range from (0-5) to (1-6) in the following language files:
  - Polish (pl.json)
  - Brazilian Portuguese (pt-br.json)
  - Simplified Chinese (zh-cn.json)
  - Czech (cs.json)
  - German (de.json)
  - English (en.json)
  - Spanish (es.json)
  - French (fr.json)
  - Hebrew (he.json)
  - Italian (it.json)
  - Dutch (nl.json)
  - Norwegian (no.json)

- Increased the maximum length for battery profile strings from 27 to 30 in the above language files.
- Removed unnecessary fields related to battery profile startup and confirmation dialog from the power section in the Polish, Brazilian Portuguese, and Simplified Chinese language files.