### PR TITLE
feat(ports): add CRSF Sensors port function

### DIFF
--- a/bin/i18n/json/en.json
+++ b/bin/i18n/json/en.json
@@ -2388,6 +2388,12 @@
           "needs_translation": false,
           "max_length": 13
         },
+        "function_crsf_sensors": {
+          "english": "CRSF Sensors",
+          "translation": "CRSF Sensors",
+          "needs_translation": false,
+          "max_length": 12
+        },
         "function_telem_frsky": {
           "english": "Telemetry FrSky",
           "translation": "Telemetry FrSky",

--- a/src/rfsuite/app/pages/ports.lua
+++ b/src/rfsuite/app/pages/ports.lua
@@ -54,6 +54,7 @@ local PORT_FUNCTIONS = {
   {id = 262144, excl = 262144, name = "@i18n(app.modules.ports.function_sbus_out)@", type = PORT_TYPE_AUTO},
   {id = 524288, excl = 524288, name = "@i18n(app.modules.ports.function_fbus_out)@", type = PORT_TYPE_AUTO},
   {id = 1048576, excl = 1048576, name = "@i18n(app.modules.ports.function_sport_input)@", type = PORT_TYPE_AUTO},
+  {id = 4194304, excl = 4194304, name = "@i18n(app.modules.ports.function_crsf_sensors)@", type = PORT_TYPE_AUTO},
   {id = 4, excl = 4668, name = "@i18n(app.modules.ports.function_telem_frsky)@", type = PORT_TYPE_TELEM},
   {id = 32, excl = 4668, name = "@i18n(app.modules.ports.function_telem_smartport)@", type = PORT_TYPE_TELEM},
   {id = 4096, excl = 4668, name = "@i18n(app.modules.ports.function_telem_ibus)@", type = PORT_TYPE_TELEM},

--- a/src/rfsuite/i18n/en.json
+++ b/src/rfsuite/i18n/en.json
@@ -4782,6 +4782,12 @@
           "needs_translation": false,
           "translation": "S.PORT Master"
         },
+        "function_crsf_sensors": {
+          "english": "CRSF Sensors",
+          "max_length": 12,
+          "needs_translation": false,
+          "translation": "CRSF Sensors"
+        },
         "function_telem_frsky": {
           "english": "Telemetry FrSky",
           "max_length": 15,


### PR DESCRIPTION
Companion to [rotorflight-firmware#497](https://github.com/rotorflight/rotorflight-firmware/pull/497), which adds `FUNCTION_CRSF_SENSORS` at serial function bit 22 (`4194304`).

## What this adds
Matching entry in `ports.lua`'s `PORT_FUNCTIONS` table, plus the `function_crsf_sensors` i18n key in both `src/rfsuite/i18n/en.json` and `bin/i18n/json/en.json`, so the new CRSF Sensors port function is selectable and correctly labeled on-radio.

## Companion PRs
- Firmware: rotorflight/rotorflight-firmware#497
- Configurator: rotorflight/rotorflight-configurator#432

🤖 Generated with [Claude Code](https://claude.com/claude-code)
