### PR TITLE
Cache page/ESC-config chunks instead of reloading via loadfile() 

### DIFF
--- a/src/rfsuite/app/lib/ui.lua
+++ b/src/rfsuite/app/lib/ui.lua
@@ -32,6 +32,35 @@ end
 
 local function NOOP_PAINT() end
 
+-- Caches the *compiled chunk* loadfile() returns for each page module
+-- path, so repeat visits to the same page (or the same script opened
+-- with a different idx/opts -- see app/modules/settings/tools/
+-- dashboard_settings.lua, which opens dashboard_settings_theme.lua
+-- with a different idx per theme button) skip re-parsing the source
+-- from disk every single time. This does NOT cache the page instance
+-- itself (app.Page) -- ui.openPage() below still calls the cached
+-- chunk fresh on every open, exactly as it called a freshly-loaded one
+-- before, so every page still gets entirely new local state each visit
+-- (Lua's own function-call semantics guarantee a chunk's locals are
+-- fresh per call, identical whether that call happens on a
+-- just-compiled chunk or a cached one -- confirmed by checking that no
+-- page module captures its chunk-level `...` for anything meaningful;
+-- ui.cleanupCurrentPage() only ever tears down app.Page's own instance
+-- state, never anything chunk-level). Unbounded (no MASK_CACHE_MAX-style
+-- eviction, unlike ui._maskCache above) -- the set of distinct page
+-- script paths in the whole app is fixed and modest, and these are small
+-- compiled functions, not bitmap-sized assets.
+ui._pageChunkCache = ui._pageChunkCache or {}
+
+local function loadPageChunk(modulePath)
+    local chunk = ui._pageChunkCache[modulePath]
+    if not chunk then
+        chunk = assert(loadfile(modulePath))
+        ui._pageChunkCache[modulePath] = chunk
+    end
+    return chunk
+end
+
 local MASK_CACHE_MAX = 16  -- a small cache for recently used masks; evict old entries to avoid unbounded memory growth.
 ui._maskCache = ui._maskCache or {}
 ui._maskCacheOrder = ui._maskCacheOrder or {}
@@ -2205,7 +2234,7 @@ function ui.openPage(opts)
     if opts.openedFromShortcuts ~= nil then
         app._openedFromShortcuts = (opts.openedFromShortcuts == true)
     end
-    app.Page = assert(loadfile(modulePath))(idx)
+    app.Page = loadPageChunk(modulePath)(idx)
     app.utils.capturePageProfileState(app.Page)
     if app._openedFromShortcuts or app._forceMenuToMain then
         app.Page.onNavMenu = function()

--- a/src/rfsuite/app/modules/esc_tools/tools/esc_tool.lua
+++ b/src/rfsuite/app/modules/esc_tools/tools/esc_tool.lua
@@ -13,6 +13,29 @@ local function loadMask(path)
     return lcd.loadMask(path)
 end
 
+-- Caches the compiled chunk for each manufacturer's escmfg/<folder>/
+-- init.lua and pages.lua -- openPage() below still CALLS the cached
+-- chunk fresh every time (same as before: assert(loadfile(path))()),
+-- so ESC/ESC.pages are still built brand new on every open; only the
+-- disk-read+parse+compile step is skipped on repeat visits to the same
+-- ESC folder. Reuses app/lib/ui.lua's own ui._pageChunkCache rather than
+-- a separate table, same reasoning as
+-- app/modules/settings/tools/dashboard_settings_theme.lua's own
+-- loadThemeChunk().
+local function loadEscChunk(modulePath)
+    local ui = rfsuite.app and rfsuite.app.ui
+    local cache = ui and ui._pageChunkCache
+    if not cache then
+        return assert(loadfile(modulePath))
+    end
+    local chunk = cache[modulePath]
+    if not chunk then
+        chunk = assert(loadfile(modulePath))
+        cache[modulePath] = chunk
+    end
+    return chunk
+end
+
 local mspSignature
 local mspBytes
 local escDetails = {}
