### PR TITLE
re-enable governor startup time parameter (ramp)

### DIFF
--- a/bin/i18n/json/en.json
+++ b/bin/i18n/json/en.json
@@ -7206,6 +7206,12 @@
           "needs_translation": false,
           "translation": "Precomp Bandwidth"
         },
+        "gov_rpm_filter": {
+          "english": "Headspeed Filter Cutoff",
+          "max_length": 23,
+          "needs_translation": false,
+          "translation": "Headspeed Filter Cutoff"
+        },
         "gov_pwr_filter": {
           "english": "Voltage Filter Cutoff",
           "max_length": 21,

--- a/src/rfsuite/app/modules/governor/tools/filters.lua
+++ b/src/rfsuite/app/modules/governor/tools/filters.lua
@@ -9,7 +9,7 @@ local navHandlers = pageRuntime.createMenuHandlers({defaultSection = "hardware",
 
 local apidata = {
     api = {[1] = 'GOVERNOR_CONFIG'},
-    formdata = {labels = {}, fields = {{t = "@i18n(app.modules.governor.startup_time)@", mspapi = 1, apikey = "gov_rpm_filter"}, {t = "@i18n(app.modules.governor.gov_pwr_filter)@", mspapi = 1, apikey = "gov_pwr_filter"}, {t = "@i18n(app.modules.governor.gov_tta_filter)@", mspapi = 1, apikey = "gov_tta_filter"}, {t = "@i18n(app.modules.governor.gov_ff_filter)@", mspapi = 1, apikey = "gov_ff_filter"}, {t = "@i18n(app.modules.governor.gov_d_filter)@", mspapi = 1, apikey = "gov_d_filter"}}}
+    formdata = {labels = {}, fields = {{t = "@i18n(app.modules.governor.gov_rpm_filter)@", mspapi = 1, apikey = "gov_rpm_filter"}, {t = "@i18n(app.modules.governor.gov_pwr_filter)@", mspapi = 1, apikey = "gov_pwr_filter"}, {t = "@i18n(app.modules.governor.gov_tta_filter)@", mspapi = 1, apikey = "gov_tta_filter"}, {t = "@i18n(app.modules.governor.gov_ff_filter)@", mspapi = 1, apikey = "gov_ff_filter"}, {t = "@i18n(app.modules.governor.gov_d_filter)@", mspapi = 1, apikey = "gov_d_filter"}}}
 }
 
 local function postLoad(self) rfsuite.app.triggers.closeProgressLoader = true end

--- a/src/rfsuite/app/modules/governor/tools/time.lua
+++ b/src/rfsuite/app/modules/governor/tools/time.lua
@@ -12,7 +12,7 @@ local apidata = {
     formdata = {
         labels = {},
         fields = {
-        --{t = "@i18n(app.modules.governor.startup_time)@", mspapi = 1, apikey = "gov_startup_time"}, 
+        {t = "@i18n(app.modules.governor.startup_time)@", mspapi = 1, apikey = "gov_startup_time"},
         {t = "@i18n(app.modules.governor.spoolup_time)@", mspapi = 1, apikey = "gov_spoolup_time"}, 
         {t = "@i18n(app.modules.governor.spooldown_time)@", mspapi = 1, apikey = "gov_spooldown_time"}, 
         {t = "@i18n(app.modules.governor.tracking_time)@", mspapi = 1, apikey = "gov_tracking_time"}, 

--- a/src/rfsuite/i18n/en.json
+++ b/src/rfsuite/i18n/en.json
@@ -7226,6 +7226,12 @@
           "needs_translation": false,
           "translation": "Voltage Filter Cutoff"
         },
+        "gov_rpm_filter": {
+          "english": "Headspeed Filter Cutoff",
+          "max_length": 23,
+          "needs_translation": false,
+          "translation": "Headspeed Filter Cutoff"
+        },
         "gov_tta_filter": {
           "english": "TTA Bandwidth",
           "max_length": 13,


### PR DESCRIPTION
This PR re-enables the governor startup time parameter, which has been commented out upstream.

**Note:** The fix has been bench tested by editing/writing parameters `startup time` and `headspeed filter cutoff` to a Nexus-X and verifiying the change with the configurator.

**Note:** There is a chance that this has already been addressed in PR #2256 in which case this fix becomes obsolete.

closes #2257