### PR TITLE
changing batter_type to battery_profile

### DIFF
--- a/src/rfsuite/tasks/scheduler/telemetry/sources/crsf.lua
+++ b/src/rfsuite/tasks/scheduler/telemetry/sources/crsf.lua
@@ -51,7 +51,7 @@ return {
     adj_v = {{category = CATEGORY_TELEMETRY_SENSOR, appId = 0x1222}},
     pid_profile = {{category = CATEGORY_TELEMETRY_SENSOR, appId = 0x1211}},
     rate_profile = {{category = CATEGORY_TELEMETRY_SENSOR, appId = 0x1212}},
-    batter_type = {{category = CATEGORY_TELEMETRY_SENSOR, appId = 0x1214}},
+    battery_profile = {{category = CATEGORY_TELEMETRY_SENSOR, appId = 0x1214}},
 
     -- Control
     throttle_percent = {{category = CATEGORY_TELEMETRY_SENSOR, appId = 0x1035}},


### PR DESCRIPTION
Issue
The battery profile sensor is incorrectly named as batter_type, it should be named battery_profile.
With the incorrect name, the sensor shows up as invalid when using ELRS with suite.