@@ -377,7 +400,7 @@ local function openPage(opts)
     escDetailsApi = nil
     escDetailsApiName = nil
 
-    ESC = assert(loadfile("app/modules/esc_tools/tools/escmfg/" .. folder .. "/init.lua"))()
+    ESC = loadEscChunk("app/modules/esc_tools/tools/escmfg/" .. folder .. "/init.lua")()
 
     if rfsuite.app and rfsuite.app.Page and ESC and ESC.mspapi then
         rfsuite.app.Page.apidata = rfsuite.app.Page.apidata or {}
@@ -413,7 +436,7 @@ local function openPage(opts)
     end
     rfsuite.app.ui.fieldHeader(headerTitle)
 
-    ESC.pages = assert(loadfile("app/modules/esc_tools/tools/escmfg/" .. folder .. "/pages.lua"))()
+    ESC.pages = loadEscChunk("app/modules/esc_tools/tools/escmfg/" .. folder .. "/pages.lua")()
 
     modelLine = form.addLine("")
     modelText = form.addStaticText(modelLine, modelTextPos, "")

--- a/src/rfsuite/app/modules/esc_tools/tools/esc_tool_4way.lua
+++ b/src/rfsuite/app/modules/esc_tools/tools/esc_tool_4way.lua
@@ -13,6 +13,25 @@ local function loadMask(path)
     return lcd.loadMask(path)
 end
 
+-- Caches the compiled chunk for each manufacturer's escmfg/<folder>/
+-- init.lua and pages.lua -- callers still CALL the cached chunk fresh
+-- every time, so ESC/ESC.pages are still built brand new on every open;
+-- only the disk-read+parse+compile step is skipped on repeat visits to
+-- the same ESC folder. Reuses app/lib/ui.lua's own ui._pageChunkCache,
+-- same as app/modules/esc_tools/tools/esc_tool.lua's own loadEscChunk().
+local function loadEscChunk(modulePath)
+    local ui = rfsuite.app and rfsuite.app.ui
+    local cache = ui and ui._pageChunkCache
+    if not cache then
+        return loadfile(modulePath)
+    end
+    local chunk = cache[modulePath]
+    if chunk then return chunk end
+    local loaded, err = loadfile(modulePath)
+    if loaded then cache[modulePath] = loaded end
+    return loaded, err
+end
+
 local mspSignature
 local mspBytes
 local simulatorResponse
@@ -854,7 +873,7 @@ end
 
 local function loadEscConfig(folder)
     local initPath = escInitPathForFolder(folder)
-    local chunk, err = loadfile(initPath)
+    local chunk, err = loadEscChunk(initPath)
     if not chunk then
         if rfsuite.utils and rfsuite.utils.log then
             rfsuite.utils.log("ESC config load failed: " .. tostring(initPath) .. " (" .. tostring(err) .. ")", "info")
@@ -930,7 +949,7 @@ renderToolPage = function(opts)
     end
     rfsuite.app.ui.fieldHeader(headerTitle)
 
-    ESC.pages = assert(loadfile("app/modules/esc_tools/tools/escmfg/" .. folder .. "/pages.lua"))()
+    ESC.pages = assert(loadEscChunk("app/modules/esc_tools/tools/escmfg/" .. folder .. "/pages.lua"))()
 
     modelLine = form.addLine("")
     modelText = form.addStaticText(modelLine, modelTextPos, "")

--- a/src/rfsuite/app/modules/settings/tools/dashboard_settings_theme.lua
+++ b/src/rfsuite/app/modules/settings/tools/dashboard_settings_theme.lua
@@ -13,6 +13,29 @@ local page
 local pageIdx
 local onNavMenu
 
