### PR TITLE
Avoid per-call closure allocation in hot pcall paths

### DIFF
--- a/src/rfsuite/tasks/scheduler/logging/logging.lua
+++ b/src/rfsuite/tasks/scheduler/logging/logging.lua
@@ -83,9 +83,13 @@ local logTable = {
 local diskFH
 local diskFHPath
 
+local function closeHandle(fh)
+    fh:close()
+end
+
 local function diskClose()
     if diskFH then
-        pcall(function() diskFH:close() end)
+        pcall(closeHandle, diskFH)
         diskFH = nil
         diskFHPath = nil
     end
@@ -188,6 +192,12 @@ local function dropQueuePrefix(n)
     log_queue_bytes = bytes
 end
 
+local function writeChunk(f, lines, n)
+    f:write(table_concat(lines, "\n", 1, n))
+    f:write("\n")
+    if f.flush then f:flush() end
+end
+
 function logging.writeLogs(forcewrite)
     if #log_queue == 0 then return end
     if not logFileName then return end
@@ -217,14 +227,10 @@ function logging.writeLogs(forcewrite)
     end
 
     -- One write call for the whole chunk is much cheaper than line-by-line.
-    local ok = pcall(function()
-        f:write(table_concat(log_queue, "\n", 1, n))
-        f:write("\n")
-        if f.flush then f:flush() end
-    end)
+    local ok = pcall(writeChunk, f, log_queue, n)
 
     if not DISK_KEEP_OPEN then
-        pcall(function() f:close() end)
+        pcall(closeHandle, f)
     end
 
     if not ok then

--- a/src/rfsuite/tasks/scheduler/msp/proto_logger.lua
+++ b/src/rfsuite/tasks/scheduler/msp/proto_logger.lua
@@ -45,6 +45,22 @@ local function now()
     return string_format("%.3f", os_clock())
 end
 
+local function flushHandle(fh)
+    fh:flush()
+end
+
+local function writeNewline(fh)
+    fh:write("\n")
+end
+
+local function closeHandle(fh)
+    fh:close()
+end
+
+local function flushLogs(logs)
+    logs.flush()
+end
+
 local function tryRequire(name)
     local ok, mod = pcall(require, name)
     if ok and mod then return mod end
@@ -102,7 +118,7 @@ local function writeLine(line)
     local t = os_clock()
     if (t - _lastFlushAt) >= _flushEvery then
         _lastFlushAt = t
-        pcall(function() _fh:flush() end)
+        pcall(flushHandle, _fh)
     end
 end
 
@@ -124,7 +140,7 @@ function M.enable(on)
         if not _logs then
             _fh = io_open(M.logFile, "a")
             if _fh then
-                pcall(function() _fh:write("\n") end)
+                pcall(writeNewline, _fh)
             end
         end
 
@@ -138,12 +154,12 @@ function M.enable(on)
 
         if _logs and _logs.flush then
             -- Ensure it hits disk on teardown, but don't touch global close() here.
-            pcall(function() _logs.flush() end)
+            pcall(flushLogs, _logs)
         end
 
         if _fh then
-            pcall(function() _fh:flush() end)
-            pcall(function() _fh:close() end)
+            pcall(flushHandle, _fh)
+            pcall(closeHandle, _fh)
         end
 
         _logs = nil

--- a/src/rfsuite/widgets/dashboard/lib/utils.lua
+++ b/src/rfsuite/widgets/dashboard/lib/utils.lua
@@ -1648,6 +1648,10 @@ function utils.clearProgressDialog(handle)
     end
 end
 
+local function setDialogMessage(handle, msg)
+    handle:message(msg)
+end
+
 function utils.updateProgressDialogMessage(statusOverride)
     if not progressDialog or not progressDialog.handle then return end
     local showDebug = rfsuite.preferences and rfsuite.preferences.general and rfsuite.preferences.general.mspstatusdialog
@@ -1656,7 +1660,7 @@ function utils.updateProgressDialogMessage(statusOverride)
     if showDebug then
         msg = mspStatus or MSP_DEBUG_PLACEHOLDER
     end
-    pcall(function() progressDialog.handle:message(msg) end)
+    pcall(setDialogMessage, progressDialog.handle, msg)
 end
 
 -- Shared dirty-check: redraws when box._currentDisplayValue changes (and


### PR DESCRIPTION
These pcall(function() ... end) sites run on every scheduler tick (progress dialog updates) or disk flush (logging, proto logger), each allocating a throwaway closure. Replace with stable named functions and pass data via pcall args to cut GC churn/heap fragmentation.