### PR TITLE
add /run/media/<username> to the list of mounted folders to search

### DIFF
--- a/.vscode/scripts/deploy.py
+++ b/.vscode/scripts/deploy.py
@@ -414,7 +414,8 @@ def scan_usb_drives_for_radio():
             except Exception:
                 pass
     else:
-        for base in ("/Volumes", "/media", "/mnt"):
+        userName = os.getenv('USER', '')
+        for base in ("/Volumes", "/media", f"/run/media/{userName}", "/mnt"):
             if not os.path.isdir(base):
                 continue
             for entry in os.listdir(base):


### PR DESCRIPTION
Add folder `/run/media/<username>` to the list of USB paths searched for deployment. This is needed to support default automount paths in RedHat/Fedora.