+-- Reuses app/lib/ui.lua's own page-chunk cache (ui._pageChunkCache) rather
+-- than a separate one here -- same reasoning: this theme settings page can
+-- be opened repeatedly (a different idx per theme button, see
+-- app/modules/settings/tools/dashboard_settings.lua), and each open used to
+-- re-parse themeScript from disk every single time via a plain loadfile().
+-- Caching the compiled chunk, not its call result, means `page` below is
+-- still built fresh (module-scope local, reassigned inside openPage() every
+-- call) on every visit -- only the disk-read+parse+compile step is skipped
+-- on repeat visits to the same theme.
+local function loadThemeChunk(modulePath)
+    local ui = rfsuite.app.ui
+    local cache = ui and ui._pageChunkCache
+    if not cache then
+        return assert(loadfile(modulePath))
+    end
+    local chunk = cache[modulePath]
+    if not chunk then
+        chunk = assert(loadfile(modulePath))
+        cache[modulePath] = chunk
+    end
+    return chunk
+end
+
 local function onSaveMenu()
     local buttons = {
         {
@@ -62,7 +85,7 @@ local function openPage(opts)
 
     local modulePath = themeScript
 
-    page = assert(loadfile(modulePath))(idx)
+    page = loadThemeChunk(modulePath)(idx)
 
     form.clear()
     rfsuite.app.ui.fieldHeader("@i18n(app.modules.settings.name)@" .. " / " .. title)


### PR DESCRIPTION

Every page open (app/lib/ui.lua's openPage()), and a few nested cases (ESC manufacturer config in esc_tool.lua/esc_tool_4way.lua, the theme sub-script in dashboard_settings_theme.lua), re-parsed its module from disk fresh via loadfile(), every single time, with no caching at all.

Found and fixed while investigating a RAM-churn issue in a sister project (rotorflight-lua-ethos-suite-lite), where the identical pattern turned out to be real, avoidable per-navigation CPU/GC churn -- caching the *compiled chunk* fully eliminates the re-parse cost with zero behavioral change, since a page/config table's own instance state was never derived from the file being freshly parsed -- it's always built by the chunk's *own execution*, which happens exactly the same way whether that execution follows a fresh loadfile() or a cached one (fresh locals every call is a basic Lua guarantee, not something a repeated call to an already-compiled chunk changes).

Verified this holds for this codebase specifically, not just in theory: ui.cleanupCurrentPage() only ever tears down app.Page's own instance state (form fields, apidata, bus subscriptions) and never touches the chunk/module that produced it; no page module captures its chunk-level `...` for anything meaningful (the `idx` argument passed at the loadfile()(idx) call site is silently unused by every page checked -- per-visit data instead flows through the `opts` table into each page's own openPage(opts) method, independent of chunk identity); no page module manipulates package.loaded or reloads itself. app/lib/ui.lua's own existing app._submenuBuilder caching (in
app/modules/manifest_menu/menu.lua) already relies on the same load-once-reuse principle for a different (stateless-library) case.

app/lib/ui.lua gains ui._pageChunkCache (unbounded -- unlike ui._maskCache's MASK_CACHE_MAX eviction, the set of distinct page script paths is fixed and these are small compiled functions, not bitmap-sized assets), keyed by module path, consulted by a new loadPageChunk() helper. openPage()'s `app.Page = assert(loadfile(modulePath))(idx)` becomes `app.Page = loadPageChunk(modulePath)(idx)` -- the chunk is still CALLED fresh on every open, only the load is cached. esc_tool.lua/esc_tool_4way.lua/dashboard_settings_theme.lua each gain a small local helper (loadEscChunk/loadThemeChunk) that reuses this same ui._pageChunkCache rather than introducing a separate one, applied to their own nested loadfile() calls for ESC manufacturer config and theme sub-scripts respectively.

Structurally verified via a Lua AST parse of every changed file (no Lua interpreter available in this environment); needs a live device/ simulator test to confirm no behavioral regression, same caveat as any change made without the ability to execute Lua directly.